### PR TITLE
chore(automation): switch dependabot tracking to openclaw-channel-octo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -20,7 +20,7 @@ body:
       label: Steps to Reproduce
       description: List the steps to reproduce
       placeholder: |
-        1. Configure dmwork channel plugin
+        1. Configure octo channel plugin
         2. Run `openclaw gateway restart`
         3. Observe logs: WebSocket disconnects every 30s
     validations:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directory: "/openclaw-channel-dmwork"
+    directory: "/openclaw-channel-octo"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Summary

Switches Dependabot to track the active `openclaw-channel-octo` package instead of the deprecated `openclaw-channel-dmwork` shim. Eliminates the major-version bump noise (#2, #3, #4) targeting the frozen dmwork directory and starts surfacing dependency updates on the package that actually receives new work.

## Related Issue

Addresses the source of the unsolicited major-bump PRs (#2 TypeScript 6, #3 Vitest 4, #4 commander 14). Those PRs should be closed after this lands.

## Changes

- **`.github/dependabot.yml`**: change `directory: /openclaw-channel-dmwork` → `/openclaw-channel-octo`. The dmwork package is now maintenance-only (migration shim for legacy dmwork users) and intentionally frozen on its current dependency set to avoid regression risk in the migration path; we no longer accept automated dependency updates for that directory.
- **`.github/ISSUE_TEMPLATE/bug_report.yml`**: rename "Configure dmwork channel plugin" → "Configure octo channel plugin" in the Steps to Reproduce placeholder so new bug reports reflect the current package name.

## Testing

- [x] Manually verified diff (config-only, 2 lines changed)
- [x] No source code, build, or CI path touched
- [ ] Unit tests added/updated — N/A (config-only)
- [ ] Manually verified Dependabot picks up the new directory — will confirm after merge by checking next Dependabot run in repo Insights

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [ ] Added tests for my changes — N/A (config-only)
- [ ] Updated documentation — N/A (separate PR will add a deprecation header to \`openclaw-channel-dmwork/README.md\`)
- [x] Followed commit message conventions (Conventional Commits)

## Follow-up

- Close existing dependabot PRs #2, #3, #4 with a comment pointing to this PR
- Optional next PR: add an explicit deprecation notice to \`openclaw-channel-dmwork/README.md\` directing users to \`openclaw-channel-octo\` (npm) or \`clawhub:octo\` (ClawHub) for new installs