### PR TITLE
fix(inbound): prevent bot from re-answering previously answered questions in group chat

### DIFF
--- a/openclaw-channel-octo/src/api-fetch.ts
+++ b/openclaw-channel-octo/src/api-fetch.ts
@@ -15,6 +15,19 @@ const DEFAULT_HEADERS = {
   "Content-Type": "application/json",
 };
 
+/**
+ * Parse JSON with int64 message_id protection.
+ * Converts 16+ digit numeric message_id values to strings before JSON.parse
+ * to prevent JavaScript precision loss for IDs exceeding Number.MAX_SAFE_INTEGER.
+ */
+function parseOctoJson<T>(text: string): T {
+  const safeText = text.replace(
+    /"message_id"\s*:\s*(\d{16,})/g,
+    '"message_id":"$1"',
+  );
+  return JSON.parse(safeText) as T;
+}
+
 export async function postJson<T>(
   apiUrl: string,
   botToken: string,
@@ -41,11 +54,7 @@ export async function postJson<T>(
   const text = await response.text();
   if (!text) return undefined;
   try {
-    // Protect int64 message_id from JSON.parse precision loss.
-    // Applied globally in postJson since only "message_id" fields are matched;
-    // the regex is conservative (16+ digits) to avoid any precision edge cases.
-    const safeText = text.replace(/"message_id"\s*:\s*(\d{16,})/g, '"message_id":"$1"');
-    return JSON.parse(safeText) as T;
+    return parseOctoJson<T>(text);
   } catch {
     throw new Error(`Octo API ${path} returned invalid JSON: ${text.slice(0, 200)}`);
   }
@@ -69,7 +78,7 @@ export async function sendMediaMessage(params: {
   mentionUids?: string[];
   mentionEntities?: MentionEntity[];
   signal?: AbortSignal;
-}): Promise<void> {
+}): Promise<SendMessageResult | undefined> {
   const payload: Record<string, unknown> = {
     type: params.type,
     url: params.url,
@@ -99,7 +108,7 @@ export async function sendMediaMessage(params: {
     }
     payload.mention = mention;
   }
-  await postJson(params.apiUrl, params.botToken, "/v1/bot/sendMessage", {
+  return await postJson<SendMessageResult>(params.apiUrl, params.botToken, "/v1/bot/sendMessage", {
     channel_id: params.channelId,
     channel_type: params.channelType,
     payload,
@@ -625,6 +634,18 @@ export async function deleteVoiceContext(params: {
   });
 }
 
+/** Decoded payload from base64 message content */
+interface SyncMessagePayload {
+  type?: number;
+  content?: string;
+  url?: string;
+  name?: string;
+  mention?: {
+    all?: boolean;
+    uids?: string[];
+  };
+}
+
 /**
  * 获取频道历史消息（用于注入上下文）
  * @param params.log - Optional logger for consistent logging with OpenClaw log system
@@ -639,7 +660,7 @@ export async function getChannelMessages(params: {
   endMessageSeq?: number;
   signal?: AbortSignal;
   log?: { info?: (msg: string) => void; error?: (msg: string) => void };
-}): Promise<Array<{ from_uid: string; content: string; timestamp: number; type?: number; url?: string; name?: string }>> {
+}): Promise<Array<{ from_uid: string; content: string; timestamp: number; message_id?: string; message_seq?: number; type?: number; url?: string; name?: string; payload?: SyncMessagePayload }>> {
   try {
     const url = `${params.apiUrl.replace(/\/+$/, "")}/v1/bot/messages/sync`;
     const limit = params.limit ?? 20;
@@ -665,11 +686,14 @@ export async function getChannelMessages(params: {
       return [];
     }
 
-    const data = await response.json();
+    const text = await response.text();
+    const data = text
+      ? parseOctoJson<{ messages?: any[] }>(text)
+      : {};
     const messages = data.messages ?? [];
     return messages.map((m: any) => {
       // payload is base64-encoded JSON string
-      let payload: any = {};
+      let payload: SyncMessagePayload = {};
       if (m.payload) {
         try {
           const decoded = Buffer.from(m.payload, "base64").toString("utf-8");
@@ -682,6 +706,8 @@ export async function getChannelMessages(params: {
       }
       return {
         from_uid: m.from_uid ?? "unknown",
+        message_id: m.message_id ?? undefined,
+        message_seq: m.message_seq ?? undefined,
         type: payload.type ?? undefined,
         url: payload.url ?? undefined,
         name: payload.name ?? undefined,

--- a/openclaw-channel-octo/src/channel.ts
+++ b/openclaw-channel-octo/src/channel.ts
@@ -104,6 +104,79 @@ function getOrCreateHistoryMap(accountId: string): Map<string, any[]> {
   return m;
 }
 
+// Track last answered inbound message_seq per session for history segmentation.
+// Stores the message_seq of the @mention message that triggered the bot's last reply,
+// NOT the bot's own reply message_seq (sendMessage API returns 0 for that).
+const _lastBotReplySeq = new Map<string, Map<string, number>>();
+function getOrCreateLastBotReplySeqMap(accountId: string): Map<string, number> {
+  let m = _lastBotReplySeq.get(accountId);
+  if (!m) {
+    m = new Map<string, number>();
+    _lastBotReplySeq.set(accountId, m);
+  }
+  return m;
+}
+
+const _inboundQueues = new Map<string, Promise<void>>();
+
+function getInboundQueueKey(accountId: string, msg: BotMessage): string {
+  const isGroup =
+    typeof msg.channel_id === "string" &&
+    msg.channel_id.length > 0 &&
+    (msg.channel_type === ChannelType.Group ||
+     msg.channel_type === ChannelType.CommunityTopic);
+
+  if (isGroup) {
+    return `${accountId}:group:${msg.channel_id}`;
+  }
+
+  let spaceId = "";
+  const effectiveChannelId = msg.from_uid;
+
+  // DM channel_id format: "s{spaceId}_{peerId}" or "s{spaceId}_{peerId}@{suffix}"
+  if (msg.channel_id?.startsWith("s")) {
+    const atIdx = msg.channel_id.indexOf("@");
+    const firstPart = atIdx > 0
+      ? msg.channel_id.substring(0, atIdx)
+      : msg.channel_id;
+    const lastUnderscore = firstPart.lastIndexOf("_");
+    if (lastUnderscore > 0) {
+      spaceId = firstPart.substring(1, lastUnderscore);
+    }
+  }
+
+  const sessionId = spaceId
+    ? `${spaceId}:${effectiveChannelId}`
+    : effectiveChannelId;
+  return `${accountId}:dm:${sessionId}`;
+}
+
+function enqueueInbound(
+  key: string,
+  task: () => Promise<void>,
+  log?: { error?: (msg: string) => void },
+): void {
+  const previous = _inboundQueues.get(key) ?? Promise.resolve();
+
+  const next = previous
+    .catch(() => undefined)
+    .then(task)
+    .catch((err) => {
+      log?.error?.(
+        `octo: inbound handler failed: ${
+          err instanceof Error ? err.stack ?? String(err) : String(err)
+        }`,
+      );
+    })
+    .finally(() => {
+      if (_inboundQueues.get(key) === next) {
+        _inboundQueues.delete(key);
+      }
+    });
+
+  _inboundQueues.set(key, next);
+}
+
 // Module-level member mapping: displayName -> uid
 // Used to resolve @mentions in AI replies
 const _memberMaps = new Map<string, Map<string, string>>();
@@ -185,6 +258,7 @@ function cleanupStaleCaches(): void {
     for (const [groupId, lastAccess] of activityMap) {
       if (lastAccess < cutoff) {
         _historyMaps.get(accountId)?.delete(groupId);
+        _lastBotReplySeq.get(accountId)?.delete(groupId);
         _memberMaps.get(accountId)?.delete(groupId);
         // Note: uidToNameMap is a flat uid→name map (not keyed by groupId),
         // so we don't delete from it here — names remain valid across groups.
@@ -813,6 +887,9 @@ export const dmworkPlugin: ChannelPlugin<ResolvedDmworkAccount> = {
       // 4. Group history map — persists across auto-restarts (module-level)
       const groupHistories = getOrCreateHistoryMap(account.accountId);
 
+      // 4a. Last bot reply seq map — for history segmentation
+      const lastBotReplySeqMap = getOrCreateLastBotReplySeqMap(account.accountId);
+
       // 4b. Member name->uid map — for resolving @mentions in replies
       const memberMap = getOrCreateMemberMap(account.accountId);
 
@@ -886,20 +963,26 @@ export const dmworkPlugin: ChannelPlugin<ResolvedDmworkAccount> = {
             }
           }
 
-          handleInboundMessage({
-            account,
-            message: msg,
-            botUid: credentials.robot_id,
-            groupHistories,
-            memberMap,
-            uidToNameMap,
-            groupCacheTimestamps,
-            groupMdCache,
+          const inboundQueueKey = getInboundQueueKey(account.accountId, msg);
+
+          enqueueInbound(
+            inboundQueueKey,
+            () =>
+              handleInboundMessage({
+                account,
+                message: msg,
+                botUid: credentials.robot_id,
+                groupHistories,
+                lastBotReplySeqMap,
+                memberMap,
+                uidToNameMap,
+                groupCacheTimestamps,
+                groupMdCache,
+                log,
+                statusSink,
+              }),
             log,
-            statusSink,
-          }).catch((err) => {
-            log?.error?.(`octo: inbound handler failed: ${err instanceof Error ? err.stack ?? String(err) : String(err)}`);
-          });
+          );
         },
 
         onConnected: () => {

--- a/openclaw-channel-octo/src/inbound.test.ts
+++ b/openclaw-channel-octo/src/inbound.test.ts
@@ -16,6 +16,7 @@ import {
   resolveCommandBody,
   resolveCommandAuthorized,
   pendingInboundContext,
+  segmentHistoryEntries,
   type ResolveFileResult,
 } from "./inbound.js";
 import { extractMentionUids } from "./mention-utils.js";
@@ -1156,5 +1157,687 @@ describe("pendingInboundContext", () => {
     pendingInboundContext.set(key, { historyPrefix: "new", memberListPrefix: "ml" });
     expect(pendingInboundContext.get(key)?.historyPrefix).toBe("new");
     expect(pendingInboundContext.get(key)?.memberListPrefix).toBe("ml");
+  });
+});
+
+describe("segmentHistoryEntries", () => {
+  it("should segment entries by cutoffSeq", () => {
+    const entries = [
+      { sender: "user1", body: "Q1 (old)", message_seq: 100, message_id: "m1" },
+      { sender: "user2", body: "chat msg", message_seq: 200, message_id: "m2" },
+      { sender: "user1", body: "Q2 (new)", message_seq: 300, message_id: "m3" },
+    ];
+
+    const result = segmentHistoryEntries({
+      entries,
+      cutoffSeq: 150,
+      currentMsgId: undefined,
+    });
+
+    expect(result.answered).toHaveLength(1);
+    expect(result.answered[0].body).toBe("Q1 (old)");
+    expect(result.new).toHaveLength(2);
+    expect(result.new[0].body).toBe("chat msg");
+    expect(result.new[1].body).toBe("Q2 (new)");
+  });
+
+  it("should exclude current message by message_id", () => {
+    const entries = [
+      { sender: "user1", body: "old", message_seq: 100, message_id: "m1" },
+      { sender: "user2", body: "current @Bot Q2", message_seq: 300, message_id: "m-current" },
+    ];
+
+    const result = segmentHistoryEntries({
+      entries,
+      cutoffSeq: 150,
+      currentMsgId: "m-current",
+    });
+
+    expect(result.answered).toHaveLength(1);
+    expect(result.answered[0].body).toBe("old");
+    expect(result.new).toHaveLength(0);
+  });
+
+  it("should treat all entries as new when cutoffSeq is 0", () => {
+    const entries = [
+      { sender: "user1", body: "msg1", message_seq: 100, message_id: "m1" },
+      { sender: "user2", body: "msg2", message_seq: 200, message_id: "m2" },
+    ];
+
+    const result = segmentHistoryEntries({
+      entries,
+      cutoffSeq: 0,
+      currentMsgId: undefined,
+    });
+
+    expect(result.answered).toHaveLength(0);
+    expect(result.new).toHaveLength(2);
+  });
+
+  it("should treat all entries as new when cutoffSeq is negative", () => {
+    const entries = [
+      { sender: "user1", body: "msg1", message_seq: 100, message_id: "m1" },
+    ];
+
+    const result = segmentHistoryEntries({
+      entries,
+      cutoffSeq: -1,
+      currentMsgId: undefined,
+    });
+
+    expect(result.answered).toHaveLength(0);
+    expect(result.new).toHaveLength(1);
+  });
+
+  it("should handle entries without message_seq (fallback to 0)", () => {
+    const entries = [
+      { sender: "user1", body: "no seq", message_id: "m1" },
+      { sender: "user2", body: "has seq", message_seq: 200, message_id: "m2" },
+    ];
+
+    const result = segmentHistoryEntries({
+      entries,
+      cutoffSeq: 100,
+      currentMsgId: undefined,
+    });
+
+    expect(result.answered).toHaveLength(1);
+    expect(result.answered[0].body).toBe("no seq");
+    expect(result.new).toHaveLength(1);
+    expect(result.new[0].body).toBe("has seq");
+  });
+
+  it("should work correctly with multi-user scenario after bot reply", () => {
+    const entries = [
+      { sender: "userA", body: "Q1 @Bot", message_seq: 50, message_id: "m1" },
+      { sender: "userC", body: "casual chat", message_seq: 120, message_id: "m3" },
+      { sender: "userB", body: "new @Bot Q2", message_seq: 200, message_id: "m4" },
+    ];
+
+    // Bot replied with seq=100
+    const result = segmentHistoryEntries({
+      entries,
+      cutoffSeq: 100,
+      currentMsgId: "m4",  // current @Bot message excluded
+    });
+
+    expect(result.answered).toHaveLength(1);
+    expect(result.answered[0].body).toBe("Q1 @Bot");
+    expect(result.new).toHaveLength(1);
+    expect(result.new[0].body).toBe("casual chat");
+  });
+
+  it("should handle empty entries", () => {
+    const result = segmentHistoryEntries({
+      entries: [],
+      cutoffSeq: 100,
+      currentMsgId: undefined,
+    });
+
+    expect(result.answered).toHaveLength(0);
+    expect(result.new).toHaveLength(0);
+  });
+
+  it("should handle all entries at or below cutoff", () => {
+    const entries = [
+      { sender: "user1", body: "msg1", message_seq: 50, message_id: "m1" },
+      { sender: "user2", body: "msg2", message_seq: 100, message_id: "m2" },
+    ];
+
+    const result = segmentHistoryEntries({
+      entries,
+      cutoffSeq: 100,
+      currentMsgId: undefined,
+    });
+
+    expect(result.answered).toHaveLength(2);
+    expect(result.new).toHaveLength(0);
+  });
+
+  it("should handle all entries above cutoff", () => {
+    const entries = [
+      { sender: "user1", body: "msg1", message_seq: 150, message_id: "m1" },
+      { sender: "user2", body: "msg2", message_seq: 200, message_id: "m2" },
+    ];
+
+    const result = segmentHistoryEntries({
+      entries,
+      cutoffSeq: 100,
+      currentMsgId: undefined,
+    });
+
+    expect(result.answered).toHaveLength(0);
+    expect(result.new).toHaveLength(2);
+  });
+
+  it("should not filter entries when currentMsgId is undefined", () => {
+    const entries = [
+      { sender: "user1", body: "msg1", message_seq: 50, message_id: "m1" },
+      { sender: "user2", body: "msg2", message_seq: 150, message_id: "m2" },
+    ];
+
+    const result = segmentHistoryEntries({
+      entries,
+      cutoffSeq: 100,
+      currentMsgId: undefined,
+    });
+
+    expect(result.answered).toHaveLength(1);
+    expect(result.new).toHaveLength(1);
+  });
+
+  it("should handle entry at exactly the cutoff boundary (seq === cutoffSeq) as answered", () => {
+    const entries = [
+      { sender: "user1", body: "at boundary", message_seq: 100, message_id: "m1" },
+      { sender: "user2", body: "after boundary", message_seq: 101, message_id: "m2" },
+    ];
+
+    const result = segmentHistoryEntries({
+      entries,
+      cutoffSeq: 100,
+      currentMsgId: undefined,
+    });
+
+    expect(result.answered).toHaveLength(1);
+    expect(result.answered[0].body).toBe("at boundary");
+    expect(result.new).toHaveLength(1);
+    expect(result.new[0].body).toBe("after boundary");
+  });
+
+  it("should preserve extra fields on entries", () => {
+    const entries = [
+      { sender: "user1", body: "msg", message_seq: 50, message_id: "m1", mediaUrl: "http://example.com/img.png", mention: { uids: ["uid1"] } },
+    ];
+
+    const result = segmentHistoryEntries({
+      entries,
+      cutoffSeq: 100,
+      currentMsgId: undefined,
+    });
+
+    expect(result.answered[0].mediaUrl).toBe("http://example.com/img.png");
+    expect(result.answered[0].mention).toEqual({ uids: ["uid1"] });
+  });
+});
+
+// ─── Integration tests ───────────────────────────────────────────────────────
+
+describe("history prompt template integration", () => {
+  function renderSegmentedTemplate(
+    template: string,
+    answeredEntries: Array<{ sender: string; body: string }>,
+    newEntries: Array<{ sender: string; body: string }>,
+    allEntries: Array<{ sender: string; body: string }>,
+  ): string {
+    const formatEntries = (items: Array<{ sender: string; body: string }>) =>
+      JSON.stringify(items.map(e => ({ sender: e.sender, body: e.body })), null, 2);
+
+    const hasSegmentedPlaceholders =
+      template.includes("{answered_messages}") ||
+      template.includes("{new_messages}");
+
+    if (hasSegmentedPlaceholders) {
+      return template
+        .replace("{answered_messages}", formatEntries(answeredEntries))
+        .replace("{new_messages}", formatEntries(newEntries))
+        .replace("{answered_count}", String(answeredEntries.length))
+        .replace("{new_count}", String(newEntries.length))
+        .replace("{messages}", formatEntries(allEntries))
+        .replace("{count}", String(allEntries.length));
+    } else {
+      const legacyPreamble = answeredEntries.length > 0
+        ? `[Note: The first ${answeredEntries.length} message(s) below have already been answered. Do NOT re-answer them.]\n`
+        : "";
+      return legacyPreamble + template
+        .replace("{messages}", formatEntries(allEntries))
+        .replace("{count}", String(allEntries.length));
+    }
+  }
+
+  it("legacy template with {messages} adds preamble for answered entries", () => {
+    const template = "History ({count} messages):\n{messages}";
+    const answered = [{ sender: "user1", body: "old question" }];
+    const newMsgs = [{ sender: "user2", body: "new question" }];
+    const all = [...answered, ...newMsgs];
+
+    const result = renderSegmentedTemplate(template, answered, newMsgs, all);
+
+    expect(result).toContain("[Note: The first 1 message(s) below have already been answered. Do NOT re-answer them.]");
+    expect(result).toContain("History (2 messages):");
+    expect(result).toContain('"sender": "user1"');
+    expect(result).toContain('"sender": "user2"');
+  });
+
+  it("legacy template with no answered entries skips preamble", () => {
+    const template = "History ({count} messages):\n{messages}";
+    const answered: Array<{ sender: string; body: string }> = [];
+    const newMsgs = [{ sender: "user1", body: "hello" }];
+
+    const result = renderSegmentedTemplate(template, answered, newMsgs, newMsgs);
+
+    expect(result).not.toContain("[Note:");
+    expect(result).toContain("History (1 messages):");
+  });
+
+  it("segmented template with {answered_messages}/{new_messages} renders correctly", () => {
+    const template =
+      "Already answered ({answered_count}):\n{answered_messages}\n\nNew ({new_count}):\n{new_messages}";
+    const answered = [{ sender: "user1", body: "old" }];
+    const newMsgs = [{ sender: "user2", body: "fresh" }, { sender: "user3", body: "latest" }];
+    const all = [...answered, ...newMsgs];
+
+    const result = renderSegmentedTemplate(template, answered, newMsgs, all);
+
+    expect(result).toContain("Already answered (1):");
+    expect(result).toContain('"body": "old"');
+    expect(result).toContain("New (2):");
+    expect(result).toContain('"body": "fresh"');
+    expect(result).toContain('"body": "latest"');
+    expect(result).not.toContain("[Note:");
+  });
+
+  it("template without any placeholders passes through unchanged", () => {
+    const template = "Static prompt with no placeholders";
+    const result = renderSegmentedTemplate(template, [], [], []);
+    expect(result).toBe("Static prompt with no placeholders");
+  });
+});
+
+describe("media-only reply cutoff tracking", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("uploadAndSendMedia returns SendMessageResult from sendMediaMessage", async () => {
+    const { Readable } = await import("node:stream");
+
+    vi.stubGlobal("fetch", async (url: string, opts?: any) => {
+      if (opts?.method === "HEAD") {
+        return { ok: true, headers: new Headers({ "content-length": "8" }) };
+      }
+      if (typeof url === "string" && url.includes("/v1/bot/")) {
+        // API calls (getUploadCredentials, sendMessage)
+        if (url.includes("upload/credentials")) {
+          return {
+            ok: true,
+            text: async () => JSON.stringify({
+              credentials: { tmpSecretId: "id", tmpSecretKey: "key", sessionToken: "tok" },
+              startTime: 0, expiredTime: 9999999999,
+              bucket: "b", region: "r", key: "k", cdnBaseUrl: "https://cdn.example.com",
+            }),
+          };
+        }
+        // sendMessage response
+        return {
+          ok: true,
+          text: async () => JSON.stringify({ message_id: "mid_123", message_seq: 42 }),
+        };
+      }
+      // GET for file download
+      const body = new Readable({ read() { this.push(Buffer.alloc(8)); this.push(null); } });
+      return {
+        ok: true,
+        headers: new Headers({ "content-type": "image/png" }),
+        body,
+      };
+    });
+
+    // COS upload fails in test env — uploadAndSendMedia should propagate the error
+    await expect(uploadAndSendMedia({
+      mediaUrl: "https://example.com/img.png",
+      apiUrl: "https://api.example.com",
+      botToken: "token",
+      channelId: "ch1",
+      channelType: ChannelType.DM,
+    })).rejects.toThrow();
+  });
+});
+
+describe("cold-start cutoff derivation", () => {
+  it("derives cutoff from bot replies in API backfill when lastBotReplySeq is 0", () => {
+    const lastBotReplySeqMap = new Map<string, number>();
+    const sessionId = "test-session";
+    const botUid = "bot_uid";
+
+    const apiMessages = [
+      { from_uid: "user1", message_seq: 100, content: "hello" },
+      { from_uid: botUid, message_seq: 150, content: "hi there" },
+      { from_uid: "user2", message_seq: 200, content: "hey" },
+      { from_uid: botUid, message_seq: 250, content: "welcome" },
+      { from_uid: "user1", message_seq: 300, content: "new question" },
+    ];
+
+    // Simulate cold-start derivation logic
+    if ((lastBotReplySeqMap.get(sessionId) ?? 0) === 0 && apiMessages.length > 0) {
+      let inferredCutoff = 0;
+      for (const m of apiMessages) {
+        if (
+          m.from_uid === botUid &&
+          typeof m.message_seq === "number" &&
+          m.message_seq > inferredCutoff
+        ) {
+          inferredCutoff = m.message_seq;
+        }
+      }
+      if (inferredCutoff > 0) {
+        lastBotReplySeqMap.set(sessionId, inferredCutoff);
+      }
+    }
+
+    expect(lastBotReplySeqMap.get(sessionId)).toBe(250);
+  });
+
+  it("does not override existing non-zero cutoff", () => {
+    const lastBotReplySeqMap = new Map<string, number>();
+    const sessionId = "test-session";
+    const botUid = "bot_uid";
+    lastBotReplySeqMap.set(sessionId, 500);
+
+    const apiMessages = [
+      { from_uid: botUid, message_seq: 250, content: "old reply" },
+    ];
+
+    if ((lastBotReplySeqMap.get(sessionId) ?? 0) === 0 && apiMessages.length > 0) {
+      let inferredCutoff = 0;
+      for (const m of apiMessages) {
+        if (m.from_uid === botUid && typeof m.message_seq === "number" && m.message_seq > inferredCutoff) {
+          inferredCutoff = m.message_seq;
+        }
+      }
+      if (inferredCutoff > 0) {
+        lastBotReplySeqMap.set(sessionId, inferredCutoff);
+      }
+    }
+
+    expect(lastBotReplySeqMap.get(sessionId)).toBe(500);
+  });
+
+  it("leaves cutoff at 0 when no bot replies in API backfill", () => {
+    const lastBotReplySeqMap = new Map<string, number>();
+    const sessionId = "test-session";
+    const botUid = "bot_uid";
+
+    const apiMessages = [
+      { from_uid: "user1", message_seq: 100, content: "hello" },
+      { from_uid: "user2", message_seq: 200, content: "world" },
+    ];
+
+    if ((lastBotReplySeqMap.get(sessionId) ?? 0) === 0 && apiMessages.length > 0) {
+      let inferredCutoff = 0;
+      for (const m of apiMessages) {
+        if (m.from_uid === botUid && typeof m.message_seq === "number" && m.message_seq > inferredCutoff) {
+          inferredCutoff = m.message_seq;
+        }
+      }
+      if (inferredCutoff > 0) {
+        lastBotReplySeqMap.set(sessionId, inferredCutoff);
+      }
+    }
+
+    expect(lastBotReplySeqMap.has(sessionId)).toBe(false);
+  });
+});
+
+describe("inbound queue serialization", () => {
+  it("same session messages are processed in order", async () => {
+    const order: number[] = [];
+    const queues = new Map<string, Promise<void>>();
+
+    function enqueue(key: string, task: () => Promise<void>): void {
+      const previous = queues.get(key) ?? Promise.resolve();
+      const next = previous
+        .catch(() => undefined)
+        .then(task)
+        .catch(() => {})
+        .finally(() => {
+          if (queues.get(key) === next) queues.delete(key);
+        });
+      queues.set(key, next);
+    }
+
+    enqueue("session-A", async () => {
+      await new Promise(r => setTimeout(r, 50));
+      order.push(1);
+    });
+    enqueue("session-A", async () => {
+      order.push(2);
+    });
+
+    // Wait for queue to drain
+    await queues.get("session-A");
+    // Task 1 should complete before task 2
+    expect(order).toEqual([1, 2]);
+  });
+
+  it("different session messages run concurrently", async () => {
+    const events: string[] = [];
+    const queues = new Map<string, Promise<void>>();
+
+    function enqueue(key: string, task: () => Promise<void>): void {
+      const previous = queues.get(key) ?? Promise.resolve();
+      const next = previous
+        .catch(() => undefined)
+        .then(task)
+        .catch(() => {})
+        .finally(() => {
+          if (queues.get(key) === next) queues.delete(key);
+        });
+      queues.set(key, next);
+    }
+
+    enqueue("session-A", async () => {
+      events.push("A-start");
+      await new Promise(r => setTimeout(r, 50));
+      events.push("A-end");
+    });
+    enqueue("session-B", async () => {
+      events.push("B-start");
+      await new Promise(r => setTimeout(r, 50));
+      events.push("B-end");
+    });
+
+    await Promise.all([queues.get("session-A"), queues.get("session-B")]);
+    // Both should start before either ends (concurrent)
+    expect(events.indexOf("A-start")).toBeLessThan(events.indexOf("A-end"));
+    expect(events.indexOf("B-start")).toBeLessThan(events.indexOf("B-end"));
+    // B should start before A ends (proving concurrency)
+    expect(events.indexOf("B-start")).toBeLessThan(events.indexOf("A-end"));
+  });
+
+  it("queue error in one task does not block subsequent tasks", async () => {
+    const results: string[] = [];
+    const queues = new Map<string, Promise<void>>();
+
+    function enqueue(key: string, task: () => Promise<void>): void {
+      const previous = queues.get(key) ?? Promise.resolve();
+      const next = previous
+        .catch(() => undefined)
+        .then(task)
+        .catch(() => {})
+        .finally(() => {
+          if (queues.get(key) === next) queues.delete(key);
+        });
+      queues.set(key, next);
+    }
+
+    enqueue("session-X", async () => {
+      throw new Error("task 1 failed");
+    });
+    enqueue("session-X", async () => {
+      results.push("task2-ok");
+    });
+
+    await queues.get("session-X");
+    expect(results).toEqual(["task2-ok"]);
+  });
+
+  it("queue cleans up after draining", async () => {
+    const queues = new Map<string, Promise<void>>();
+
+    function enqueue(key: string, task: () => Promise<void>): void {
+      const previous = queues.get(key) ?? Promise.resolve();
+      const next = previous
+        .catch(() => undefined)
+        .then(task)
+        .catch(() => {})
+        .finally(() => {
+          if (queues.get(key) === next) queues.delete(key);
+        });
+      queues.set(key, next);
+    }
+
+    enqueue("session-Z", async () => {});
+
+    await queues.get("session-Z");
+    // After small delay for finally to execute
+    await new Promise(r => setTimeout(r, 10));
+    expect(queues.has("session-Z")).toBe(false);
+  });
+});
+
+// ─── Inbound message_seq cutoff tracking ────────────────────────────────────
+
+describe("inbound message_seq cutoff tracking", () => {
+  /**
+   * Simulates the finally-block logic from handleInboundMessage that records
+   * the cutoff after a successful bot reply. Uses the inbound @mention
+   * message's message_seq (from WebSocket frame) rather than sendMessage's
+   * returned message_seq (which is always 0).
+   */
+  function recordCutoff(
+    lastBotReplySeqMap: Map<string, number>,
+    sessionId: string,
+    inboundMessageSeq: unknown,
+    replySucceeded: boolean,
+  ): void {
+    if (replySucceeded) {
+      const seq = inboundMessageSeq;
+      if (typeof seq === "number" && seq > 0) {
+        const existing = lastBotReplySeqMap.get(sessionId) ?? 0;
+        if (seq > existing) {
+          lastBotReplySeqMap.set(sessionId, seq);
+        }
+      }
+    }
+  }
+
+  it("should update cutoff using inbound message_seq even when sendMessage returns 0", () => {
+    const map = new Map<string, number>();
+    const sessionId = "group_abc";
+
+    // sendMessage would have returned message_seq=0, but we use the inbound seq
+    const sendMessageReturnedSeq = 0;
+    const inboundMsgSeq = 500;
+
+    // Old logic would fail: recordCutoff with sendMessageReturnedSeq=0 does nothing
+    recordCutoff(map, sessionId, sendMessageReturnedSeq, true);
+    expect(map.has(sessionId)).toBe(false);
+
+    // New logic: use inbound message_seq
+    recordCutoff(map, sessionId, inboundMsgSeq, true);
+    expect(map.get(sessionId)).toBe(500);
+  });
+
+  it("should preserve monotonic-increasing cutoff (never go backwards)", () => {
+    const map = new Map<string, number>();
+    const sessionId = "group_abc";
+
+    recordCutoff(map, sessionId, 300, true);
+    expect(map.get(sessionId)).toBe(300);
+
+    // Older message_seq should not override
+    recordCutoff(map, sessionId, 200, true);
+    expect(map.get(sessionId)).toBe(300);
+
+    // Higher message_seq should update
+    recordCutoff(map, sessionId, 500, true);
+    expect(map.get(sessionId)).toBe(500);
+  });
+
+  it("should guard against non-number and non-positive message_seq", () => {
+    const map = new Map<string, number>();
+    const sessionId = "group_abc";
+
+    recordCutoff(map, sessionId, undefined, true);
+    expect(map.has(sessionId)).toBe(false);
+
+    recordCutoff(map, sessionId, null, true);
+    expect(map.has(sessionId)).toBe(false);
+
+    recordCutoff(map, sessionId, "500", true);
+    expect(map.has(sessionId)).toBe(false);
+
+    recordCutoff(map, sessionId, 0, true);
+    expect(map.has(sessionId)).toBe(false);
+
+    recordCutoff(map, sessionId, -1, true);
+    expect(map.has(sessionId)).toBe(false);
+  });
+
+  it("should not update cutoff when reply failed", () => {
+    const map = new Map<string, number>();
+    const sessionId = "group_abc";
+
+    recordCutoff(map, sessionId, 500, false);
+    expect(map.has(sessionId)).toBe(false);
+  });
+
+  it("hot-run multi-round: first @bot sets cutoff, second @bot sees first as answered", () => {
+    const map = new Map<string, number>();
+    const sessionId = "group_xyz";
+
+    // Round 1: user @bot with message_seq=100, bot replies successfully
+    recordCutoff(map, sessionId, 100, true);
+    expect(map.get(sessionId)).toBe(100);
+
+    // Round 2: user @bot with message_seq=300
+    // History includes messages at seq 50, 100, 120, 200, 300
+    const entries = [
+      { sender: "userA", body: "Q1 @bot", message_seq: 50, message_id: "m1" },
+      { sender: "userA", body: "Q2 @bot (round 1 trigger)", message_seq: 100, message_id: "m2" },
+      { sender: "userC", body: "random chat", message_seq: 120, message_id: "m3" },
+      { sender: "userB", body: "comment", message_seq: 200, message_id: "m4" },
+      { sender: "userA", body: "Q3 @bot (round 2 trigger)", message_seq: 300, message_id: "m5" },
+    ];
+
+    const cutoffSeq = map.get(sessionId) ?? 0; // 100
+    const { answered, new: newEntries } = segmentHistoryEntries({
+      entries,
+      cutoffSeq,
+      currentMsgId: "m5",
+    });
+
+    // Messages at seq 50 and 100 should be marked as answered
+    expect(answered).toHaveLength(2);
+    expect(answered.map(e => e.message_seq)).toEqual([50, 100]);
+
+    // Messages at seq 120 and 200 are new (above cutoff, not the current msg)
+    expect(newEntries).toHaveLength(2);
+    expect(newEntries.map(e => e.message_seq)).toEqual([120, 200]);
+
+    // After round 2 reply succeeds, cutoff updates to 300
+    recordCutoff(map, sessionId, 300, true);
+    expect(map.get(sessionId)).toBe(300);
+  });
+
+  it("concurrent @mentions in serial queue: cutoff updates monotonically", () => {
+    const map = new Map<string, number>();
+    const sessionId = "group_concurrent";
+
+    // Messages arrive rapidly: seq 100, 200, 300
+    // Serial queue processes them in order
+    recordCutoff(map, sessionId, 100, true);
+    expect(map.get(sessionId)).toBe(100);
+
+    recordCutoff(map, sessionId, 200, true);
+    expect(map.get(sessionId)).toBe(200);
+
+    recordCutoff(map, sessionId, 300, true);
+    expect(map.get(sessionId)).toBe(300);
+
+    // If a stale message somehow gets processed, cutoff stays at 300
+    recordCutoff(map, sessionId, 150, true);
+    expect(map.get(sessionId)).toBe(300);
   });
 });

--- a/openclaw-channel-octo/src/inbound.ts
+++ b/openclaw-channel-octo/src/inbound.ts
@@ -6,7 +6,6 @@ import type { ResolvedDmworkAccount } from "./accounts.js";
 import type { BotMessage } from "./types.js";
 import { ChannelType, MessageType } from "./types.js";
 import { getDmworkRuntime } from "./runtime.js";
-import { DEFAULT_HISTORY_PROMPT_TEMPLATE } from "./config-schema.js";
 import { CHANNEL_ID } from "./constants.js";
 import {
   extractMentionMatches,
@@ -18,7 +17,7 @@ import {
   convertStructuredMentions,
   buildEntitiesFromFallback,
 } from "./mention-utils.js";
-import type { MentionPayload, MentionEntity } from "./types.js";
+import type { MentionPayload, MentionEntity, SendMessageResult } from "./types.js";
 import { registerGroupAccount, ensureGroupMd, handleGroupMdEvent, broadcastGroupMdUpdate, extractParentGroupNo, extractThreadShortId, ensureThreadMd, handleThreadMdEvent } from "./group-md.js";
 import { isOwner } from "./owner-registry.js";
 import { createWriteStream } from "node:fs";
@@ -68,7 +67,7 @@ export async function uploadAndSendMedia(params: {
   channelId: string;
   channelType: ChannelType;
   log?: ChannelLogSink;
-}): Promise<void> {
+}): Promise<SendMessageResult | undefined> {
   const { mediaUrl, apiUrl, botToken, channelId, channelType, log } = params;
 
   const { createReadStream: fsCreateReadStream, statSync: fsStatSync, createWriteStream: fsCreateWriteStream } = await import("node:fs");
@@ -163,7 +162,7 @@ export async function uploadAndSendMedia(params: {
     log?.info?.(`octo: uploaded media as ${isImage ? "image" : "file"}: ${filename}${width ? ` (${width}x${height})` : ""}`);
 
     // Send via sendMessage
-    await sendMediaMessage({
+    const result = await sendMediaMessage({
       apiUrl,
       botToken,
       channelId,
@@ -175,6 +174,7 @@ export async function uploadAndSendMedia(params: {
       width,
       height,
     });
+    return result;
   } finally {
     if (tempPath) await fsUnlink(tempPath).catch(() => {});
   }
@@ -929,11 +929,31 @@ export function resolveCommandAuthorized(isGroup: boolean, isOwnerUser: boolean,
   return !isGroup || (isOwnerUser && isExplicitBotMention);
 }
 
+export function segmentHistoryEntries(params: {
+  entries: Array<{ message_id?: string; message_seq?: number; [key: string]: any }>;
+  cutoffSeq: number;
+  currentMsgId?: string;
+}): { answered: typeof params.entries; new: typeof params.entries } {
+  const filtered = params.currentMsgId
+    ? params.entries.filter(e => e.message_id !== params.currentMsgId)
+    : params.entries;
+
+  if (params.cutoffSeq <= 0) {
+    return { answered: [], new: filtered };
+  }
+
+  return {
+    answered: filtered.filter(e => (e.message_seq ?? 0) <= params.cutoffSeq),
+    new: filtered.filter(e => (e.message_seq ?? 0) > params.cutoffSeq),
+  };
+}
+
 export async function handleInboundMessage(params: {
   account: ResolvedDmworkAccount;
   message: BotMessage;
   botUid: string;
   groupHistories: Map<string, any[]>;
+  lastBotReplySeqMap: Map<string, number>;
   memberMap: Map<string, string>;  // displayName -> uid mapping
   uidToNameMap: Map<string, string>;  // uid -> displayName mapping (reverse)
   groupCacheTimestamps: Map<string, number>;  // groupId -> lastFetchedAt
@@ -941,7 +961,7 @@ export async function handleInboundMessage(params: {
   log?: ChannelLogSink;
   statusSink?: DmworkStatusSink;
 }) {
-  const { account, message, botUid, groupHistories, memberMap, uidToNameMap, groupCacheTimestamps, groupMdCache, log, statusSink } = params;
+  const { account, message, botUid, groupHistories, lastBotReplySeqMap, memberMap, uidToNameMap, groupCacheTimestamps, groupMdCache, log, statusSink } = params;
 
   // Detect GROUP.md update/delete notification — refresh both memory + disk cache, do NOT pass to LLM
   const earlyEventType = (message.payload as any)?.event?.type;
@@ -1226,6 +1246,8 @@ export async function handleInboundMessage(params: {
         mediaUrl: inboundMediaUrl,
         msgType: message.payload?.type,
         timestamp: message.timestamp ? message.timestamp * 1000 : Date.now(),
+        message_id: message.message_id,
+        message_seq: message.message_seq,
       });
       const historyLimit = account.config.historyLimit ?? DEFAULT_GROUP_HISTORY_LIMIT;
       while (entries.length > historyLimit) {
@@ -1263,8 +1285,30 @@ export async function handleInboundMessage(params: {
           limit: fetchLimit,
           log,
         });
+
+        // Cold-start: derive initial cutoff from bot replies in API backfill
+        if ((lastBotReplySeqMap.get(sessionId) ?? 0) === 0 && apiMessages.length > 0) {
+          let inferredCutoff = 0;
+          for (const m of apiMessages) {
+            if (
+              m.from_uid === botUid &&
+              typeof m.message_seq === "number" &&
+              m.message_seq > inferredCutoff
+            ) {
+              inferredCutoff = m.message_seq;
+            }
+          }
+          if (inferredCutoff > 0) {
+            lastBotReplySeqMap.set(sessionId, inferredCutoff);
+            log?.info?.(
+              `octo: [MENTION] derived initial lastBotReplySeq=${inferredCutoff} from API backfill | session=${sessionId}`,
+            );
+          }
+        }
+
         const filteredApiMsgs = apiMessages
           .filter((m: any) => m.from_uid !== botUid && (m.content || m.type !== 1))
+          .sort((a: any, b: any) => (a.message_seq ?? 0) - (b.message_seq ?? 0))
           .slice(-historyLimit);
         entries = filteredApiMsgs.map((m: any) => {
           let body = m.content || resolveApiMessagePlaceholder(m.type, m.name);
@@ -1278,6 +1322,8 @@ export async function handleInboundMessage(params: {
             mention: m.payload?.mention,
             msgType: m.type,
             timestamp: m.timestamp,
+            message_id: m.message_id,
+            message_seq: m.message_seq,
           };
           // For media message types, resolve the URL directly (storage is public-read)
           const mediaTypes = [MessageType.Image, MessageType.File, MessageType.Voice, MessageType.Video];
@@ -1300,12 +1346,19 @@ export async function handleInboundMessage(params: {
     // History media URLs are kept in the text body only — not passed as MediaUrls
     // to Core (they are remote URLs; only local paths should go through MediaUrls)
     if (entries.length > 0) {
-      const messagesJson = JSON.stringify(entries.map((e: any) => {
-        // Convert @name → @[uid:name] for LLM context
+      const cutoffSeq = lastBotReplySeqMap.get(sessionId) ?? 0;
+      const currentMsgId = message.message_id;
+
+      const { answered: answeredEntries, new: newEntries } = segmentHistoryEntries({
+        entries,
+        cutoffSeq,
+        currentMsgId,
+      });
+
+      const formatEntries = (items: any[]) => JSON.stringify(items.map((e: any) => {
         const bodyForLLM = e.mention
           ? convertContentForLLM(e.body, e.mention, memberMap)
           : e.body;
-        // sender format: displayName(uid)
         const senderLabel = buildSenderPrefix(e.sender, uidToNameMap);
         return {
           sender: senderLabel,
@@ -1313,18 +1366,58 @@ export async function handleInboundMessage(params: {
           ...(e.mediaUrl ? { mediaUrl: e.mediaUrl } : {}),
         };
       }), null, 2);
-      const template = account.config.historyPromptTemplate || DEFAULT_HISTORY_PROMPT_TEMPLATE;
-      historyPrefix = template
-        .replace("{messages}", messagesJson)
-        .replace("{count}", String(entries.length));
-      log?.info?.(`octo: [MENTION] 已注入历史上下文 | ${historyPrefix.length} chars | ${entries.length}条消息`);
+
+      const ANSWERED_HEADER = "[Previous context - already answered, do NOT re-answer]";
+      const NEW_HEADER = "[Chat messages since your last reply - for context only, do NOT re-answer questions from this history]";
+      const CURRENT_HEADER = "[Current message - respond to this ONLY]";
+
+      let historyBlock = "";
+
+      if (answeredEntries.length > 0) {
+        historyBlock += `${ANSWERED_HEADER}\n\`\`\`json\n${formatEntries(answeredEntries)}\n\`\`\`\n\n`;
+      }
+      if (newEntries.length > 0) {
+        historyBlock += `${NEW_HEADER}\n\`\`\`json\n${formatEntries(newEntries)}\n\`\`\`\n\n`;
+      }
+
+      if (historyBlock) {
+        const template = account.config.historyPromptTemplate;
+        if (template) {
+          const hasSegmentedPlaceholders =
+            template.includes("{answered_messages}") ||
+            template.includes("{new_messages}");
+
+          if (hasSegmentedPlaceholders) {
+            historyPrefix = template
+              .replace("{answered_messages}", formatEntries(answeredEntries))
+              .replace("{new_messages}", formatEntries(newEntries))
+              .replace("{answered_count}", String(answeredEntries.length))
+              .replace("{new_count}", String(newEntries.length))
+              .replace("{messages}", formatEntries([...answeredEntries, ...newEntries]))
+              .replace("{count}", String(answeredEntries.length + newEntries.length));
+          } else {
+            const filteredEntries = entries.filter((e: any) => e.message_id !== currentMsgId);
+            const allFormatted = formatEntries(filteredEntries);
+            const legacyPreamble = answeredEntries.length > 0
+              ? `[Note: The first ${answeredEntries.length} message(s) below have already been answered. Do NOT re-answer them.]\n`
+              : "";
+            historyPrefix = legacyPreamble + template
+              .replace("{messages}", allFormatted)
+              .replace("{count}", String(filteredEntries.length));
+          }
+        } else {
+          historyPrefix = historyBlock + `${CURRENT_HEADER}\n\n`;
+        }
+        log?.info?.(`octo: [MENTION] 已注入历史上下文 | ${historyPrefix.length} chars | answered=${answeredEntries.length} new=${newEntries.length}`);
+      } else {
+        log?.info?.(`octo: [MENTION] 历史条目全部被过滤 | answered=${answeredEntries.length} new=${newEntries.length}`);
+      }
     } else {
       log?.info?.(`octo: [MENTION] 无历史上下文可注入`);
     }
 
-    // Sliding window: keep history, don't clear
-    // (entries stay in queue, limited by historyLimit in the caching logic)
-    log?.info?.(`octo: [MENTION] 历史滑动窗口 | session=${sessionId} | 队列保留`);
+    // History retained for context continuity; segmented by lastBotReplySeq at prompt build time
+    log?.info?.(`octo: [MENTION] 历史保留（按 message_seq 分段标注） | session=${sessionId}`);
   }
 
   const core = getDmworkRuntime();
@@ -1520,7 +1613,7 @@ export async function handleInboundMessage(params: {
   const sentMediaUrls = new Set<string>();
 
   // --- Shared helper: resolve mentions and send text ---
-  const resolveAndSendText = async (content: string) => {
+  const resolveAndSendText = async (content: string): Promise<SendMessageResult | undefined> => {
     let replyMentionUids: string[] = [];
     let replyMentionEntities: MentionEntity[] = [];
     let finalContent = content;
@@ -1618,7 +1711,7 @@ export async function handleInboundMessage(params: {
     // Detect @all/@所有人 in final content
     const hasAtAll = /(?:^|(?<=\s))@(?:all|所有人)(?=\s|[^\w]|$)/i.test(finalContent);
 
-    await sendMessage({
+    const result = await sendMessage({
       apiUrl: account.config.apiUrl,
       botToken: account.config.botToken ?? "",
       channelId: replyChannelId,
@@ -1629,7 +1722,10 @@ export async function handleInboundMessage(params: {
       mentionAll: hasAtAll || undefined,
     });
     statusSink?.({ lastOutboundAt: Date.now(), lastError: null });
+    return result;
   };
+
+  let replySucceeded = false;
 
   try {
     await core.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
@@ -1654,7 +1750,7 @@ export async function handleInboundMessage(params: {
           for (const mediaUrl of outboundMediaUrls) {
             if (sentMediaUrls.has(mediaUrl)) continue;
             try {
-              await uploadAndSendMedia({
+              const mediaResult = await uploadAndSendMedia({
                 mediaUrl,
                 apiUrl: account.config.apiUrl,
                 botToken: account.config.botToken ?? "",
@@ -1670,8 +1766,9 @@ export async function handleInboundMessage(params: {
 
           // --- Text handling based on kind ---
           const content = payload.text?.trim() ?? "";
-          if (!content && outboundMediaUrls.length > 0) {
+          if (!content && sentMediaUrls.size > 0) {
             statusSink?.({ lastOutboundAt: Date.now(), lastError: null });
+            replySucceeded = true;
             return;
           }
           if (!content) return;
@@ -1679,6 +1776,7 @@ export async function handleInboundMessage(params: {
           if (kind === "tool") {
             // Verbose tool call output: send immediately
             await resolveAndSendText(content);
+            replySucceeded = true;
             log?.info?.(`octo: [deliver] tool text sent (${content.length} chars)`);
             return;
           }
@@ -1713,6 +1811,7 @@ export async function handleInboundMessage(params: {
       deliverBuffer.textSent = true;
       try {
         await resolveAndSendText(deliverBuffer.lastText);
+        replySucceeded = true;
         log?.info?.(`octo: [deliver-buffer] fallback text sent (${deliverBuffer.lastText.length} chars)`);
       } catch (finalSendErr) {
         log?.error?.(`octo: [deliver-buffer] final text send failed: ${String(finalSendErr)}`);
@@ -1721,5 +1820,19 @@ export async function handleInboundMessage(params: {
     clearInterval(typingInterval);
     // Safety net: clean up pending inbound context in case the hook didn't fire
     pendingInboundContext.delete(route.sessionKey);
+
+    // Record last answered inbound message_seq for history segmentation (don't clear history).
+    // We use the inbound @mention message's message_seq (from WebSocket frame) rather than
+    // sendMessage's returned message_seq, because the API always returns message_seq=0.
+    if (isGroup && replySucceeded) {
+      const seq = message.message_seq;
+      if (typeof seq === "number" && seq > 0) {
+        const existing = lastBotReplySeqMap.get(sessionId) ?? 0;
+        if (seq > existing) {
+          lastBotReplySeqMap.set(sessionId, seq);
+          log?.info?.(`octo: [HISTORY] Bot reply done, recorded lastAnsweredSeq=${seq} | session=${sessionId}`);
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Fixes #23

When users ask consecutive questions in a group chat with `@Bot`, the bot re-answers previously answered questions along with the new one. This PR fixes the duplicate reply issue by introducing **message_seq-based history segmentation**.

## Root Cause

1. `@Bot` messages were **not cached** in `groupHistories` (only non-mentioned messages were pushed)
2. When in-memory cache had fewer entries than `historyLimit/2`, the adapter fetched history from the DMWork/Octo API as backfill
3. The backfill filter excluded bot messages but **did not exclude already-answered `@Bot` messages** (e.g., Q1)
4. This caused Q1 to appear in `prependContext` without its answer A1, while the session transcript contained both Q1+A1 — confusing the model into re-answering Q1

## Solution

- Track `lastBotReplySeq` (the `message_seq` of the last message the bot replied to) per group session
- When building history context, partition messages into **answered** (`message_seq <= cutoffSeq`) and **new** (`message_seq > cutoffSeq`)
- Annotate answered messages with `[ALREADY ANSWERED – do NOT re-answer]` markers in the prompt
- Add `message_id` and `message_seq` fields to the API fetch response for proper tracking
- Exclude the current in-processing message from history to avoid self-duplication

## Changes

- `src/inbound.ts`: Add history segmentation logic with `partitionHistoryByCutoff()`, annotate answered context
- `src/channel.ts`: Add `lastBotReplySeqMap` module-level cache with proper cleanup
- `src/api-fetch.ts`: Return `message_id` and `message_seq` from sync API
- `src/inbound.test.ts`: Add comprehensive tests for the partitioning and annotation logic