### PR TITLE
fix(workflows): grant contents:read to octo-pr-feed caller

### DIFF
--- a/.github/workflows/octo-pr-feed.yml
+++ b/.github/workflows/octo-pr-feed.yml
@@ -4,7 +4,12 @@ on:
   pull_request_target:
     types: [opened, closed, reopened, ready_for_review, review_requested]
 
-permissions: {}  # GITHUB_TOKEN not used; lock down to minimum
+# Minimum permissions: the @v1 reusable workflow checks out
+# Mininglamp-OSS/.github scripts via actions/checkout, which needs
+# contents:read. (The prior SHA-pinned version used inline Python
+# and needed no token at all — see PR #21 review.)
+permissions:
+  contents: read
 
 jobs:
   notify:


### PR DESCRIPTION
## Summary

Follow-up fix for PR #21 review finding: the `octo-pr-feed.yml` caller
workflow had `permissions: {}` which conflicts with the `@v1` reusable
workflow's `actions/checkout` step.

## Root Cause

The `@v1` reusable workflow was refactored from inline Python (no checkout
needed) to `actions/checkout` + external `scripts/octo_pr_feed_notify.py`.
The caller's `permissions: {}` was correct for the old version but starves
the new version of `contents:read` needed for the checkout.

## Fix

Replace `permissions: {}` with `permissions: { contents: read }` and update
the comment to explain why.

## Related

- PR #21 (merged with this gap)
- Review findings: 齐静春 + Jerry-Xin independently identified the mismatch