### PR TITLE
ci: improve GitHub Actions workflows for octo-adapters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,21 +15,26 @@ concurrency:
 
 jobs:
   build:
-    name: Build & Type Check
+    name: Build & Type-check
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: openclaw-channel-dmwork
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
-          cache: 'npm'
-          cache-dependency-path: openclaw-channel-dmwork/package-lock.json
+          node-version: '20'
+
       - name: Install dependencies
         run: npm install
-      - name: Type check
+
+      - name: Type-check
         run: npm run type-check
+
       - name: Build
         run: npm run build
+
+      - name: Test
+        run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build & Type Check
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: openclaw-channel-dmwork
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: openclaw-channel-dmwork/package-lock.json
+      - name: Install dependencies
+        run: npm install
+      - name: Type check
+        run: npm run type-check
+      - name: Build
+        run: npm run build

--- a/.github/workflows/pr-merged-done.yml
+++ b/.github/workflows/pr-merged-done.yml
@@ -17,6 +17,8 @@ on:
   pull_request_target:
     types: [closed]
 
+permissions: {}  # GITHUB_TOKEN not used; PROJECT_TOKEN is passed explicitly
+
 jobs:
   move-to-done:
     if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == github.event.repository.default_branch


### PR DESCRIPTION
## Changes

### A2 — New CI workflow (`ci.yml`)

Adds a build / type-check / test gate for the `openclaw-channel-dmwork` TypeScript adapter.

- **Trigger:** push and PR to `main`
- **Runner:** `ubuntu-latest`, Node.js 20 (Active LTS)
- **Working directory:** `openclaw-channel-dmwork/`
- **Steps:** `npm install` → `npm run type-check` → `npm run build` → `npm test`
- No npm cache configured (repo intentionally gitignores `package-lock.json`; caching against a missing lockfile would break `setup-node`)
- `permissions: contents: read` — minimum required to check out the repo

### D — `pr-merged-done.yml`: add explicit `permissions: {}`

Adds `permissions: {}` between the `on:` block and `jobs:` to make it explicit that `GITHUB_TOKEN` is not used. The reusable workflow receives only `PROJECT_TOKEN` (passed explicitly via `secrets:`).