### PR TITLE
feat(octo): persona-clone adapter passthrough (onBehalfOf → on_behalf_of)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- openclaw-channel-octo: new optional account config `onBehalfOf`. When set, the adapter forwards `on_behalf_of` on every `/v1/bot/sendMessage` request so the bot can post as a real user under a Persona Clone (OBO) grant. Unset → identical behavior to before (field omitted from request body).
+
 ## [0.3.6] - 2026-03-14
 
 ### Changed

--- a/openclaw-channel-octo/README.md
+++ b/openclaw-channel-octo/README.md
@@ -106,6 +106,7 @@ Configuration fields per account:
 - `wsUrl` (optional): WuKongIM WebSocket URL. Auto-detected if omitted.
 - `requireMention` (optional): Only respond when @mentioned in groups
 - `historyLimit` (optional): Group chat history message limit (default: 20)
+- `onBehalfOf` (optional): Real user UID this bot sends on behalf of (Persona Clone / OBO). When set, every outbound message includes `on_behalf_of` and is delivered as that user. Requires an active server-side OBO grant; otherwise the server returns 403. Leave empty/unset for normal bot behavior.
 
 ## What it does
 

--- a/openclaw-channel-octo/README.md
+++ b/openclaw-channel-octo/README.md
@@ -106,7 +106,7 @@ Configuration fields per account:
 - `wsUrl` (optional): WuKongIM WebSocket URL. Auto-detected if omitted.
 - `requireMention` (optional): Only respond when @mentioned in groups
 - `historyLimit` (optional): Group chat history message limit (default: 20)
-- `onBehalfOf` (optional): Real user UID this bot sends on behalf of (Persona Clone / OBO). When set, every outbound message includes `on_behalf_of` and is delivered as that user. Requires an active server-side OBO grant; otherwise the server returns 403. Leave empty/unset for normal bot behavior.
+- `onBehalfOf` (optional): Real user UID this bot sends on behalf of (Persona Clone / OBO). When set, every outbound message includes `on_behalf_of` and is delivered as that user. Requires an active server-side OBO grant; otherwise the server returns 403. Omit the field entirely for normal bot behavior — empty string is rejected by config validation (`minLength: 1`).
 
 ## What it does
 

--- a/openclaw-channel-octo/openclaw.plugin.json
+++ b/openclaw-channel-octo/openclaw.plugin.json
@@ -30,7 +30,7 @@
           "botUid": { "type": "string" },
           "historyLimit": { "type": "number", "minimum": 1, "maximum": 100 },
           "historyPromptTemplate": { "type": "string" },
-          "onBehalfOf": { "type": "string", "minLength": 1 },
+          "onBehalfOf": { "type": "string", "minLength": 1, "pattern": "\\S" },
           "accounts": {
             "type": "object",
             "additionalProperties": {
@@ -49,7 +49,7 @@
                 "botUid": { "type": "string" },
                 "historyLimit": { "type": "number", "minimum": 1, "maximum": 100 },
                 "historyPromptTemplate": { "type": "string" },
-                "onBehalfOf": { "type": "string", "minLength": 1 }
+                "onBehalfOf": { "type": "string", "minLength": 1, "pattern": "\\S" }
               }
             }
           }

--- a/openclaw-channel-octo/openclaw.plugin.json
+++ b/openclaw-channel-octo/openclaw.plugin.json
@@ -30,6 +30,7 @@
           "botUid": { "type": "string" },
           "historyLimit": { "type": "number", "minimum": 1, "maximum": 100 },
           "historyPromptTemplate": { "type": "string" },
+          "onBehalfOf": { "type": "string" },
           "accounts": {
             "type": "object",
             "additionalProperties": {
@@ -47,7 +48,8 @@
                 "ignoreMentionAll": { "type": "boolean" },
                 "botUid": { "type": "string" },
                 "historyLimit": { "type": "number", "minimum": 1, "maximum": 100 },
-                "historyPromptTemplate": { "type": "string" }
+                "historyPromptTemplate": { "type": "string" },
+                "onBehalfOf": { "type": "string" }
               }
             }
           }

--- a/openclaw-channel-octo/openclaw.plugin.json
+++ b/openclaw-channel-octo/openclaw.plugin.json
@@ -30,7 +30,7 @@
           "botUid": { "type": "string" },
           "historyLimit": { "type": "number", "minimum": 1, "maximum": 100 },
           "historyPromptTemplate": { "type": "string" },
-          "onBehalfOf": { "type": "string" },
+          "onBehalfOf": { "type": "string", "minLength": 1 },
           "accounts": {
             "type": "object",
             "additionalProperties": {
@@ -49,7 +49,7 @@
                 "botUid": { "type": "string" },
                 "historyLimit": { "type": "number", "minimum": 1, "maximum": 100 },
                 "historyPromptTemplate": { "type": "string" },
-                "onBehalfOf": { "type": "string" }
+                "onBehalfOf": { "type": "string", "minLength": 1 }
               }
             }
           }

--- a/openclaw-channel-octo/src/accounts.ts
+++ b/openclaw-channel-octo/src/accounts.ts
@@ -23,6 +23,7 @@ export type ResolvedDmworkAccount = {
     ignoreMentionAll?: boolean;
     historyLimit?: number;  // 群聊历史消息条数限制
     historyPromptTemplate?: string;  // Template for group history context injection
+    onBehalfOf?: string;  // Persona Clone / OBO: real user UID to send on behalf of
   };
 };
 
@@ -90,6 +91,7 @@ export function resolveDmworkAccount(params: {
       ignoreMentionAll: accountConfig.ignoreMentionAll ?? channel.ignoreMentionAll,
       historyLimit: accountConfig.historyLimit ?? channel.historyLimit ?? 20,
       historyPromptTemplate: accountConfig.historyPromptTemplate ?? channel.historyPromptTemplate,
+      onBehalfOf: accountConfig.onBehalfOf ?? channel.onBehalfOf,
     },
   };
 }

--- a/openclaw-channel-octo/src/actions.test.ts
+++ b/openclaw-channel-octo/src/actions.test.ts
@@ -1973,3 +1973,92 @@ describe("extractInlineMentionUids", () => {
     expect(extractInlineMentionUids("group:grp1@uid1,,uid2,")).toEqual(["uid1", "uid2"]);
   });
 });
+
+// ─── handleDmworkMessageAction("send") — onBehalfOf passthrough ────────────
+// Regression for PR #35 review (lml2468 option 1): the structural change adds
+// `onBehalfOf?: string` to handleDmworkMessageAction params, threaded down to
+// handleSend → sendMessage and handleSend → uploadAndSendMedia. Pins that
+// the LLM `message(action=send)` tool path carries `on_behalf_of` in the
+// outbound HTTP body.
+
+describe("handleDmworkMessageAction send — onBehalfOf passthrough", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    _clearOwnerRegistry();
+    _clearMemberCache();
+    _resetGroupMd();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("forwards onBehalfOf to /v1/bot/sendMessage as on_behalf_of (text)", async () => {
+    let sentPayload: any = null;
+    globalThis.fetch = mockFetch({
+      "/v1/bot/sendMessage": async (_url, init) => {
+        sentPayload = JSON.parse(init?.body as string);
+        return jsonResponse({ message_id: 1, message_seq: 1 });
+      },
+    });
+
+    const { handleDmworkMessageAction } = await import("./actions.js");
+    const result = await handleDmworkMessageAction({
+      action: "send",
+      args: { target: "group:chan123", message: "hi" },
+      apiUrl: "http://localhost:8090",
+      botToken: "test-token",
+      onBehalfOf: "yu_uid",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(sentPayload).not.toBeNull();
+    expect(sentPayload.on_behalf_of).toBe("yu_uid");
+  });
+
+  it("omits on_behalf_of when onBehalfOf is unset (backward compat)", async () => {
+    let sentPayload: any = null;
+    globalThis.fetch = mockFetch({
+      "/v1/bot/sendMessage": async (_url, init) => {
+        sentPayload = JSON.parse(init?.body as string);
+        return jsonResponse({ message_id: 1, message_seq: 1 });
+      },
+    });
+
+    const { handleDmworkMessageAction } = await import("./actions.js");
+    const result = await handleDmworkMessageAction({
+      action: "send",
+      args: { target: "group:chan123", message: "hi" },
+      apiUrl: "http://localhost:8090",
+      botToken: "test-token",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(sentPayload).not.toBeNull();
+    expect(sentPayload).not.toHaveProperty("on_behalf_of");
+  });
+
+  it("forwards onBehalfOf to uploadAndSendMedia for media-only sends", async () => {
+    // uploadAndSendMedia is mocked at the top of this file; just verify it
+    // received onBehalfOf in its params.
+    const inbound = await import("./inbound.js");
+    (inbound.uploadAndSendMedia as any).mockClear();
+
+    const { handleDmworkMessageAction } = await import("./actions.js");
+    const result = await handleDmworkMessageAction({
+      action: "send",
+      args: {
+        target: "group:chan123",
+        mediaUrl: "https://cdn.example/x.png",
+      },
+      apiUrl: "http://localhost:8090",
+      botToken: "test-token",
+      onBehalfOf: "yu_uid",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(inbound.uploadAndSendMedia).toHaveBeenCalledTimes(1);
+    const call = (inbound.uploadAndSendMedia as any).mock.calls[0][0];
+    expect(call.onBehalfOf).toBe("yu_uid");
+  });
+});

--- a/openclaw-channel-octo/src/actions.ts
+++ b/openclaw-channel-octo/src/actions.ts
@@ -224,9 +224,10 @@ export async function handleDmworkMessageAction(params: {
   threadId?: string | number | null;
   requesterSenderId?: string;
   accountId?: string;
+  onBehalfOf?: string;
   log?: LogSink;
 }): Promise<MessageActionResult> {
-  const { action, args, apiUrl, botToken, memberMap, uidToNameMap, groupMdCache, currentChannelId, threadId, requesterSenderId, accountId, log } =
+  const { action, args, apiUrl, botToken, memberMap, uidToNameMap, groupMdCache, currentChannelId, threadId, requesterSenderId, accountId, onBehalfOf, log } =
     params;
 
   if (!botToken) {
@@ -235,7 +236,7 @@ export async function handleDmworkMessageAction(params: {
 
   switch (action) {
     case "send":
-      return handleSend({ args, apiUrl, botToken, memberMap, uidToNameMap, currentChannelId, threadId, log });
+      return handleSend({ args, apiUrl, botToken, memberMap, uidToNameMap, currentChannelId, threadId, onBehalfOf, log });
     case "read":
       return handleRead({ args, apiUrl, botToken, uidToNameMap, currentChannelId, requesterSenderId, accountId, log });
     case "search":
@@ -270,9 +271,10 @@ async function handleSend(params: {
   uidToNameMap?: Map<string, string>;
   currentChannelId?: string;
   threadId?: string | number | null;
+  onBehalfOf?: string;
   log?: LogSink;
 }): Promise<MessageActionResult> {
-  const { args, apiUrl, botToken, memberMap, uidToNameMap, currentChannelId, threadId, log } = params;
+  const { args, apiUrl, botToken, memberMap, uidToNameMap, currentChannelId, threadId, onBehalfOf, log } = params;
 
   const target = args.target as string | undefined;
   if (!target) {
@@ -390,6 +392,7 @@ async function handleSend(params: {
       ...(mentionUids.length > 0 ? { mentionUids } : {}),
       ...(mentionEntities.length > 0 ? { mentionEntities } : {}),
       mentionAll: hasAtAll || undefined,
+      ...(onBehalfOf ? { onBehalfOf } : {}),
     });
   }
 
@@ -401,6 +404,7 @@ async function handleSend(params: {
       botToken,
       channelId,
       channelType,
+      ...(onBehalfOf ? { onBehalfOf } : {}),
       log: log as any,
     });
   }

--- a/openclaw-channel-octo/src/api-fetch.test.ts
+++ b/openclaw-channel-octo/src/api-fetch.test.ts
@@ -1201,3 +1201,102 @@ describe("sendMessage — mentionAll serialization", () => {
     expect(sentBody.payload.mention).toBeUndefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// sendMessage / sendMediaMessage — onBehalfOf (Persona Clone / OBO) passthrough
+// ---------------------------------------------------------------------------
+describe("sendMessage — onBehalfOf passthrough", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("onBehalfOf 设置后请求体应包含 on_behalf_of", async () => {
+    let sentBody: any = null;
+    global.fetch = vi.fn().mockImplementation(async (_url: string, init?: RequestInit) => {
+      sentBody = JSON.parse(init?.body as string);
+      return new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    const { sendMessage } = await import("./api-fetch.js");
+    await sendMessage({
+      apiUrl: "http://localhost:8090",
+      botToken: "test-token",
+      channelId: "group1",
+      channelType: ChannelType.Group,
+      content: "代发的回复",
+      onBehalfOf: "yu_uid",
+    });
+
+    expect(sentBody.on_behalf_of).toBe("yu_uid");
+    // 兼容性: payload 内部结构不变
+    expect(sentBody.channel_id).toBe("group1");
+    expect(sentBody.payload.content).toBe("代发的回复");
+  });
+
+  it("onBehalfOf 未设置 / 空串时请求体不应包含该字段（向后兼容）", async () => {
+    let bodies: any[] = [];
+    global.fetch = vi.fn().mockImplementation(async (_url: string, init?: RequestInit) => {
+      bodies.push(JSON.parse(init?.body as string));
+      return new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    const { sendMessage } = await import("./api-fetch.js");
+    await sendMessage({
+      apiUrl: "http://localhost:8090",
+      botToken: "test-token",
+      channelId: "group1",
+      channelType: ChannelType.Group,
+      content: "normal",
+    });
+    await sendMessage({
+      apiUrl: "http://localhost:8090",
+      botToken: "test-token",
+      channelId: "group1",
+      channelType: ChannelType.Group,
+      content: "normal",
+      onBehalfOf: "",
+    });
+
+    expect(bodies).toHaveLength(2);
+    expect(bodies[0]).not.toHaveProperty("on_behalf_of");
+    expect(bodies[1]).not.toHaveProperty("on_behalf_of");
+  });
+
+  it("sendMediaMessage 也应透传 on_behalf_of", async () => {
+    let sentBody: any = null;
+    global.fetch = vi.fn().mockImplementation(async (_url: string, init?: RequestInit) => {
+      sentBody = JSON.parse(init?.body as string);
+      return new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    const { sendMediaMessage } = await import("./api-fetch.js");
+    await sendMediaMessage({
+      apiUrl: "http://localhost:8090",
+      botToken: "test-token",
+      channelId: "group1",
+      channelType: ChannelType.Group,
+      type: MessageType.Image,
+      url: "https://cdn.example.com/img.png",
+      width: 100,
+      height: 100,
+      onBehalfOf: "yu_uid",
+    });
+
+    expect(sentBody.on_behalf_of).toBe("yu_uid");
+  });
+});

--- a/openclaw-channel-octo/src/api-fetch.ts
+++ b/openclaw-channel-octo/src/api-fetch.ts
@@ -77,6 +77,7 @@ export async function sendMediaMessage(params: {
   height?: number;
   mentionUids?: string[];
   mentionEntities?: MentionEntity[];
+  onBehalfOf?: string;
   signal?: AbortSignal;
 }): Promise<SendMessageResult | undefined> {
   const payload: Record<string, unknown> = {
@@ -111,6 +112,7 @@ export async function sendMediaMessage(params: {
   return await postJson<SendMessageResult>(params.apiUrl, params.botToken, "/v1/bot/sendMessage", {
     channel_id: params.channelId,
     channel_type: params.channelType,
+    ...(params.onBehalfOf ? { on_behalf_of: params.onBehalfOf } : {}),
     payload,
   }, params.signal);
 }
@@ -215,6 +217,7 @@ export async function sendMessage(params: {
   mentionEntities?: MentionEntity[];
   mentionAll?: boolean;
   replyMsgId?: string;
+  onBehalfOf?: string;
   signal?: AbortSignal;
 }): Promise<SendMessageResult | undefined> {
   const payload: Record<string, unknown> = {
@@ -246,6 +249,7 @@ export async function sendMessage(params: {
   return await postJson<SendMessageResult>(params.apiUrl, params.botToken, "/v1/bot/sendMessage", {
     channel_id: params.channelId,
     channel_type: params.channelType,
+    ...(params.onBehalfOf ? { on_behalf_of: params.onBehalfOf } : {}),
     payload,
   }, params.signal);
 }

--- a/openclaw-channel-octo/src/channel.test.ts
+++ b/openclaw-channel-octo/src/channel.test.ts
@@ -713,3 +713,170 @@ describe("outbound sendText/sendMedia — accountId correction threads through t
     expect(call.botToken).toBe("tok-bot-b");
   });
 });
+
+// ─── outbound onBehalfOf passthrough (Persona Clone / OBO) ─────────────────
+// Regression for PR #35 review (Jerry-Xin / lml2468): the original wiring
+// only threaded `account.config.onBehalfOf` through the inbound reply paths.
+// Framework-driven outbound sends (skills, scheduled pushes) and the LLM
+// `message(action=send)` tool path were silently dropping it, breaking the
+// documented contract that every outbound message carries `on_behalf_of`.
+// These tests pin down that:
+//   1. outbound.sendText forwards account.config.onBehalfOf
+//   2. outbound.sendMedia (image + file) forwards it
+//   3. handleDmworkMessageAction("send") forwards it (text + media)
+//   4. Unset / empty onBehalfOf still produces a payload WITHOUT the field
+//      (backward compatibility — no `on_behalf_of: undefined` leaking)
+
+describe("outbound.sendText — onBehalfOf passthrough", () => {
+  const cfgWithObo = {
+    channels: {
+      octo: {
+        apiUrl: "https://api.example",
+        accounts: {
+          default: {
+            botToken: "bf_test",
+            apiUrl: "https://api.example",
+            onBehalfOf: "yu_uid",
+          },
+        },
+      },
+    },
+  };
+
+  const cfgWithoutObo = {
+    channels: {
+      octo: {
+        apiUrl: "https://api.example",
+        accounts: {
+          default: { botToken: "bf_test", apiUrl: "https://api.example" },
+        },
+      },
+    },
+  };
+
+  beforeEach(async () => {
+    const apiFetch = await import("./api-fetch.js");
+    (apiFetch.sendMessage as any).mockClear();
+  });
+
+  it("forwards account.config.onBehalfOf to sendMessage", async () => {
+    const { dmworkPlugin } = await import("./channel.js");
+    const { sendMessage } = await import("./api-fetch.js");
+
+    await dmworkPlugin.outbound!.sendText!({
+      cfg: cfgWithObo,
+      to: "group:grp_obo_test",
+      text: "scheduled push",
+      accountId: "default",
+    } as any);
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    const call = (sendMessage as any).mock.calls[0][0];
+    expect(call.onBehalfOf).toBe("yu_uid");
+  });
+
+  it("omits onBehalfOf when not configured (backward compat)", async () => {
+    const { dmworkPlugin } = await import("./channel.js");
+    const { sendMessage } = await import("./api-fetch.js");
+
+    await dmworkPlugin.outbound!.sendText!({
+      cfg: cfgWithoutObo,
+      to: "group:grp_obo_test",
+      text: "scheduled push",
+      accountId: "default",
+    } as any);
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    const call = (sendMessage as any).mock.calls[0][0];
+    expect(call).not.toHaveProperty("onBehalfOf");
+  });
+});
+
+describe("outbound.sendMedia — onBehalfOf passthrough", () => {
+  const cfgWithObo = {
+    channels: {
+      octo: {
+        apiUrl: "https://api.example",
+        accounts: {
+          default: {
+            botToken: "bf_test",
+            apiUrl: "https://api.example",
+            onBehalfOf: "yu_uid",
+          },
+        },
+      },
+    },
+  };
+
+  const cfgWithoutObo = {
+    channels: {
+      octo: {
+        apiUrl: "https://api.example",
+        accounts: {
+          default: { botToken: "bf_test", apiUrl: "https://api.example" },
+        },
+      },
+    },
+  };
+
+  beforeEach(async () => {
+    const apiFetch = await import("./api-fetch.js");
+    (apiFetch.sendMediaMessage as any).mockClear();
+    (apiFetch.getUploadCredentials as any).mockClear();
+    (apiFetch.uploadFileToCOS as any).mockClear();
+  });
+
+  it("forwards onBehalfOf for file/text media uploads", async () => {
+    const { dmworkPlugin } = await import("./channel.js");
+    const { sendMediaMessage } = await import("./api-fetch.js");
+
+    await dmworkPlugin.outbound!.sendMedia!({
+      cfg: cfgWithObo,
+      to: "group:grp_obo_test",
+      text: "",
+      mediaUrl: "data:text/plain;base64,aGVsbG8=",
+      accountId: "default",
+    } as any);
+
+    expect(sendMediaMessage).toHaveBeenCalledTimes(1);
+    const call = (sendMediaMessage as any).mock.calls[0][0];
+    expect(call.onBehalfOf).toBe("yu_uid");
+  });
+
+  it("forwards onBehalfOf for image media uploads", async () => {
+    const { dmworkPlugin } = await import("./channel.js");
+    const { sendMediaMessage } = await import("./api-fetch.js");
+
+    // 1x1 transparent PNG — exercises the image branch (msgType === Image)
+    const pngBase64 =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
+    await dmworkPlugin.outbound!.sendMedia!({
+      cfg: cfgWithObo,
+      to: "group:grp_obo_test",
+      text: "",
+      mediaUrl: `data:image/png;base64,${pngBase64}`,
+      accountId: "default",
+    } as any);
+
+    expect(sendMediaMessage).toHaveBeenCalledTimes(1);
+    const call = (sendMediaMessage as any).mock.calls[0][0];
+    expect(call.onBehalfOf).toBe("yu_uid");
+  });
+
+  it("omits onBehalfOf when not configured (backward compat)", async () => {
+    const { dmworkPlugin } = await import("./channel.js");
+    const { sendMediaMessage } = await import("./api-fetch.js");
+
+    await dmworkPlugin.outbound!.sendMedia!({
+      cfg: cfgWithoutObo,
+      to: "group:grp_obo_test",
+      text: "",
+      mediaUrl: "data:text/plain;base64,aGVsbG8=",
+      accountId: "default",
+    } as any);
+
+    expect(sendMediaMessage).toHaveBeenCalledTimes(1);
+    const call = (sendMediaMessage as any).mock.calls[0][0];
+    expect(call).not.toHaveProperty("onBehalfOf");
+  });
+});

--- a/openclaw-channel-octo/src/channel.ts
+++ b/openclaw-channel-octo/src/channel.ts
@@ -434,6 +434,7 @@ export const dmworkPlugin: ChannelPlugin<ResolvedDmworkAccount> = {
         threadId: ctx.toolContext?.threadId ?? ctx.params?.threadId ?? undefined,
         requesterSenderId: ctx.requesterSenderId ?? undefined,
         accountId,
+        onBehalfOf: account.config.onBehalfOf,
         log: ctx.log,
       });
     },
@@ -550,6 +551,7 @@ export const dmworkPlugin: ChannelPlugin<ResolvedDmworkAccount> = {
         ...(mentionUids.length > 0 ? { mentionUids } : {}),
         ...(mentionEntities.length > 0 ? { mentionEntities } : {}),
         mentionAll: hasAtAll || undefined,
+        ...(account.config.onBehalfOf ? { onBehalfOf: account.config.onBehalfOf } : {}),
       });
 
       return { channel: CHANNEL_ID, to: ctx.to, messageId: "" };
@@ -687,6 +689,7 @@ export const dmworkPlugin: ChannelPlugin<ResolvedDmworkAccount> = {
             height: dims?.height,
             name: filename,
             size: fileSize,
+            ...(account.config.onBehalfOf ? { onBehalfOf: account.config.onBehalfOf } : {}),
           });
         } else {
           await sendMediaMessage({
@@ -698,6 +701,7 @@ export const dmworkPlugin: ChannelPlugin<ResolvedDmworkAccount> = {
             url: cdnUrl,
             name: filename,
             size: fileSize,
+            ...(account.config.onBehalfOf ? { onBehalfOf: account.config.onBehalfOf } : {}),
           });
         }
       } finally {

--- a/openclaw-channel-octo/src/config-schema.ts
+++ b/openclaw-channel-octo/src/config-schema.ts
@@ -57,7 +57,7 @@ export const DmworkConfigJsonSchema = {
       botUid: { type: "string" },
       historyLimit: { type: "number", minimum: 1, maximum: 100 },
       historyPromptTemplate: { type: "string" },
-      onBehalfOf: { type: "string" },
+      onBehalfOf: { type: "string", minLength: 1 },
       accounts: {
         type: "object",
         additionalProperties: {
@@ -76,7 +76,7 @@ export const DmworkConfigJsonSchema = {
             botUid: { type: "string" },
             historyLimit: { type: "number", minimum: 1, maximum: 100 },
             historyPromptTemplate: { type: "string" },
-            onBehalfOf: { type: "string" },
+            onBehalfOf: { type: "string", minLength: 1 },
           },
         },
       },

--- a/openclaw-channel-octo/src/config-schema.ts
+++ b/openclaw-channel-octo/src/config-schema.ts
@@ -14,6 +14,7 @@ export interface DmworkAccountConfig {
   botUid?: string;
   historyLimit?: number;  // 群聊历史消息条数限制（默认20）
   historyPromptTemplate?: string;  // Template for group history context injection
+  onBehalfOf?: string;  // 该 bot 代理发送的真人 uid。设置后,所有 outbound 消息以该 uid 身份发出。
 }
 
 export interface DmworkConfig {
@@ -30,6 +31,7 @@ export interface DmworkConfig {
   botUid?: string;
   historyLimit?: number;  // 群聊历史消息条数限制（默认20）
   historyPromptTemplate?: string;  // Template for group history context injection
+  onBehalfOf?: string;  // 该 bot 代理发送的真人 uid。设置后,所有 outbound 消息以该 uid 身份发出。
   accounts?: Record<string, DmworkAccountConfig | undefined>;
 }
 
@@ -55,6 +57,7 @@ export const DmworkConfigJsonSchema = {
       botUid: { type: "string" },
       historyLimit: { type: "number", minimum: 1, maximum: 100 },
       historyPromptTemplate: { type: "string" },
+      onBehalfOf: { type: "string" },
       accounts: {
         type: "object",
         additionalProperties: {
@@ -73,6 +76,7 @@ export const DmworkConfigJsonSchema = {
             botUid: { type: "string" },
             historyLimit: { type: "number", minimum: 1, maximum: 100 },
             historyPromptTemplate: { type: "string" },
+            onBehalfOf: { type: "string" },
           },
         },
       },

--- a/openclaw-channel-octo/src/config-schema.ts
+++ b/openclaw-channel-octo/src/config-schema.ts
@@ -57,7 +57,11 @@ export const DmworkConfigJsonSchema = {
       botUid: { type: "string" },
       historyLimit: { type: "number", minimum: 1, maximum: 100 },
       historyPromptTemplate: { type: "string" },
-      onBehalfOf: { type: "string", minLength: 1 },
+      // `\\S` requires at least one non-whitespace char so a value like "   "
+      // (which `minLength: 1` would otherwise accept) is rejected. The OBO
+      // attribution path keys identity off this string, so a whitespace-only
+      // grantor would silently fail server-side OBO lookups.
+      onBehalfOf: { type: "string", minLength: 1, pattern: "\\S" },
       accounts: {
         type: "object",
         additionalProperties: {
@@ -76,7 +80,7 @@ export const DmworkConfigJsonSchema = {
             botUid: { type: "string" },
             historyLimit: { type: "number", minimum: 1, maximum: 100 },
             historyPromptTemplate: { type: "string" },
-            onBehalfOf: { type: "string", minLength: 1 },
+            onBehalfOf: { type: "string", minLength: 1, pattern: "\\S" },
           },
         },
       },

--- a/openclaw-channel-octo/src/inbound.test.ts
+++ b/openclaw-channel-octo/src/inbound.test.ts
@@ -18,6 +18,7 @@ import {
   resolveReplyChannelId,
   resolveSessionId,
   isOBOFanoutMessage,
+  resolveEffectiveSender,
   pendingInboundContext,
   segmentHistoryEntries,
   type ResolveFileResult,
@@ -84,12 +85,14 @@ describe("mention.all detection", () => {
  *
  * Trigger rule (mirrors inbound.ts):
  *   isMentioned =
- *       (aisFlag && !ignoreMentionAll)
+ *       ((aisFlag || legacyAll) && !ignoreMentionAll)
  *     || mentionUids.includes(botUid)
  *
- * Where `aisFlag = mention.ais === true || === 1`. `humans` and legacy
- * `all` do NOT wake the bot — `all` is server outbound double-write of
- * humans-only broadcast for legacy clients.
+ * Where `aisFlag = mention.ais === true || === 1` and `legacyAll` is the
+ * pre-three-state broadcast that means "everyone including bots". Legacy
+ * `all` MUST keep waking bots — old servers/clients still emit only `all`,
+ * and dropping that would silently regress bot triggering (Jerry-Xin
+ * review feedback). `humans=1` alone never wakes a bot.
  */
 describe("mention three-state trigger (PR-B)", () => {
   // Helper that mirrors the inbound.ts decision block verbatim.
@@ -103,9 +106,9 @@ describe("mention three-state trigger (PR-B)", () => {
     const hasHumans = m.humans === true || m.humans === 1;
     const hasAis = m.ais === true || m.ais === 1;
     const hasAll = m.all === true || m.all === 1;
-    void (hasHumans || hasAll); // humansFlag — does not gate bot
-    const aisFlag = hasAis;
-    return (aisFlag && !ignoreMentionAll) || mentionUids.includes(botUid);
+    void hasHumans; // humansFlag — does not gate bot
+    const broadcastWakesBot = hasAis || hasAll;
+    return (broadcastWakesBot && !ignoreMentionAll) || mentionUids.includes(botUid);
   }
 
   const BOT_UID = "bot_uid";
@@ -125,9 +128,14 @@ describe("mention three-state trigger (PR-B)", () => {
     expect(computeIsMentioned(mention, BOT_UID, false)).toBe(true);
   });
 
-  it("legacy all=1 (server double-write) → bot NOT triggered (hasAll → humans, NOT ais)", () => {
+  it("legacy all=1 only → bot triggered (backward compat with pre-three-state clients)", () => {
     const mention: MentionPayload = { all: 1 };
-    expect(computeIsMentioned(mention, BOT_UID, false)).toBe(false);
+    expect(computeIsMentioned(mention, BOT_UID, false)).toBe(true);
+  });
+
+  it("legacy all=1 + humans=1 → bot triggered (legacy `all` wakes bot regardless of humans)", () => {
+    const mention: MentionPayload = { all: 1, humans: 1 };
+    expect(computeIsMentioned(mention, BOT_UID, false)).toBe(true);
   });
 
   it("explicit uid mention → bot triggered (unchanged regression coverage)", () => {
@@ -140,7 +148,7 @@ describe("mention three-state trigger (PR-B)", () => {
     expect(computeIsMentioned(mention, BOT_UID, true)).toBe(false);
   });
 
-  it("legacy all=1 with ignoreMentionAll=true → bot NOT triggered (regression coverage)", () => {
+  it("legacy all=1 with ignoreMentionAll=true → bot NOT triggered (opt-out covers both broadcasts)", () => {
     const mention: MentionPayload = { all: 1 };
     expect(computeIsMentioned(mention, BOT_UID, true)).toBe(false);
   });
@@ -150,8 +158,18 @@ describe("mention three-state trigger (PR-B)", () => {
     expect(computeIsMentioned(mention, BOT_UID, false)).toBe(true);
   });
 
+  it("all=true (boolean form) → bot triggered (parity with numeric 1)", () => {
+    const mention: MentionPayload = { all: true };
+    expect(computeIsMentioned(mention, BOT_UID, false)).toBe(true);
+  });
+
   it("ais=1 + explicit uid mention → bot triggered (ignoreMentionAll does NOT silence explicit @)", () => {
     const mention: MentionPayload = { ais: 1, uids: [BOT_UID] };
+    expect(computeIsMentioned(mention, BOT_UID, true)).toBe(true);
+  });
+
+  it("legacy all=1 + explicit uid mention → bot triggered (ignoreMentionAll does NOT silence explicit @)", () => {
+    const mention: MentionPayload = { all: 1, uids: [BOT_UID] };
     expect(computeIsMentioned(mention, BOT_UID, true)).toBe(true);
   });
 
@@ -2307,5 +2325,151 @@ describe("resolveSessionId — OBO fan-out session isolation (PR-B)", () => {
     ).toBe(
       resolveSessionId({ isGroup: false, effectiveDmPeer: peerSpoofB }),
     );
+  });
+});
+
+/**
+ * Tests for resolveEffectiveSender — OBO sender attribution (Jerry-Xin
+ * review fix).
+ *
+ * Identity-bearing fields (`From`, `SenderId`, `SenderUsername`, `isOwner`
+ * checks, audit logs, etc.) must reflect the real conversation peer, not
+ * the OBO grantor stamped on `from_uid` by the server's fan-out copy.
+ *
+ * Scope:
+ * - DM with `obo_origin_from_uid` and `hasOnBehalfOfConfig=true` → real
+ *   peer attribution; grantor preserved separately.
+ * - DM without OBO marker → falls back to `from_uid` (backward compat).
+ * - Group messages → always use `from_uid` (groups don't fan out OBO).
+ * - Non-OBO accounts → ignore the marker (spoof defense).
+ */
+describe("resolveEffectiveSender — OBO sender attribution (Jerry-Xin fix)", () => {
+  it("DM with obo_origin_from_uid attributes to the real peer; grantor preserved", () => {
+    const result = resolveEffectiveSender({
+      isGroup: false,
+      fromUid: "u_admin",
+      payload: {
+        type: 1,
+        content: "hi",
+        obo_origin_from_uid: "u_bob",
+      },
+      hasOnBehalfOfConfig: true,
+    });
+    expect(result.senderUid).toBe("u_bob");
+    expect(result.grantorUid).toBe("u_admin");
+  });
+
+  it("DM without obo_origin_from_uid falls back to from_uid (backward compat)", () => {
+    const result = resolveEffectiveSender({
+      isGroup: false,
+      fromUid: "u_alice",
+      payload: { type: 1, content: "hi" },
+      hasOnBehalfOfConfig: true,
+    });
+    expect(result.senderUid).toBe("u_alice");
+    expect(result.grantorUid).toBeUndefined();
+  });
+
+  it("DM with empty obo_origin_from_uid falls back to from_uid", () => {
+    const result = resolveEffectiveSender({
+      isGroup: false,
+      fromUid: "u_alice",
+      payload: {
+        type: 1,
+        content: "hi",
+        obo_origin_from_uid: "",
+      },
+      hasOnBehalfOfConfig: true,
+    });
+    expect(result.senderUid).toBe("u_alice");
+    expect(result.grantorUid).toBeUndefined();
+  });
+
+  it("DM with non-string obo_origin_from_uid falls back to from_uid", () => {
+    const result = resolveEffectiveSender({
+      isGroup: false,
+      fromUid: "u_alice",
+      payload: {
+        type: 1,
+        content: "hi",
+        obo_origin_from_uid: 12345 as unknown as string,
+      },
+      hasOnBehalfOfConfig: true,
+    });
+    expect(result.senderUid).toBe("u_alice");
+    expect(result.grantorUid).toBeUndefined();
+  });
+
+  it("group messages always use from_uid (OBO marker ignored even if present)", () => {
+    // Defensive: if some upstream accidentally stamped obo_origin_from_uid
+    // on a group message, we must not redirect attribution — the real
+    // speaker in a group is already `from_uid`.
+    const result = resolveEffectiveSender({
+      isGroup: true,
+      fromUid: "u_carol",
+      payload: {
+        type: 1,
+        content: "hi",
+        obo_origin_from_uid: "u_bob",
+      },
+      hasOnBehalfOfConfig: true,
+    });
+    expect(result.senderUid).toBe("u_carol");
+    expect(result.grantorUid).toBeUndefined();
+  });
+
+  it("non-OBO account (hasOnBehalfOfConfig=false) ignores marker — spoof defense", () => {
+    // A spoofed `obo_origin_from_uid` on an account that is NOT OBO-configured
+    // must not be honored; otherwise an arbitrary sender could redirect
+    // attribution to anyone (and inherit their roles).
+    const result = resolveEffectiveSender({
+      isGroup: false,
+      fromUid: "u_attacker",
+      payload: {
+        type: 1,
+        content: "hi",
+        obo_origin_from_uid: "u_owner",
+      },
+      hasOnBehalfOfConfig: false,
+    });
+    expect(result.senderUid).toBe("u_attacker");
+    expect(result.grantorUid).toBeUndefined();
+  });
+
+  it("default hasOnBehalfOfConfig (omitted) preserves OBO behavior", () => {
+    const result = resolveEffectiveSender({
+      isGroup: false,
+      fromUid: "u_admin",
+      payload: {
+        type: 1,
+        content: "hi",
+        obo_origin_from_uid: "u_bob",
+      },
+    });
+    expect(result.senderUid).toBe("u_bob");
+    expect(result.grantorUid).toBe("u_admin");
+  });
+
+  it("OBO origin and reply target are derived from the same source (lockstep)", () => {
+    // Regression guard: effective sender uid and reply channel id must agree
+    // on the OBO origin so attribution and reply routing don't drift.
+    const payload = {
+      type: 1,
+      content: "hi",
+      obo_origin_from_uid: "u_bob",
+    };
+    const sender = resolveEffectiveSender({
+      isGroup: false,
+      fromUid: "u_admin",
+      payload,
+      hasOnBehalfOfConfig: true,
+    });
+    const replyTarget = resolveReplyChannelId({
+      isGroup: false,
+      fromUid: "u_admin",
+      payload,
+      hasOnBehalfOfConfig: true,
+    });
+    expect(sender.senderUid).toBe(replyTarget);
   });
 });

--- a/openclaw-channel-octo/src/inbound.test.ts
+++ b/openclaw-channel-octo/src/inbound.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { ChannelType, MessageType, type MentionPayload } from "./types.js";
+import { ChannelType, MessageType, type MentionPayload, type BotMessage } from "./types.js";
 import { DEFAULT_HISTORY_PROMPT_TEMPLATE } from "./config-schema.js";
 import {
   resolveInnerMessageText,
@@ -85,14 +85,17 @@ describe("mention.all detection", () => {
  *
  * Trigger rule (mirrors inbound.ts):
  *   isMentioned =
- *       ((aisFlag || legacyAll) && !ignoreMentionAll)
+ *       (aisFlag && !ignoreMentionAll)
  *     || mentionUids.includes(botUid)
  *
- * Where `aisFlag = mention.ais === true || === 1` and `legacyAll` is the
- * pre-three-state broadcast that means "everyone including bots". Legacy
- * `all` MUST keep waking bots — old servers/clients still emit only `all`,
- * and dropping that would silently regress bot triggering (Jerry-Xin
- * review feedback). `humans=1` alone never wakes a bot.
+ * Where `aisFlag = mention.ais === true || === 1`.
+ *
+ * `humans=1` and legacy `all=1` are BOTH humans-only signals per the
+ * server-authoritative contract (server `all=humans`, see
+ * `MentionPayload.all` in types.ts and the Jerry-Xin R2 review). Neither
+ * wakes a bot on its own — only `ais=1` (the explicit AI broadcast) does.
+ * An explicit uid mention always wakes the bot regardless of the broadcast
+ * flags.
  */
 describe("mention three-state trigger (PR-B)", () => {
   // Helper that mirrors the inbound.ts decision block verbatim.
@@ -107,7 +110,8 @@ describe("mention three-state trigger (PR-B)", () => {
     const hasAis = m.ais === true || m.ais === 1;
     const hasAll = m.all === true || m.all === 1;
     void hasHumans; // humansFlag — does not gate bot
-    const broadcastWakesBot = hasAis || hasAll;
+    void hasAll; // legacyAllFlag — does not gate bot (humans-only signal)
+    const broadcastWakesBot = hasAis;
     return (broadcastWakesBot && !ignoreMentionAll) || mentionUids.includes(botUid);
   }
 
@@ -128,13 +132,22 @@ describe("mention three-state trigger (PR-B)", () => {
     expect(computeIsMentioned(mention, BOT_UID, false)).toBe(true);
   });
 
-  it("legacy all=1 only → bot triggered (backward compat with pre-three-state clients)", () => {
+  it("legacy all=1 only → bot NOT triggered (server `all=humans`, humans-only signal)", () => {
+    // Server double-writes legacy `all=1` for `@所有人` (humans only). It must
+    // NOT wake the bot on its own; doing so contradicts the type contract on
+    // `MentionPayload.all` and would summon AIs to a humans-only broadcast
+    // (Jerry-Xin R2 blocker — fixed by aligning impl with the contract).
     const mention: MentionPayload = { all: 1 };
-    expect(computeIsMentioned(mention, BOT_UID, false)).toBe(true);
+    expect(computeIsMentioned(mention, BOT_UID, false)).toBe(false);
   });
 
-  it("legacy all=1 + humans=1 → bot triggered (legacy `all` wakes bot regardless of humans)", () => {
+  it("legacy all=1 + humans=1 → bot NOT triggered (both humans-only signals)", () => {
     const mention: MentionPayload = { all: 1, humans: 1 };
+    expect(computeIsMentioned(mention, BOT_UID, false)).toBe(false);
+  });
+
+  it("legacy all=1 + ais=1 → bot triggered (ais wakes the bot, all is irrelevant)", () => {
+    const mention: MentionPayload = { all: 1, ais: 1 };
     expect(computeIsMentioned(mention, BOT_UID, false)).toBe(true);
   });
 
@@ -148,7 +161,7 @@ describe("mention three-state trigger (PR-B)", () => {
     expect(computeIsMentioned(mention, BOT_UID, true)).toBe(false);
   });
 
-  it("legacy all=1 with ignoreMentionAll=true → bot NOT triggered (opt-out covers both broadcasts)", () => {
+  it("legacy all=1 with ignoreMentionAll=true → bot NOT triggered (humans-only signal anyway)", () => {
     const mention: MentionPayload = { all: 1 };
     expect(computeIsMentioned(mention, BOT_UID, true)).toBe(false);
   });
@@ -158,9 +171,9 @@ describe("mention three-state trigger (PR-B)", () => {
     expect(computeIsMentioned(mention, BOT_UID, false)).toBe(true);
   });
 
-  it("all=true (boolean form) → bot triggered (parity with numeric 1)", () => {
+  it("all=true (boolean form) → bot NOT triggered (humans-only signal in either form)", () => {
     const mention: MentionPayload = { all: true };
-    expect(computeIsMentioned(mention, BOT_UID, false)).toBe(true);
+    expect(computeIsMentioned(mention, BOT_UID, false)).toBe(false);
   });
 
   it("ais=1 + explicit uid mention → bot triggered (ignoreMentionAll does NOT silence explicit @)", () => {
@@ -168,7 +181,7 @@ describe("mention three-state trigger (PR-B)", () => {
     expect(computeIsMentioned(mention, BOT_UID, true)).toBe(true);
   });
 
-  it("legacy all=1 + explicit uid mention → bot triggered (ignoreMentionAll does NOT silence explicit @)", () => {
+  it("legacy all=1 + explicit uid mention → bot triggered via explicit uid (not via all)", () => {
     const mention: MentionPayload = { all: 1, uids: [BOT_UID] };
     expect(computeIsMentioned(mention, BOT_UID, true)).toBe(true);
   });
@@ -2471,5 +2484,291 @@ describe("resolveEffectiveSender — OBO sender attribution (Jerry-Xin fix)", ()
       hasOnBehalfOfConfig: true,
     });
     expect(sender.senderUid).toBe(replyTarget);
+  });
+});
+
+/**
+ * OBO marker trust gate (Jerry-Xin R2 P0 blocker #1).
+ *
+ * Background: previously the call-site computed `hasOnBehalfOfConfig =
+ * Boolean(account.config.onBehalfOf)` — i.e. it only checked whether the
+ * receiving account is OBO-enabled. That alone is NOT sufficient: any
+ * inbound message on an OBO-enabled account could stuff a spoofed
+ * `obo_origin_from_uid` into its payload and redirect both the reply
+ * target and the OpenClaw session/peer identity.
+ *
+ * Fix: the OBO marker is now only trusted when the inbound message is
+ * actually a fan-out copy from the configured grantor. Concretely, trust
+ * requires:
+ *   - `account.config.onBehalfOf` is set (account is OBO-enabled), AND
+ *   - `message.from_uid === account.config.onBehalfOf` (server-side, fan-out
+ *     copies always stamp `from_uid` to the grantor), AND
+ *   - `payload.obo_grantor_uid` (when present) also matches the configured
+ *     grantor.
+ *
+ * The helpers `resolveReplyChannelId`, `isOBOFanoutMessage`, and
+ * `resolveEffectiveSender` still take a `hasOnBehalfOfConfig` flag — the
+ * semantics is now "the OBO marker is trusted for THIS message", computed
+ * at the call site. These tests verify the trust decision the call site
+ * computes for representative inbound shapes.
+ */
+describe("OBO marker trust gate (Jerry-Xin R2)", () => {
+  // Mirror of the trust check in inbound.ts ~ handleInboundMessage.
+  function computeOboMarkerTrusted(params: {
+    configuredGrantor: string | undefined;
+    fromUid: string;
+    payload?: BotMessage["payload"];
+  }): boolean {
+    const oboGrantorUidRaw = (params.payload as { obo_grantor_uid?: unknown } | undefined)
+      ?.obo_grantor_uid;
+    const oboGrantorUid =
+      typeof oboGrantorUidRaw === "string" && oboGrantorUidRaw.length > 0
+        ? oboGrantorUidRaw
+        : undefined;
+    return Boolean(
+      params.configuredGrantor &&
+        params.fromUid === params.configuredGrantor &&
+        (oboGrantorUid === undefined || oboGrantorUid === params.configuredGrantor),
+    );
+  }
+
+  const ADMIN = "u_admin";
+  const SPOOFER = "u_evil";
+  const VICTIM = "u_victim";
+
+  // ─── trust check unit tests ──────────────────────────────────────────────
+
+  it("trust=false when account is NOT OBO-configured", () => {
+    expect(
+      computeOboMarkerTrusted({
+        configuredGrantor: undefined,
+        fromUid: ADMIN,
+        payload: {
+          type: MessageType.Text,
+          content: "hi",
+          obo_origin_from_uid: VICTIM,
+          obo_grantor_uid: ADMIN,
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("trust=true when from_uid matches configured grantor and obo_grantor_uid also matches", () => {
+    expect(
+      computeOboMarkerTrusted({
+        configuredGrantor: ADMIN,
+        fromUid: ADMIN,
+        payload: {
+          type: MessageType.Text,
+          content: "hi",
+          obo_origin_from_uid: VICTIM,
+          obo_grantor_uid: ADMIN,
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("trust=true when from_uid matches and obo_grantor_uid is absent", () => {
+    expect(
+      computeOboMarkerTrusted({
+        configuredGrantor: ADMIN,
+        fromUid: ADMIN,
+        payload: {
+          type: MessageType.Text,
+          content: "hi",
+          obo_origin_from_uid: VICTIM,
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("trust=false when from_uid is NOT the configured grantor (spoof attempt)", () => {
+    expect(
+      computeOboMarkerTrusted({
+        configuredGrantor: ADMIN,
+        fromUid: SPOOFER,
+        payload: {
+          type: MessageType.Text,
+          content: "redirect me",
+          obo_origin_from_uid: VICTIM, // attacker tries to redirect to victim
+          obo_grantor_uid: ADMIN, // attacker may stamp anything here
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("trust=false when from_uid matches but obo_grantor_uid contradicts configured grantor", () => {
+    expect(
+      computeOboMarkerTrusted({
+        configuredGrantor: ADMIN,
+        fromUid: ADMIN,
+        payload: {
+          type: MessageType.Text,
+          content: "hi",
+          obo_origin_from_uid: VICTIM,
+          obo_grantor_uid: SPOOFER, // mismatch — refuse to trust
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("trust=false when payload is undefined and from_uid mismatch", () => {
+    expect(
+      computeOboMarkerTrusted({
+        configuredGrantor: ADMIN,
+        fromUid: SPOOFER,
+        payload: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  // ─── end-to-end: spoof attempts on OBO-enabled accounts ──────────────────
+
+  it("resolveReplyChannelId: spoof from non-grantor on OBO account → reply falls back to from_uid", () => {
+    const trusted = computeOboMarkerTrusted({
+      configuredGrantor: ADMIN,
+      fromUid: SPOOFER,
+      payload: {
+        type: MessageType.Text,
+        content: "redirect me",
+        obo_origin_from_uid: VICTIM,
+        obo_grantor_uid: ADMIN,
+      },
+    });
+    const reply = resolveReplyChannelId({
+      isGroup: false,
+      channelId: SPOOFER,
+      fromUid: SPOOFER,
+      payload: {
+        type: MessageType.Text,
+        content: "redirect me",
+        obo_origin_from_uid: VICTIM,
+        obo_grantor_uid: ADMIN,
+      },
+      hasOnBehalfOfConfig: trusted,
+    });
+    // Spoofed OBO marker MUST be ignored — reply target stays with the
+    // actual sender (the spoofer), NOT the victim.
+    expect(reply).toBe(SPOOFER);
+  });
+
+  it("isOBOFanoutMessage: spoof from non-grantor on OBO account → not a fan-out copy", () => {
+    const trusted = computeOboMarkerTrusted({
+      configuredGrantor: ADMIN,
+      fromUid: SPOOFER,
+      payload: {
+        type: MessageType.Text,
+        content: "x",
+        obo_origin_from_uid: VICTIM,
+        obo_grantor_uid: ADMIN,
+      },
+    });
+    expect(
+      isOBOFanoutMessage(
+        {
+          type: MessageType.Text,
+          content: "x",
+          obo_origin_from_uid: VICTIM,
+          obo_grantor_uid: ADMIN,
+        },
+        { hasOnBehalfOfConfig: trusted },
+      ),
+    ).toBe(false);
+  });
+
+  it("resolveEffectiveSender: spoof from non-grantor on OBO account → sender stays as from_uid", () => {
+    const trusted = computeOboMarkerTrusted({
+      configuredGrantor: ADMIN,
+      fromUid: SPOOFER,
+      payload: {
+        type: MessageType.Text,
+        content: "x",
+        obo_origin_from_uid: VICTIM,
+        obo_grantor_uid: ADMIN,
+      },
+    });
+    const sender = resolveEffectiveSender({
+      isGroup: false,
+      fromUid: SPOOFER,
+      payload: {
+        type: MessageType.Text,
+        content: "x",
+        obo_origin_from_uid: VICTIM,
+        obo_grantor_uid: ADMIN,
+      },
+      hasOnBehalfOfConfig: trusted,
+    });
+    // Spoofed marker MUST NOT redirect sender attribution — downstream
+    // permission checks must see the real sender (the spoofer), not the
+    // victim's uid.
+    expect(sender.senderUid).toBe(SPOOFER);
+    expect(sender.grantorUid).toBeUndefined();
+  });
+
+  it("legitimate fan-out copy (from configured grantor) → OBO marker honored", () => {
+    const trusted = computeOboMarkerTrusted({
+      configuredGrantor: ADMIN,
+      fromUid: ADMIN, // server stamps fan-out copies with the grantor
+      payload: {
+        type: MessageType.Text,
+        content: "hi",
+        obo_origin_from_uid: VICTIM,
+        obo_grantor_uid: ADMIN,
+      },
+    });
+    expect(trusted).toBe(true);
+    const reply = resolveReplyChannelId({
+      isGroup: false,
+      channelId: ADMIN,
+      fromUid: ADMIN,
+      payload: {
+        type: MessageType.Text,
+        content: "hi",
+        obo_origin_from_uid: VICTIM,
+        obo_grantor_uid: ADMIN,
+      },
+      hasOnBehalfOfConfig: trusted,
+    });
+    expect(reply).toBe(VICTIM);
+
+    const sender = resolveEffectiveSender({
+      isGroup: false,
+      fromUid: ADMIN,
+      payload: {
+        type: MessageType.Text,
+        content: "hi",
+        obo_origin_from_uid: VICTIM,
+        obo_grantor_uid: ADMIN,
+      },
+      hasOnBehalfOfConfig: trusted,
+    });
+    expect(sender.senderUid).toBe(VICTIM);
+    expect(sender.grantorUid).toBe(ADMIN);
+  });
+
+  it("non-OBO account ignores OBO marker regardless of from_uid (existing defense, regression guard)", () => {
+    const trusted = computeOboMarkerTrusted({
+      configuredGrantor: undefined,
+      fromUid: ADMIN,
+      payload: {
+        type: MessageType.Text,
+        content: "x",
+        obo_origin_from_uid: VICTIM,
+        obo_grantor_uid: ADMIN,
+      },
+    });
+    expect(trusted).toBe(false);
+    const reply = resolveReplyChannelId({
+      isGroup: false,
+      channelId: ADMIN,
+      fromUid: ADMIN,
+      payload: {
+        type: MessageType.Text,
+        content: "x",
+        obo_origin_from_uid: VICTIM,
+      },
+      hasOnBehalfOfConfig: trusted,
+    });
+    expect(reply).toBe(ADMIN);
   });
 });

--- a/openclaw-channel-octo/src/inbound.test.ts
+++ b/openclaw-channel-octo/src/inbound.test.ts
@@ -77,6 +77,90 @@ describe("mention.all detection", () => {
 });
 
 /**
+ * Tests for the three-state mention trigger logic (PR-B / octo-server #94).
+ *
+ * Server is the authoritative decider for `humans` / `ais` semantics. Adapter
+ * only reads the flags and decides whether THIS bot instance wakes up.
+ *
+ * Trigger rule (mirrors inbound.ts):
+ *   isMentioned =
+ *       (aisFlag && !ignoreMentionAll)
+ *     || mentionUids.includes(botUid)
+ *
+ * Where `aisFlag = mention.ais === true || === 1`. `humans` and legacy
+ * `all` do NOT wake the bot — `all` is server outbound double-write of
+ * humans-only broadcast for legacy clients.
+ */
+describe("mention three-state trigger (PR-B)", () => {
+  // Helper that mirrors the inbound.ts decision block verbatim.
+  function computeIsMentioned(
+    mention: MentionPayload | undefined,
+    botUid: string,
+    ignoreMentionAll: boolean,
+  ): boolean {
+    const mentionUids = extractMentionUids(mention);
+    const m = mention ?? {};
+    const hasHumans = m.humans === true || m.humans === 1;
+    const hasAis = m.ais === true || m.ais === 1;
+    const hasAll = m.all === true || m.all === 1;
+    void (hasHumans || hasAll); // humansFlag — does not gate bot
+    const aisFlag = hasAis;
+    return (aisFlag && !ignoreMentionAll) || mentionUids.includes(botUid);
+  }
+
+  const BOT_UID = "bot_uid";
+
+  it("humans=1 only → bot NOT triggered (humansFlag does not gate bot)", () => {
+    const mention: MentionPayload = { humans: 1 };
+    expect(computeIsMentioned(mention, BOT_UID, false)).toBe(false);
+  });
+
+  it("ais=1 only → bot triggered", () => {
+    const mention: MentionPayload = { ais: 1 };
+    expect(computeIsMentioned(mention, BOT_UID, false)).toBe(true);
+  });
+
+  it("humans=1 AND ais=1 → bot triggered (ais wakes the bot)", () => {
+    const mention: MentionPayload = { humans: 1, ais: 1 };
+    expect(computeIsMentioned(mention, BOT_UID, false)).toBe(true);
+  });
+
+  it("legacy all=1 (server double-write) → bot NOT triggered (hasAll → humans, NOT ais)", () => {
+    const mention: MentionPayload = { all: 1 };
+    expect(computeIsMentioned(mention, BOT_UID, false)).toBe(false);
+  });
+
+  it("explicit uid mention → bot triggered (unchanged regression coverage)", () => {
+    const mention: MentionPayload = { uids: [BOT_UID] };
+    expect(computeIsMentioned(mention, BOT_UID, false)).toBe(true);
+  });
+
+  it("ais=1 with ignoreMentionAll=true → bot NOT triggered (opt-out reuses single knob)", () => {
+    const mention: MentionPayload = { ais: 1 };
+    expect(computeIsMentioned(mention, BOT_UID, true)).toBe(false);
+  });
+
+  it("legacy all=1 with ignoreMentionAll=true → bot NOT triggered (regression coverage)", () => {
+    const mention: MentionPayload = { all: 1 };
+    expect(computeIsMentioned(mention, BOT_UID, true)).toBe(false);
+  });
+
+  it("ais=true (boolean form) → bot triggered (parity with numeric 1)", () => {
+    const mention: MentionPayload = { ais: true };
+    expect(computeIsMentioned(mention, BOT_UID, false)).toBe(true);
+  });
+
+  it("ais=1 + explicit uid mention → bot triggered (ignoreMentionAll does NOT silence explicit @)", () => {
+    const mention: MentionPayload = { ais: 1, uids: [BOT_UID] };
+    expect(computeIsMentioned(mention, BOT_UID, true)).toBe(true);
+  });
+
+  it("empty mention → bot NOT triggered", () => {
+    expect(computeIsMentioned(undefined, BOT_UID, false)).toBe(false);
+  });
+});
+
+/**
  * Tests for historyPromptTemplate configuration.
  *
  * The template supports placeholders:

--- a/openclaw-channel-octo/src/inbound.test.ts
+++ b/openclaw-channel-octo/src/inbound.test.ts
@@ -16,6 +16,7 @@ import {
   resolveCommandBody,
   resolveCommandAuthorized,
   resolveReplyChannelId,
+  isOBOFanoutMessage,
   pendingInboundContext,
   segmentHistoryEntries,
   type ResolveFileResult,
@@ -1943,5 +1944,99 @@ describe("resolveReplyChannelId", () => {
       payload: { type: MessageType.Text, content: "hello" },
     });
     expect(result).toBe("g_team_chat");
+  });
+});
+
+/**
+ * Tests for OBO fan-out detection (PR-B).
+ *
+ * In an OBO fan-out copy, the server stashes the original sender's uid in
+ * `payload.obo_origin_from_uid`. The bot is, by design, NOT friends with that
+ * sender, so the server's friend gate rejects cosmetic side-channel signals
+ * (readReceipt / typing) — and those endpoints don't support the
+ * `on_behalf_of` bypass. Callers use `isOBOFanoutMessage` to skip those
+ * signals while still letting `sendMessage` (which does pass on_behalf_of)
+ * proceed normally.
+ */
+describe("isOBOFanoutMessage", () => {
+  it("returns true for an OBO fan-out copy (obo_origin_from_uid present)", () => {
+    expect(
+      isOBOFanoutMessage({
+        type: MessageType.Text,
+        content: "hello",
+        obo_origin_from_uid: "u_bob",
+        obo_origin_channel_id: "admin",
+        obo_grantor_uid: "admin",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for a normal DM (no OBO marker)", () => {
+    expect(
+      isOBOFanoutMessage({ type: MessageType.Text, content: "hello" }),
+    ).toBe(false);
+  });
+
+  it("returns false when obo_origin_from_uid is an empty string", () => {
+    expect(
+      isOBOFanoutMessage({
+        type: MessageType.Text,
+        content: "hello",
+        obo_origin_from_uid: "",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when obo_origin_from_uid is not a string", () => {
+    expect(
+      isOBOFanoutMessage({
+        type: MessageType.Text,
+        content: "hello",
+        // Defensive: server should always send a string, but guard anyway
+        obo_origin_from_uid: 12345 as unknown as string,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for undefined payload", () => {
+    expect(isOBOFanoutMessage(undefined)).toBe(false);
+  });
+});
+
+/**
+ * Behavioral guarantee for the readReceipt/typing skip in handleInboundMessage
+ * (see src/inbound.ts: `if (!isOBOFanout) { sendReadReceipt + sendTyping }`).
+ *
+ * The skip gate is `isOBOFanoutMessage(message.payload)`. These tests assert
+ * the gate produces the correct skip/no-skip decision for the exact message
+ * shapes the OBO fan-out and normal-DM paths produce, so a regression on the
+ * gate would be caught here without needing to spin up the full runtime.
+ */
+describe("readReceipt/typing skip gate (PR-B behavioral)", () => {
+  it("OBO fan-out copy → gate fires → readReceipt/typing skipped", () => {
+    // Shape produced by octo-server's buildFanoutCopyReq:
+    //   from_uid = grantor (admin), payload.obo_origin_from_uid = real sender
+    const fanoutCopyPayload = {
+      type: MessageType.Text,
+      content: "hello bot",
+      obo_origin_from_uid: "u_bob",
+      obo_origin_channel_id: "admin",
+      obo_grantor_uid: "admin",
+    };
+    expect(isOBOFanoutMessage(fanoutCopyPayload)).toBe(true);
+  });
+
+  it("normal DM → gate does not fire → readReceipt/typing still sent (backward compat)", () => {
+    const normalDmPayload = { type: MessageType.Text, content: "hi" };
+    expect(isOBOFanoutMessage(normalDmPayload)).toBe(false);
+  });
+
+  it("group message → gate does not fire (group never carries OBO marker)", () => {
+    // Even if some upstream accidentally set obo_origin_from_uid on a group
+    // payload, replyChannelId is resolved from channel_id for groups (not from
+    // obo_origin_from_uid), and the bot IS a group member, so the friend gate
+    // does not reject — gating only matters for DM fan-out copies.
+    const groupPayload = { type: MessageType.Text, content: "hi everyone" };
+    expect(isOBOFanoutMessage(groupPayload)).toBe(false);
   });
 });

--- a/openclaw-channel-octo/src/inbound.test.ts
+++ b/openclaw-channel-octo/src/inbound.test.ts
@@ -15,6 +15,7 @@ import {
   buildMemberListPrefix,
   resolveCommandBody,
   resolveCommandAuthorized,
+  resolveReplyChannelId,
   pendingInboundContext,
   segmentHistoryEntries,
   type ResolveFileResult,
@@ -1839,5 +1840,108 @@ describe("inbound message_seq cutoff tracking", () => {
     // If a stale message somehow gets processed, cutoff stays at 300
     recordCutoff(map, sessionId, 150, true);
     expect(map.get(sessionId)).toBe(300);
+  });
+});
+
+/**
+ * Tests for resolveReplyChannelId — OBO (On-Behalf-Of) fan-out reply target
+ * resolution.
+ *
+ * Background: when octo-server fans out a DM that was sent on-behalf-of a
+ * grantor, the fan-out copy delivered to the acting agent has `from_uid` set
+ * to the grantor (e.g. admin) for invisibility. The real conversation peer
+ * lives in `payload.obo_origin_from_uid`. Replying to `from_uid` would target
+ * the grantor itself (self-send), so we must reply to the OBO origin when
+ * present. Non-OBO messages fall back to `from_uid` unchanged.
+ */
+describe("resolveReplyChannelId", () => {
+  it("DM with obo_origin_from_uid uses the OBO origin as reply target", () => {
+    const result = resolveReplyChannelId({
+      isGroup: false,
+      channelId: "admin",
+      fromUid: "admin", // grantor in fan-out copy
+      payload: {
+        type: MessageType.Text,
+        content: "hello",
+        obo_origin_from_uid: "u_bob",
+        obo_origin_channel_id: "admin",
+        obo_grantor_uid: "admin",
+      },
+    });
+    expect(result).toBe("u_bob");
+  });
+
+  it("DM without obo_origin_from_uid falls back to from_uid (backward compat)", () => {
+    const result = resolveReplyChannelId({
+      isGroup: false,
+      channelId: "u_alice",
+      fromUid: "u_alice",
+      payload: { type: MessageType.Text, content: "hello" },
+    });
+    expect(result).toBe("u_alice");
+  });
+
+  it("DM with empty obo_origin_from_uid falls back to from_uid", () => {
+    const result = resolveReplyChannelId({
+      isGroup: false,
+      channelId: "u_alice",
+      fromUid: "u_alice",
+      payload: {
+        type: MessageType.Text,
+        content: "hello",
+        obo_origin_from_uid: "",
+      },
+    });
+    expect(result).toBe("u_alice");
+  });
+
+  it("DM with non-string obo_origin_from_uid falls back to from_uid", () => {
+    const result = resolveReplyChannelId({
+      isGroup: false,
+      channelId: "u_alice",
+      fromUid: "u_alice",
+      payload: {
+        type: MessageType.Text,
+        content: "hello",
+        // Defensive: server should always send a string, but guard anyway
+        obo_origin_from_uid: 12345 as unknown as string,
+      },
+    });
+    expect(result).toBe("u_alice");
+  });
+
+  it("DM with undefined payload falls back to from_uid", () => {
+    const result = resolveReplyChannelId({
+      isGroup: false,
+      channelId: "u_alice",
+      fromUid: "u_alice",
+      payload: undefined,
+    });
+    expect(result).toBe("u_alice");
+  });
+
+  it("group message always uses channel_id, ignoring OBO fields", () => {
+    const result = resolveReplyChannelId({
+      isGroup: true,
+      channelId: "g_team_chat",
+      fromUid: "admin",
+      payload: {
+        type: MessageType.Text,
+        content: "hello",
+        // OBO field present but should be ignored for group replies
+        obo_origin_from_uid: "u_bob",
+      },
+    });
+    expect(result).toBe("g_team_chat");
+  });
+
+  it("group message uses channel_id even without OBO marker", () => {
+    const result = resolveReplyChannelId({
+      isGroup: true,
+      channelId: "g_team_chat",
+      fromUid: "u_alice",
+      payload: { type: MessageType.Text, content: "hello" },
+    });
+    expect(result).toBe("g_team_chat");
   });
 });

--- a/openclaw-channel-octo/src/inbound.test.ts
+++ b/openclaw-channel-octo/src/inbound.test.ts
@@ -16,6 +16,7 @@ import {
   resolveCommandBody,
   resolveCommandAuthorized,
   resolveReplyChannelId,
+  resolveSessionId,
   isOBOFanoutMessage,
   pendingInboundContext,
   segmentHistoryEntries,
@@ -2038,5 +2039,189 @@ describe("readReceipt/typing skip gate (PR-B behavioral)", () => {
     // does not reject — gating only matters for DM fan-out copies.
     const groupPayload = { type: MessageType.Text, content: "hi everyone" };
     expect(isOBOFanoutMessage(groupPayload)).toBe(false);
+  });
+});
+
+/**
+ * Tests for the `hasOnBehalfOfConfig` gate on `isOBOFanoutMessage` and
+ * `resolveReplyChannelId`. The gate hardens detection against spoofed
+ * `payload.obo_origin_from_uid` values on accounts that are NOT actually
+ * OBO-configured (`account.config.onBehalfOf` unset). Default behavior
+ * (flag omitted or `true`) is unchanged for backward compat.
+ */
+describe("OBO fan-out gating on account.config.onBehalfOf", () => {
+  const fanoutPayload = {
+    type: MessageType.Text,
+    content: "hello bot",
+    obo_origin_from_uid: "u_bob",
+    obo_origin_channel_id: "admin",
+    obo_grantor_uid: "admin",
+  };
+
+  it("isOBOFanoutMessage returns false when account has no onBehalfOf config", () => {
+    expect(
+      isOBOFanoutMessage(fanoutPayload, { hasOnBehalfOfConfig: false }),
+    ).toBe(false);
+  });
+
+  it("isOBOFanoutMessage returns true when account IS OBO-configured", () => {
+    expect(
+      isOBOFanoutMessage(fanoutPayload, { hasOnBehalfOfConfig: true }),
+    ).toBe(true);
+  });
+
+  it("isOBOFanoutMessage default (no opts) still honors the marker (backward compat)", () => {
+    expect(isOBOFanoutMessage(fanoutPayload)).toBe(true);
+  });
+
+  it("resolveReplyChannelId ignores obo marker when account is not OBO-configured", () => {
+    const result = resolveReplyChannelId({
+      isGroup: false,
+      channelId: "admin",
+      fromUid: "admin",
+      payload: fanoutPayload,
+      hasOnBehalfOfConfig: false,
+    });
+    // Spoofed marker must NOT redirect the reply — falls back to from_uid.
+    expect(result).toBe("admin");
+  });
+
+  it("resolveReplyChannelId honors obo marker when account IS OBO-configured", () => {
+    const result = resolveReplyChannelId({
+      isGroup: false,
+      channelId: "admin",
+      fromUid: "admin",
+      payload: fanoutPayload,
+      hasOnBehalfOfConfig: true,
+    });
+    expect(result).toBe("u_bob");
+  });
+});
+
+/**
+ * Session isolation tests for OBO fan-out copies (the PR-B blocking finding).
+ *
+ * Before the fix, sessionId for DMs was derived from `message.from_uid`. In
+ * an OBO fan-out copy, `from_uid` is the grantor (e.g. admin), so two
+ * different fan-out conversations (bob→admin and charlie→admin) collapsed
+ * onto the same OpenClaw session, leaking context across users.
+ *
+ * After the fix, sessionId is derived from the effective DM peer (the real
+ * conversation counterpart, resolved via `resolveReplyChannelId`). Two
+ * fan-out conversations with the same grantor but different
+ * `payload.obo_origin_from_uid` now produce different sessionIds.
+ */
+describe("resolveSessionId — OBO fan-out session isolation (PR-B)", () => {
+  function makeFanoutPayload(originUid: string) {
+    return {
+      type: MessageType.Text,
+      content: "hi",
+      obo_origin_from_uid: originUid,
+      obo_origin_channel_id: "admin",
+      obo_grantor_uid: "admin",
+    };
+  }
+
+  it("two OBO fan-out messages with same grantor but different origins produce different sessionIds", () => {
+    // Bob → admin fan-out copy delivered to the bot
+    const peerBob = resolveReplyChannelId({
+      isGroup: false,
+      channelId: "admin",
+      fromUid: "admin",
+      payload: makeFanoutPayload("u_bob"),
+      hasOnBehalfOfConfig: true,
+    });
+    // Charlie → admin fan-out copy delivered to the bot
+    const peerCharlie = resolveReplyChannelId({
+      isGroup: false,
+      channelId: "admin",
+      fromUid: "admin",
+      payload: makeFanoutPayload("u_charlie"),
+      hasOnBehalfOfConfig: true,
+    });
+
+    const sessionBob = resolveSessionId({
+      isGroup: false,
+      channelId: "admin",
+      effectiveDmPeer: peerBob,
+    });
+    const sessionCharlie = resolveSessionId({
+      isGroup: false,
+      channelId: "admin",
+      effectiveDmPeer: peerCharlie,
+    });
+
+    expect(sessionBob).toBe("u_bob");
+    expect(sessionCharlie).toBe("u_charlie");
+    expect(sessionBob).not.toBe(sessionCharlie);
+  });
+
+  it("non-OBO DM sessionId still uses from_uid (backward compat)", () => {
+    const peer = resolveReplyChannelId({
+      isGroup: false,
+      channelId: "u_alice",
+      fromUid: "u_alice",
+      payload: { type: MessageType.Text, content: "hi" },
+      hasOnBehalfOfConfig: false,
+    });
+    const sessionId = resolveSessionId({
+      isGroup: false,
+      channelId: "u_alice",
+      effectiveDmPeer: peer,
+    });
+    expect(sessionId).toBe("u_alice");
+  });
+
+  it("spaceId is prefixed onto the effective DM peer for Space isolation", () => {
+    const peer = resolveReplyChannelId({
+      isGroup: false,
+      channelId: "admin",
+      fromUid: "admin",
+      payload: makeFanoutPayload("u_bob"),
+      hasOnBehalfOfConfig: true,
+    });
+    const sessionId = resolveSessionId({
+      isGroup: false,
+      channelId: "admin",
+      spaceId: "abc123",
+      effectiveDmPeer: peer,
+    });
+    expect(sessionId).toBe("abc123:u_bob");
+  });
+
+  it("group messages key sessionId by channel_id, not by effective peer", () => {
+    const sessionId = resolveSessionId({
+      isGroup: true,
+      channelId: "g_team_chat",
+      effectiveDmPeer: "ignored_for_groups",
+    });
+    expect(sessionId).toBe("g_team_chat");
+  });
+
+  it("spoofed obo marker on a non-OBO account does NOT split sessions", () => {
+    // Two messages from the same actual sender admin, both carrying a
+    // spoofed obo_origin_from_uid. On a non-OBO account, the gate ignores
+    // the marker, so both still map to the same admin session — no leak.
+    const peerSpoofA = resolveReplyChannelId({
+      isGroup: false,
+      channelId: "admin",
+      fromUid: "admin",
+      payload: { type: MessageType.Text, obo_origin_from_uid: "u_attacker_a" },
+      hasOnBehalfOfConfig: false,
+    });
+    const peerSpoofB = resolveReplyChannelId({
+      isGroup: false,
+      channelId: "admin",
+      fromUid: "admin",
+      payload: { type: MessageType.Text, obo_origin_from_uid: "u_attacker_b" },
+      hasOnBehalfOfConfig: false,
+    });
+    expect(peerSpoofA).toBe("admin");
+    expect(peerSpoofB).toBe("admin");
+    expect(
+      resolveSessionId({ isGroup: false, effectiveDmPeer: peerSpoofA }),
+    ).toBe(
+      resolveSessionId({ isGroup: false, effectiveDmPeer: peerSpoofB }),
+    );
   });
 });

--- a/openclaw-channel-octo/src/inbound.ts
+++ b/openclaw-channel-octo/src/inbound.ts
@@ -964,6 +964,23 @@ export function resolveReplyChannelId(params: {
   return params.fromUid;
 }
 
+/**
+ * Detect OBO fan-out copies delivered to the acting agent.
+ *
+ * When octo-server fans out an OBO message (e.g. James acting on-behalf-of
+ * admin in admin↔bob DM), the copy delivered to the bot stashes the original
+ * sender's uid in `payload.obo_origin_from_uid` (e.g. "u_bob"). In this mode
+ * the bot is, by design, NOT a friend of the original sender, so cosmetic
+ * side-channel signals (readReceipt / typing) cannot succeed: the server's
+ * friend gate rejects them and those endpoints do not accept the
+ * `on_behalf_of` bypass. Callers should skip those signals when this returns
+ * true. The sendMessage path is unaffected — it passes `on_behalf_of`.
+ */
+export function isOBOFanoutMessage(payload?: BotMessage["payload"]): boolean {
+  const origin = payload?.obo_origin_from_uid;
+  return typeof origin === "string" && origin.length > 0;
+}
+
 export function segmentHistoryEntries(params: {
   entries: Array<{ message_id?: string; message_seq?: number; [key: string]: any }>;
   cutoffSeq: number;
@@ -1630,23 +1647,38 @@ export async function handleInboundMessage(params: {
   });
   const replyChannelType = isGroup ? (message.channel_type ?? ChannelType.Group) : ChannelType.DM;
 
-  // 已读回执 + 正在输入 — fire-and-forget
-  log?.info?.(`octo: sending readReceipt+typing to channel=${replyChannelId} type=${replyChannelType} apiUrl=${account.config.apiUrl}`);
-  const messageIds = message.message_id ? [message.message_id] : [];
-  sendReadReceipt({ apiUrl: account.config.apiUrl, botToken: account.config.botToken ?? "", channelId: replyChannelId, channelType: replyChannelType, messageIds })
-    .then(() => log?.info?.("octo: readReceipt sent OK"))
-    .catch((err) => log?.error?.(`octo: readReceipt failed: ${String(err)}`));
-  sendTyping({ apiUrl: account.config.apiUrl, botToken: account.config.botToken ?? "", channelId: replyChannelId, channelType: replyChannelType })
-    .then(() => log?.info?.("octo: typing sent OK"))
-    .catch((err) => log?.error?.(`octo: typing failed: ${String(err)}`));
+  // Detect OBO fan-out copies: the server stashes the original sender's uid in
+  // `payload.obo_origin_from_uid` (e.g. u_bob) while setting `from_uid` to the
+  // grantor (e.g. admin) for invisibility. In this mode the bot is, by design,
+  // NOT a friend of the original sender, so the server's friend gate rejects
+  // readReceipt/typing — those endpoints don't accept `on_behalf_of`. The
+  // sendMessage path is unaffected because it does pass `on_behalf_of`.
+  // These side-channel signals are cosmetic only, so we skip them.
+  const isOBOFanout = isOBOFanoutMessage(message.payload);
 
   const apiUrl = account.config.apiUrl;
   const botToken = account.config.botToken ?? "";
 
-  // Keep sending typing indicator while AI is processing
-  const typingInterval = setInterval(() => {
-    sendTyping({ apiUrl, botToken, channelId: replyChannelId, channelType: replyChannelType }).catch(() => {});
-  }, 5000);
+  // 已读回执 + 正在输入 — fire-and-forget (skip for OBO fan-out copies)
+  if (!isOBOFanout) {
+    log?.info?.(`octo: sending readReceipt+typing to channel=${replyChannelId} type=${replyChannelType} apiUrl=${account.config.apiUrl}`);
+    const messageIds = message.message_id ? [message.message_id] : [];
+    sendReadReceipt({ apiUrl: account.config.apiUrl, botToken: account.config.botToken ?? "", channelId: replyChannelId, channelType: replyChannelType, messageIds })
+      .then(() => log?.info?.("octo: readReceipt sent OK"))
+      .catch((err) => log?.error?.(`octo: readReceipt failed: ${String(err)}`));
+    sendTyping({ apiUrl: account.config.apiUrl, botToken: account.config.botToken ?? "", channelId: replyChannelId, channelType: replyChannelType })
+      .then(() => log?.info?.("octo: typing sent OK"))
+      .catch((err) => log?.error?.(`octo: typing failed: ${String(err)}`));
+  } else {
+    log?.info?.(`octo: skipping readReceipt+typing for OBO fan-out copy (bot not friend of original sender by design) channel=${replyChannelId}`);
+  }
+
+  // Keep sending typing indicator while AI is processing (skip for OBO fan-out)
+  const typingInterval = isOBOFanout
+    ? (null as ReturnType<typeof setInterval> | null)
+    : setInterval(() => {
+        sendTyping({ apiUrl, botToken, channelId: replyChannelId, channelType: replyChannelType }).catch(() => {});
+      }, 5000);
 
   // Buffer text across streaming deliver calls; only send once after dispatcher finishes.
   // Media is sent immediately (no edit problem); text is buffered (each call overwrites).
@@ -1832,7 +1864,7 @@ export async function handleInboundMessage(params: {
           log?.debug?.(`octo: [deliver-buffer] ${kind} text buffered (${content.length} chars)`);
         },
         onError: async (err: unknown, info: { kind: string }) => {
-          clearInterval(typingInterval);
+          if (typingInterval) clearInterval(typingInterval);
           log?.error?.(`octo ${info.kind} reply failed: ${String(err)}`);
           // Prevent finally block from sending stale buffered text after error
           deliverBuffer.lastText = null;
@@ -1864,7 +1896,7 @@ export async function handleInboundMessage(params: {
         log?.error?.(`octo: [deliver-buffer] final text send failed: ${String(finalSendErr)}`);
       }
     }
-    clearInterval(typingInterval);
+    if (typingInterval) clearInterval(typingInterval);
     // Safety net: clean up pending inbound context in case the hook didn't fire
     pendingInboundContext.delete(route.sessionKey);
 

--- a/openclaw-channel-octo/src/inbound.ts
+++ b/openclaw-channel-octo/src/inbound.ts
@@ -931,6 +931,39 @@ export function resolveCommandAuthorized(isGroup: boolean, isOwnerUser: boolean,
   return !isGroup || (isOwnerUser && isExplicitBotMention);
 }
 
+/**
+ * Resolve the reply target channelId for an inbound message.
+ *
+ * For group messages, replies always go to the group channel.
+ * For DM messages, replies normally go back to the sender (`from_uid`).
+ *
+ * OBO (On-Behalf-Of) fan-out copy case:
+ *   When the server fans out an OBO message to the agent (e.g. James acting
+ *   on-behalf-of admin in admin↔bob DM), it sets `from_uid` to the grantor
+ *   (admin) for invisibility — see octo-server's `buildFanoutCopyReq`. The
+ *   real conversation peer is stashed in `payload.obo_origin_from_uid` (e.g.
+ *   "u_bob"). Replying to `from_uid=admin` would target the grantor itself
+ *   (admin→admin self-send, which the server rejects). We must reply to the
+ *   real peer instead.
+ *
+ * Falls back to `fromUid` when no OBO marker is present (backward compat).
+ */
+export function resolveReplyChannelId(params: {
+  isGroup: boolean;
+  channelId?: string;
+  fromUid: string;
+  payload?: BotMessage["payload"];
+}): string {
+  if (params.isGroup) {
+    return params.channelId!;
+  }
+  const oboOriginFromUid = params.payload?.obo_origin_from_uid;
+  if (typeof oboOriginFromUid === "string" && oboOriginFromUid.length > 0) {
+    return oboOriginFromUid;
+  }
+  return params.fromUid;
+}
+
 export function segmentHistoryEntries(params: {
   entries: Array<{ message_id?: string; message_seq?: number; [key: string]: any }>;
   cutoffSeq: number;
@@ -1585,7 +1618,16 @@ export async function handleInboundMessage(params: {
 
   statusSink?.({ lastInboundAt: Date.now(), lastError: null });
 
-  const replyChannelId = isGroup ? message.channel_id! : message.from_uid;
+  // For OBO fan-out copies, the server sets from_uid to the grantor (e.g. admin)
+  // for invisibility, while the real conversation peer lives in
+  // payload.obo_origin_from_uid (e.g. u_bob). Replying to from_uid would target
+  // the grantor (self-send), so we must use the OBO origin when present.
+  const replyChannelId = resolveReplyChannelId({
+    isGroup,
+    channelId: message.channel_id,
+    fromUid: message.from_uid,
+    payload: message.payload,
+  });
   const replyChannelType = isGroup ? (message.channel_type ?? ChannelType.Group) : ChannelType.DM;
 
   // 已读回执 + 正在输入 — fire-and-forget

--- a/openclaw-channel-octo/src/inbound.ts
+++ b/openclaw-channel-octo/src/inbound.ts
@@ -947,19 +947,32 @@ export function resolveCommandAuthorized(isGroup: boolean, isOwnerUser: boolean,
  *   real peer instead.
  *
  * Falls back to `fromUid` when no OBO marker is present (backward compat).
+ *
+ * `hasOnBehalfOfConfig` (optional, default `true`) gates whether the OBO
+ * marker is honored. Set it to `false` for accounts that are NOT OBO-configured
+ * (i.e. `account.config.onBehalfOf` is unset) so a spoofed
+ * `payload.obo_origin_from_uid` from an arbitrary sender cannot redirect
+ * replies / split sessions. When `true` (or omitted) the existing OBO
+ * behavior is preserved.
  */
 export function resolveReplyChannelId(params: {
   isGroup: boolean;
   channelId?: string;
   fromUid: string;
   payload?: BotMessage["payload"];
+  hasOnBehalfOfConfig?: boolean;
 }): string {
   if (params.isGroup) {
     return params.channelId!;
   }
-  const oboOriginFromUid = params.payload?.obo_origin_from_uid;
-  if (typeof oboOriginFromUid === "string" && oboOriginFromUid.length > 0) {
-    return oboOriginFromUid;
+  // Only OBO-configured accounts may honor the fan-out marker. Default true
+  // preserves the existing behavior for callers that don't pass the flag.
+  const obeyObo = params.hasOnBehalfOfConfig !== false;
+  if (obeyObo) {
+    const oboOriginFromUid = params.payload?.obo_origin_from_uid;
+    if (typeof oboOriginFromUid === "string" && oboOriginFromUid.length > 0) {
+      return oboOriginFromUid;
+    }
   }
   return params.fromUid;
 }
@@ -975,10 +988,55 @@ export function resolveReplyChannelId(params: {
  * friend gate rejects them and those endpoints do not accept the
  * `on_behalf_of` bypass. Callers should skip those signals when this returns
  * true. The sendMessage path is unaffected — it passes `on_behalf_of`.
+ *
+ * `opts.hasOnBehalfOfConfig` (optional, default `true`) gates the detection
+ * on the receiving account actually being OBO-configured. When `false`
+ * (account has no `onBehalfOf`), an arbitrary `payload.obo_origin_from_uid`
+ * from an inbound message is treated as untrusted and the function returns
+ * `false`. This prevents spoofed payloads from affecting non-OBO accounts.
  */
-export function isOBOFanoutMessage(payload?: BotMessage["payload"]): boolean {
+export function isOBOFanoutMessage(
+  payload?: BotMessage["payload"],
+  opts?: { hasOnBehalfOfConfig?: boolean },
+): boolean {
   const origin = payload?.obo_origin_from_uid;
-  return typeof origin === "string" && origin.length > 0;
+  if (typeof origin !== "string" || origin.length === 0) {
+    return false;
+  }
+  // Default true preserves existing behavior; only suppress when caller
+  // explicitly says the account is not OBO-configured.
+  if (opts && opts.hasOnBehalfOfConfig === false) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Compute the OpenClaw session id for an inbound message.
+ *
+ * Group messages share a session keyed by `channel_id`. DM messages are keyed
+ * by the effective DM peer (the real conversation counterpart), optionally
+ * prefixed by `spaceId` for per-Space isolation.
+ *
+ * For OBO fan-out copies, the effective peer is the original sender (from
+ * `payload.obo_origin_from_uid`), NOT the grantor in `from_uid`. Using the
+ * grantor would collapse every fan-out conversation onto a single shared
+ * session, leaking context across users. Callers should pre-compute
+ * `effectiveDmPeer` via `resolveReplyChannelId(...)` so reply target and
+ * session identity stay in lockstep.
+ */
+export function resolveSessionId(params: {
+  isGroup: boolean;
+  channelId?: string;
+  spaceId?: string;
+  effectiveDmPeer: string;
+}): string {
+  if (params.isGroup) {
+    return params.channelId!;
+  }
+  return params.spaceId
+    ? `${params.spaceId}:${params.effectiveDmPeer}`
+    : params.effectiveDmPeer;
 }
 
 export function segmentHistoryEntries(params: {
@@ -1134,8 +1192,27 @@ export async function handleInboundMessage(params: {
   // Parse space_id from channel_id (format: s{spaceId}_{peerId})
   // For DM, channel_id is a fake channel: s{spaceId}_{uid1}@s{spaceId}_{uid2}
   // Use LastIndex approach: spaceId is everything between 's' and the last '_' before peerId
+  //
+  // OBO fan-out: for fan-out copies the server sets `from_uid` to the grantor
+  // (e.g. admin) while the real DM peer lives in `payload.obo_origin_from_uid`
+  // (e.g. u_bob). Derive a single "effective DM peer" once and reuse it for
+  // session identity, route peer, fromLabel, senderName resolution, and reply
+  // target — otherwise two different fan-out conversations (same grantor,
+  // different obo_origin_from_uid) would collapse onto the same OpenClaw
+  // session and leak context across users.
+  const hasOnBehalfOfConfig = Boolean(account.config.onBehalfOf);
+  const effectiveDmPeer = isGroup
+    ? message.channel_id!
+    : resolveReplyChannelId({
+        isGroup: false,
+        channelId: message.channel_id,
+        fromUid: message.from_uid,
+        payload: message.payload,
+        hasOnBehalfOfConfig,
+      });
+
   let spaceId = "";
-  const effectiveChannelId = isGroup ? message.channel_id! : message.from_uid;
+  const effectiveChannelId = isGroup ? message.channel_id! : effectiveDmPeer;
   if (effectiveChannelId.startsWith("s")) {
     const lastUnderscore = effectiveChannelId.lastIndexOf("_");
     if (lastUnderscore > 0) {
@@ -1155,10 +1232,15 @@ export async function handleInboundMessage(params: {
     }
   }
 
-  // Session ID: include spaceId for Space isolation (same user in different Spaces = different sessions)
-  const sessionId = isGroup
-    ? message.channel_id!
-    : spaceId ? `${spaceId}:${message.from_uid}` : message.from_uid;
+  // Session ID: include spaceId for Space isolation (same user in different Spaces = different sessions).
+  // For OBO fan-out, sessionId is keyed by the effective peer (real sender)
+  // so each fan-out conversation gets its own isolated OpenClaw session.
+  const sessionId = resolveSessionId({
+    isGroup,
+    channelId: message.channel_id,
+    spaceId,
+    effectiveDmPeer,
+  });
 
   const resolved = resolveContent(message.payload, account.config.apiUrl, log, account.config.cdnUrl);
   let rawBody = resolved.text;
@@ -1531,7 +1613,7 @@ export async function handleInboundMessage(params: {
 
   const fromLabel = isGroup
     ? `group:${message.channel_id}`
-    : spaceId ? `space:${spaceId}:user:${message.from_uid}` : `user:${message.from_uid}`;
+    : spaceId ? `space:${spaceId}:user:${effectiveDmPeer}` : `user:${effectiveDmPeer}`;
 
   const storePath = core.channel.session.resolveStorePath(config.session?.store, {
     agentId: route.agentId,
@@ -1564,25 +1646,30 @@ export async function handleInboundMessage(params: {
   // GROUP.md injection is handled exclusively by the before_prompt_build hook
   // (see index.ts → getGroupMdForPrompt) — no longer set here to avoid duplication.
 
-  // Resolve sender display name — async fallback for DM users not in cache
-  let senderName = resolveSenderName(message.from_uid, uidToNameMap);
+  // Resolve sender display name — async fallback for DM users not in cache.
+  // For OBO fan-out copies, the real sender's uid is `effectiveDmPeer`
+  // (= `payload.obo_origin_from_uid`), not `message.from_uid` (the grantor),
+  // so we resolve the name against the effective peer. Groups always resolve
+  // against the actual `from_uid` (the speaking member).
+  const senderLookupUid = isGroup ? message.from_uid : effectiveDmPeer;
+  let senderName = resolveSenderName(senderLookupUid, uidToNameMap);
   if (!senderName && !isGroup) {
     // DM user not in any group cache — try backend user info API
     // Skip if we already tried and failed (negative cache sentinel "")
-    const cached = uidToNameMap.get(message.from_uid);
+    const cached = uidToNameMap.get(senderLookupUid);
     if (cached === undefined) {
       const userInfo = await fetchUserInfo({
         apiUrl: account.config.apiUrl,
         botToken: account.config.botToken ?? "",
-        uid: message.from_uid,
+        uid: senderLookupUid,
         log,
       });
       if (userInfo?.name) {
         senderName = userInfo.name;
-        uidToNameMap.set(message.from_uid, userInfo.name);
+        uidToNameMap.set(senderLookupUid, userInfo.name);
       } else {
         // Negative cache — prevent repeated API calls for unknown UIDs
-        uidToNameMap.set(message.from_uid, "");
+        uidToNameMap.set(senderLookupUid, "");
       }
     }
   }
@@ -1639,12 +1726,9 @@ export async function handleInboundMessage(params: {
   // for invisibility, while the real conversation peer lives in
   // payload.obo_origin_from_uid (e.g. u_bob). Replying to from_uid would target
   // the grantor (self-send), so we must use the OBO origin when present.
-  const replyChannelId = resolveReplyChannelId({
-    isGroup,
-    channelId: message.channel_id,
-    fromUid: message.from_uid,
-    payload: message.payload,
-  });
+  // `effectiveDmPeer` was computed earlier with the same OBO-config gate, so
+  // reuse it to keep reply target and session identity in lockstep.
+  const replyChannelId = effectiveDmPeer;
   const replyChannelType = isGroup ? (message.channel_type ?? ChannelType.Group) : ChannelType.DM;
 
   // Detect OBO fan-out copies: the server stashes the original sender's uid in
@@ -1654,7 +1738,9 @@ export async function handleInboundMessage(params: {
   // readReceipt/typing — those endpoints don't accept `on_behalf_of`. The
   // sendMessage path is unaffected because it does pass `on_behalf_of`.
   // These side-channel signals are cosmetic only, so we skip them.
-  const isOBOFanout = isOBOFanoutMessage(message.payload);
+  // Gated on `account.config.onBehalfOf` so a spoofed `obo_origin_from_uid`
+  // on a non-OBO account cannot trip the skip path.
+  const isOBOFanout = isOBOFanoutMessage(message.payload, { hasOnBehalfOfConfig });
 
   const apiUrl = account.config.apiUrl;
   const botToken = account.config.botToken ?? "";

--- a/openclaw-channel-octo/src/inbound.ts
+++ b/openclaw-channel-octo/src/inbound.ts
@@ -949,11 +949,14 @@ export function resolveCommandAuthorized(isGroup: boolean, isOwnerUser: boolean,
  * Falls back to `fromUid` when no OBO marker is present (backward compat).
  *
  * `hasOnBehalfOfConfig` (optional, default `true`) gates whether the OBO
- * marker is honored. Set it to `false` for accounts that are NOT OBO-configured
- * (i.e. `account.config.onBehalfOf` is unset) so a spoofed
- * `payload.obo_origin_from_uid` from an arbitrary sender cannot redirect
- * replies / split sessions. When `true` (or omitted) the existing OBO
- * behavior is preserved.
+ * marker is honored. Despite its historical name, callers should pass the
+ * stronger "OBO marker is trusted for this message" decision computed at the
+ * call site (see `handleInboundMessage` — trust requires both the account
+ * being OBO-enabled AND the inbound `message.from_uid` matching the
+ * configured grantor, plus `obo_grantor_uid` if present). Set to `false`
+ * whenever those checks fail so a spoofed `payload.obo_origin_from_uid`
+ * from an arbitrary sender cannot redirect replies / split sessions.
+ * When `true` (or omitted) the OBO marker is honored.
  */
 export function resolveReplyChannelId(params: {
   isGroup: boolean;
@@ -990,10 +993,15 @@ export function resolveReplyChannelId(params: {
  * true. The sendMessage path is unaffected — it passes `on_behalf_of`.
  *
  * `opts.hasOnBehalfOfConfig` (optional, default `true`) gates the detection
- * on the receiving account actually being OBO-configured. When `false`
- * (account has no `onBehalfOf`), an arbitrary `payload.obo_origin_from_uid`
- * from an inbound message is treated as untrusted and the function returns
- * `false`. This prevents spoofed payloads from affecting non-OBO accounts.
+ * on whether the OBO marker is trusted for this message. Despite the
+ * historical name, callers should pass the call-site trust decision (see
+ * `handleInboundMessage` — trust requires both the account being
+ * OBO-enabled AND `message.from_uid` matching the configured grantor,
+ * plus `obo_grantor_uid` if present). When `false`, an arbitrary
+ * `payload.obo_origin_from_uid` from an inbound message is treated as
+ * untrusted and the function returns `false`. This prevents spoofed
+ * payloads from being honored on non-OBO accounts or from non-grantor
+ * senders on OBO-enabled accounts.
  */
 export function isOBOFanoutMessage(
   payload?: BotMessage["payload"],
@@ -1028,8 +1036,10 @@ export function isOBOFanoutMessage(
  * Gating:
  * - Only DM (`isGroup=false`) honors the OBO origin marker. Groups always
  *   carry the actual speaker in `from_uid`.
- * - `hasOnBehalfOfConfig=false` suppresses honoring the marker — a spoofed
- *   `obo_origin_from_uid` on a non-OBO account cannot redirect attribution.
+ * - `hasOnBehalfOfConfig=false` suppresses honoring the marker — used when
+ *   the OBO marker is NOT trusted for this message (account not OBO-enabled,
+ *   or `from_uid` / `obo_grantor_uid` mismatch with the configured grantor),
+ *   so a spoofed `obo_origin_from_uid` cannot redirect attribution.
  */
 export function resolveEffectiveSender(params: {
   isGroup: boolean;
@@ -1236,7 +1246,48 @@ export async function handleInboundMessage(params: {
   // target — otherwise two different fan-out conversations (same grantor,
   // different obo_origin_from_uid) would collapse onto the same OpenClaw
   // session and leak context across users.
-  const hasOnBehalfOfConfig = Boolean(account.config.onBehalfOf);
+  //
+  // OBO marker trust gate (Jerry-Xin R2 review feedback):
+  // It is NOT enough that the receiving account has `onBehalfOf` configured —
+  // a non-grantor sender on an OBO-enabled account could otherwise stuff a
+  // spoofed `obo_origin_from_uid` into their payload and redirect the
+  // session/reply target. We trust the OBO marker only when the inbound
+  // message actually comes from the configured grantor:
+  //   - `account.config.onBehalfOf` is set (account is OBO-enabled)
+  //   - AND `message.from_uid === account.config.onBehalfOf` (server-side,
+  //     fan-out copies always stamp `from_uid` to the grantor; a payload
+  //     from any other sender is not a fan-out copy and its OBO fields are
+  //     attacker-controlled)
+  //   - AND when the server populates `payload.obo_grantor_uid`, it must
+  //     also match the configured grantor (extra defense-in-depth so that
+  //     even if `from_uid` were bypassed, the explicit grantor stamp has
+  //     to match too).
+  // Anywhere the helpers below take a `hasOnBehalfOfConfig` flag, we now
+  // pass `oboMarkerTrusted` — the flag's effective meaning is "the OBO
+  // marker on THIS message is trusted", not "this account is OBO-enabled".
+  const configuredGrantor = account.config.onBehalfOf;
+  const oboGrantorUidFromPayloadRaw = (message.payload as { obo_grantor_uid?: unknown } | undefined)
+    ?.obo_grantor_uid;
+  const oboGrantorUidFromPayload =
+    typeof oboGrantorUidFromPayloadRaw === "string" && oboGrantorUidFromPayloadRaw.length > 0
+      ? oboGrantorUidFromPayloadRaw
+      : undefined;
+  const oboMarkerTrusted = Boolean(
+    configuredGrantor &&
+      message.from_uid === configuredGrantor &&
+      (oboGrantorUidFromPayload === undefined || oboGrantorUidFromPayload === configuredGrantor),
+  );
+  if (configuredGrantor && !oboMarkerTrusted) {
+    // Either from_uid mismatch or obo_grantor_uid mismatch on an OBO-enabled
+    // account — most likely a spoof attempt (or simply a non-fan-out message
+    // on an OBO-enabled account). Either way we ignore the OBO markers.
+    log?.debug?.(
+      `octo: [OBO] marker not trusted (from_uid=${message.from_uid}, ` +
+        `obo_grantor_uid=${oboGrantorUidFromPayload ?? "<none>"}, ` +
+        `configured grantor=${configuredGrantor}) — ignoring obo_origin_from_uid`,
+    );
+  }
+  const hasOnBehalfOfConfig = oboMarkerTrusted;
   const effectiveDmPeer = isGroup
     ? message.channel_id!
     : resolveReplyChannelId({
@@ -1399,38 +1450,44 @@ export async function handleInboundMessage(params: {
     //
     // Server contract on inbound payloads:
     //   - canonical form: `{humans?: 1, ais?: 1}` (independent flags)
-    //   - legacy form:    `{all: 1}` — emitted by old servers/clients that
-    //                     pre-date the three-state split. Semantically means
-    //                     "everyone, including bots", so it MUST continue to
-    //                     wake bots — otherwise this PR silently regresses
-    //                     bot triggering for any caller still on the legacy
-    //                     wire format. (Jerry-Xin review feedback.) `ais`
-    //                     is additive, not a replacement for `all`.
+    //   - legacy form:    `{all: 1}` — server double-writes this for legacy
+    //                     clients even post-three-state split. Server-side
+    //                     semantic is `all = humans` (i.e. "@所有人"),
+    //                     NOT "everyone including bots". See the comment on
+    //                     `MentionPayload.all` in types.ts: the adapter
+    //                     treats `all=1` as a humans-only signal so a bot
+    //                     does NOT wake on an `@所有人` broadcast that was
+    //                     never intended to summon AIs (Jerry-Xin R2
+    //                     blocker — previous implementation made `all`
+    //                     wake bots, contradicting the type contract and
+    //                     incorrectly triggering on human-only broadcasts).
     //
-    // Trigger rule: bots wake up on `ais=1` OR legacy `all=1` (subject to
-    // the existing `ignoreMentionAll` opt-out), or an explicit uid mention.
-    // `humans=1` alone never wakes a bot.
+    // Trigger rule: bots wake up on `ais=1` (subject to the existing
+    // `ignoreMentionAll` opt-out), or on an explicit uid mention.
+    // `humans=1` and legacy `all=1` (both humans-only signals) never wake
+    // a bot on their own.
     const mention = message.payload?.mention ?? {};
     const hasHumans = mention.humans === true || mention.humans === 1;
     const hasAis = mention.ais === true || mention.ais === 1;
     const hasAll = mention.all === true || mention.all === 1;
 
-    // `humansFlag` is computed for parity / debug logs but does NOT gate the
-    // bot. Both `ais` (new explicit broadcast) and `all` (legacy "everyone
-    // including bots") wake the bot, so they fold together into the trigger.
+    // `humansFlag` and `legacyAllFlag` are computed for parity / debug logs
+    // but do NOT gate the bot — both are humans-only signals per the
+    // server-authoritative contract. Only `ais` (the explicit AI broadcast)
+    // wakes the bot.
     const humansFlag = hasHumans;
     const aisFlag = hasAis;
-    const broadcastWakesBot = hasAis || hasAll;
+    const legacyAllFlag = hasAll;
+    const broadcastWakesBot = hasAis;
 
-    // Reuse existing ignoreMentionAll for opt-out. No separate ignoreAis
-    // config — keeps a single user-facing knob for "don't trigger me on
-    // broadcast mentions" regardless of which broadcast flavor the server
-    // emits.
+    // Reuse existing ignoreMentionAll for opt-out on the AI broadcast. Kept
+    // as a single user-facing knob ("don't trigger me on broadcast mentions")
+    // rather than splitting into separate `ignoreAis` config.
     isMentioned = (broadcastWakesBot && !account.config.ignoreMentionAll) || mentionUids.includes(botUid);
     isExplicitBotMention = mentionUids.includes(botUid);
 
     log?.debug?.(
-      `octo: [RECV] mention three-state: humans=${humansFlag} ais=${aisFlag} legacyAll=${hasAll} → bot triggered=${isMentioned}`,
+      `octo: [RECV] mention three-state: humans=${humansFlag} ais=${aisFlag} legacyAll=${legacyAllFlag} → bot triggered=${isMentioned}`,
     );
 
     // Defensive fallback: if payload.mention is missing/empty but the message
@@ -1839,8 +1896,10 @@ export async function handleInboundMessage(params: {
   // readReceipt/typing — those endpoints don't accept `on_behalf_of`. The
   // sendMessage path is unaffected because it does pass `on_behalf_of`.
   // These side-channel signals are cosmetic only, so we skip them.
-  // Gated on `account.config.onBehalfOf` so a spoofed `obo_origin_from_uid`
-  // on a non-OBO account cannot trip the skip path.
+  // Gated on the call-site OBO marker trust check (account is OBO-enabled
+  // AND `message.from_uid` matches the configured grantor) so a spoofed
+  // `obo_origin_from_uid` from a non-grantor sender — or any sender on a
+  // non-OBO account — cannot trip the skip path.
   const isOBOFanout = isOBOFanoutMessage(message.payload, { hasOnBehalfOfConfig });
 
   const apiUrl = account.config.apiUrl;

--- a/openclaw-channel-octo/src/inbound.ts
+++ b/openclaw-channel-octo/src/inbound.ts
@@ -1012,6 +1012,42 @@ export function isOBOFanoutMessage(
 }
 
 /**
+ * Resolve the effective sender attribution for an inbound message.
+ *
+ * For OBO fan-out copies, the server stamps `from_uid` with the grantor
+ * (e.g. admin) and stashes the real conversation peer / actual speaker in
+ * `payload.obo_origin_from_uid` (e.g. u_bob). All downstream identity-bearing
+ * fields (`From`, `SenderId`, `SenderUsername`, the `isOwner` check, audit
+ * logs, etc.) MUST attribute the message to the real peer — otherwise the
+ * peer's message inherits the grantor's roles and bypasses gating
+ * (Jerry-Xin review feedback).
+ *
+ * The grantor uid is preserved separately (`grantorUid`) so callers can
+ * surface it as audit / OBO metadata without losing speaker attribution.
+ *
+ * Gating:
+ * - Only DM (`isGroup=false`) honors the OBO origin marker. Groups always
+ *   carry the actual speaker in `from_uid`.
+ * - `hasOnBehalfOfConfig=false` suppresses honoring the marker — a spoofed
+ *   `obo_origin_from_uid` on a non-OBO account cannot redirect attribution.
+ */
+export function resolveEffectiveSender(params: {
+  isGroup: boolean;
+  fromUid: string;
+  payload?: BotMessage["payload"];
+  hasOnBehalfOfConfig?: boolean;
+}): { senderUid: string; grantorUid: string | undefined } {
+  const obeyObo = params.hasOnBehalfOfConfig !== false;
+  if (!params.isGroup && obeyObo) {
+    const origin = params.payload?.obo_origin_from_uid;
+    if (typeof origin === "string" && origin.length > 0) {
+      return { senderUid: origin, grantorUid: params.fromUid };
+    }
+  }
+  return { senderUid: params.fromUid, grantorUid: undefined };
+}
+
+/**
  * Compute the OpenClaw session id for an inbound message.
  *
  * Group messages share a session keyed by `channel_id`. DM messages are keyed
@@ -1211,6 +1247,25 @@ export async function handleInboundMessage(params: {
         hasOnBehalfOfConfig,
       });
 
+  // OBO-aware sender attribution (Jerry-Xin review fix):
+  // When the server fans out an OBO copy, `from_uid` is the grantor (e.g.
+  // admin) for invisibility, but the real conversation peer / actual speaker
+  // lives in `payload.obo_origin_from_uid` (e.g. u_bob). Downstream
+  // permission checks (isOwner, cross-channel read auth) MUST attribute the
+  // message to the real peer, NOT the grantor — otherwise the peer's
+  // message inherits the grantor's owner role and bypasses gating.
+  //
+  // The grantor identity is preserved separately in `OboGrantorId` /
+  // `OboGrantorUsername` on the OpenClaw context so downstream code can
+  // audit who delegated the session without losing speaker attribution.
+  const { senderUid: effectiveSenderUid, grantorUid: oboGrantorUid } =
+    resolveEffectiveSender({
+      isGroup,
+      fromUid: message.from_uid,
+      payload: message.payload,
+      hasOnBehalfOfConfig,
+    });
+
   let spaceId = "";
   const effectiveChannelId = isGroup ? message.channel_id! : effectiveDmPeer;
   if (effectiveChannelId.startsWith("s")) {
@@ -1344,28 +1399,34 @@ export async function handleInboundMessage(params: {
     //
     // Server contract on inbound payloads:
     //   - canonical form: `{humans?: 1, ais?: 1}` (independent flags)
-    //   - legacy form:    `{all: 1}` — server outbound double-writes this
-    //                     for legacy clients; semantically equals humans=1
-    //                     (NOT ais). Defensive read mirrors that decision.
+    //   - legacy form:    `{all: 1}` — emitted by old servers/clients that
+    //                     pre-date the three-state split. Semantically means
+    //                     "everyone, including bots", so it MUST continue to
+    //                     wake bots — otherwise this PR silently regresses
+    //                     bot triggering for any caller still on the legacy
+    //                     wire format. (Jerry-Xin review feedback.) `ais`
+    //                     is additive, not a replacement for `all`.
     //
-    // Trigger rule: bots wake up on `ais=1` (subject to opt-out) or an
-    // explicit uid mention. `humans=1` / `all=1` never wakes a bot.
+    // Trigger rule: bots wake up on `ais=1` OR legacy `all=1` (subject to
+    // the existing `ignoreMentionAll` opt-out), or an explicit uid mention.
+    // `humans=1` alone never wakes a bot.
     const mention = message.payload?.mention ?? {};
     const hasHumans = mention.humans === true || mention.humans === 1;
     const hasAis = mention.ais === true || mention.ais === 1;
     const hasAll = mention.all === true || mention.all === 1;
 
-    // hasAll folds into humans, NOT ais — matches server's "all = humans-only"
-    // decision. `humansFlag` is computed for parity / future read sites
-    // (e.g. debug logs) even though it intentionally does NOT gate the bot.
-    const humansFlag = hasHumans || hasAll;
+    // `humansFlag` is computed for parity / debug logs but does NOT gate the
+    // bot. Both `ais` (new explicit broadcast) and `all` (legacy "everyone
+    // including bots") wake the bot, so they fold together into the trigger.
+    const humansFlag = hasHumans;
     const aisFlag = hasAis;
+    const broadcastWakesBot = hasAis || hasAll;
 
     // Reuse existing ignoreMentionAll for opt-out. No separate ignoreAis
     // config — keeps a single user-facing knob for "don't trigger me on
     // broadcast mentions" regardless of which broadcast flavor the server
     // emits.
-    isMentioned = (aisFlag && !account.config.ignoreMentionAll) || mentionUids.includes(botUid);
+    isMentioned = (broadcastWakesBot && !account.config.ignoreMentionAll) || mentionUids.includes(botUid);
     isExplicitBotMention = mentionUids.includes(botUid);
 
     log?.debug?.(
@@ -1706,7 +1767,10 @@ export async function handleInboundMessage(params: {
   }
 
   const commandBody = resolveCommandBody(rawBody, isGroup, isExplicitBotMention);
-  const commandAuthorized = resolveCommandAuthorized(isGroup, isOwner(account.accountId, message.from_uid), isExplicitBotMention);
+  // Owner check uses `effectiveSenderUid` so OBO fan-out copies attribute
+  // ownership to the real peer (e.g. u_bob), not the grantor (admin). Without
+  // this, a non-owner peer would inherit the grantor's owner role.
+  const commandAuthorized = resolveCommandAuthorized(isGroup, isOwner(account.accountId, effectiveSenderUid), isExplicitBotMention);
 
   const ctxPayload = core.channel.reply.finalizeInboundContext({
     Body: body,
@@ -1722,15 +1786,21 @@ export async function handleInboundMessage(params: {
       return current ? [current] : undefined;
     })(),
     MediaTypes: resolved.mediaType ? [resolved.mediaType] : undefined,
-    From: `${CHANNEL_ID}:${message.from_uid}`,
+    From: `${CHANNEL_ID}:${effectiveSenderUid}`,
     To: `${CHANNEL_ID}:${sessionId}`,
     SessionKey: route.sessionKey,
     AccountId: route.accountId,
     ChatType: isGroup ? "group" : "direct",
     ConversationLabel: fromLabel,
-    SenderId: message.from_uid,
+    SenderId: effectiveSenderUid,
     SenderName: senderName,
-    SenderUsername: message.from_uid,
+    SenderUsername: effectiveSenderUid,
+    // OBO grantor metadata: when this message is an OBO fan-out copy, the
+    // grantor (e.g. admin) is preserved here so downstream auditing can see
+    // who delegated. `SenderId` deliberately points at the real peer instead.
+    ...(oboGrantorUid
+      ? { OboGrantorId: oboGrantorUid, OboGrantorUsername: oboGrantorUid }
+      : {}),
     WasMentioned: isGroup ? isMentioned : undefined,
     MessageSid: String(message.message_id),
     Timestamp: message.timestamp ? message.timestamp * 1000 : undefined,

--- a/openclaw-channel-octo/src/inbound.ts
+++ b/openclaw-channel-octo/src/inbound.ts
@@ -1336,10 +1336,41 @@ export async function handleInboundMessage(params: {
   let isExplicitBotMention = false;
   if (isGroup) {
     const mentionUids = extractMentionUids(message.payload?.mention);
-    const mentionAllRaw = message.payload?.mention?.all;
-    const mentionAll: boolean = mentionAllRaw === true || mentionAllRaw === 1;
-    isMentioned = (!account.config.ignoreMentionAll && mentionAll) || mentionUids.includes(botUid);
+
+    // ── Mention three-state read (PR-B; tracks octo-server #94) ────────────
+    // Adapter is NOT a decision boundary — server decides what "humans" vs
+    // "ais" means. We only read the three flags and decide whether THIS bot
+    // instance should be triggered.
+    //
+    // Server contract on inbound payloads:
+    //   - canonical form: `{humans?: 1, ais?: 1}` (independent flags)
+    //   - legacy form:    `{all: 1}` — server outbound double-writes this
+    //                     for legacy clients; semantically equals humans=1
+    //                     (NOT ais). Defensive read mirrors that decision.
+    //
+    // Trigger rule: bots wake up on `ais=1` (subject to opt-out) or an
+    // explicit uid mention. `humans=1` / `all=1` never wakes a bot.
+    const mention = message.payload?.mention ?? {};
+    const hasHumans = mention.humans === true || mention.humans === 1;
+    const hasAis = mention.ais === true || mention.ais === 1;
+    const hasAll = mention.all === true || mention.all === 1;
+
+    // hasAll folds into humans, NOT ais — matches server's "all = humans-only"
+    // decision. `humansFlag` is computed for parity / future read sites
+    // (e.g. debug logs) even though it intentionally does NOT gate the bot.
+    const humansFlag = hasHumans || hasAll;
+    const aisFlag = hasAis;
+
+    // Reuse existing ignoreMentionAll for opt-out. No separate ignoreAis
+    // config — keeps a single user-facing knob for "don't trigger me on
+    // broadcast mentions" regardless of which broadcast flavor the server
+    // emits.
+    isMentioned = (aisFlag && !account.config.ignoreMentionAll) || mentionUids.includes(botUid);
     isExplicitBotMention = mentionUids.includes(botUid);
+
+    log?.debug?.(
+      `octo: [RECV] mention three-state: humans=${humansFlag} ais=${aisFlag} legacyAll=${hasAll} → bot triggered=${isMentioned}`,
+    );
 
     // Defensive fallback: if payload.mention is missing/empty but the message
     // text contains @botName, treat it as a mention.  This covers old senders

--- a/openclaw-channel-octo/src/inbound.ts
+++ b/openclaw-channel-octo/src/inbound.ts
@@ -66,9 +66,10 @@ export async function uploadAndSendMedia(params: {
   botToken: string;
   channelId: string;
   channelType: ChannelType;
+  onBehalfOf?: string;
   log?: ChannelLogSink;
 }): Promise<SendMessageResult | undefined> {
-  const { mediaUrl, apiUrl, botToken, channelId, channelType, log } = params;
+  const { mediaUrl, apiUrl, botToken, channelId, channelType, onBehalfOf, log } = params;
 
   const { createReadStream: fsCreateReadStream, statSync: fsStatSync, createWriteStream: fsCreateWriteStream } = await import("node:fs");
   const { basename, join: pathJoin } = await import("node:path");
@@ -173,6 +174,7 @@ export async function uploadAndSendMedia(params: {
       size: fileSize,
       width,
       height,
+      ...(onBehalfOf ? { onBehalfOf } : {}),
     });
     return result;
   } finally {
@@ -1720,6 +1722,7 @@ export async function handleInboundMessage(params: {
       ...(replyMentionUids.length > 0 ? { mentionUids: replyMentionUids } : {}),
       ...(replyMentionEntities.length > 0 ? { mentionEntities: replyMentionEntities } : {}),
       mentionAll: hasAtAll || undefined,
+      ...(account.config.onBehalfOf ? { onBehalfOf: account.config.onBehalfOf } : {}),
     });
     statusSink?.({ lastOutboundAt: Date.now(), lastError: null });
     return result;
@@ -1756,6 +1759,7 @@ export async function handleInboundMessage(params: {
                 botToken: account.config.botToken ?? "",
                 channelId: replyChannelId,
                 channelType: replyChannelType,
+                ...(account.config.onBehalfOf ? { onBehalfOf: account.config.onBehalfOf } : {}),
                 log,
               });
               sentMediaUrls.add(mediaUrl);
@@ -1798,6 +1802,7 @@ export async function handleInboundMessage(params: {
               channelId: replyChannelId,
               channelType: replyChannelType,
               content: "⚠️ 抱歉，处理您的消息时遇到了问题，请稍后重试。",
+              ...(account.config.onBehalfOf ? { onBehalfOf: account.config.onBehalfOf } : {}),
             });
           } catch (sendErr) {
             log?.error?.(`octo: failed to send error message: ${String(sendErr)}`);

--- a/openclaw-channel-octo/src/manifest-schema-sync.test.ts
+++ b/openclaw-channel-octo/src/manifest-schema-sync.test.ts
@@ -61,4 +61,27 @@ describe("openclaw.plugin.json onBehalfOf validation", () => {
     const accountProps = props.accounts.additionalProperties.properties;
     expect(accountProps.onBehalfOf.minLength).toBe(1);
   });
+
+  // Jerry-Xin R2 P1: minLength alone accepts whitespace-only typos like
+  // "   " (each space counts as a character). Adding `pattern: "\\S"`
+  // requires at least one non-whitespace character.
+  it("top-level onBehalfOf has pattern \\S to reject whitespace-only values", () => {
+    expect(
+      manifest.channelConfigs.octo.schema.properties.onBehalfOf.pattern,
+    ).toBe("\\S");
+  });
+
+  it("per-account onBehalfOf has pattern \\S to reject whitespace-only values", () => {
+    const accountProps =
+      manifest.channelConfigs.octo.schema.properties.accounts
+        .additionalProperties.properties;
+    expect(accountProps.onBehalfOf.pattern).toBe("\\S");
+  });
+
+  it("TS-side DmworkConfigJsonSchema mirrors pattern \\S", () => {
+    const props = DmworkConfigJsonSchema.schema.properties as any;
+    expect(props.onBehalfOf.pattern).toBe("\\S");
+    const accountProps = props.accounts.additionalProperties.properties;
+    expect(accountProps.onBehalfOf.pattern).toBe("\\S");
+  });
 });

--- a/openclaw-channel-octo/src/manifest-schema-sync.test.ts
+++ b/openclaw-channel-octo/src/manifest-schema-sync.test.ts
@@ -34,3 +34,31 @@ describe("openclaw.plugin.json channelConfigs", () => {
     );
   });
 });
+
+// Regression for PR #35 review: onBehalfOf must reject whitespace-only /
+// empty-string typos at config validation time (`minLength: 1`).
+describe("openclaw.plugin.json onBehalfOf validation", () => {
+  const manifest = JSON.parse(
+    readFileSync(resolve(__dirname, "..", "openclaw.plugin.json"), "utf-8"),
+  );
+
+  it("top-level onBehalfOf has minLength: 1", () => {
+    expect(
+      manifest.channelConfigs.octo.schema.properties.onBehalfOf.minLength,
+    ).toBe(1);
+  });
+
+  it("per-account onBehalfOf has minLength: 1", () => {
+    const accountProps =
+      manifest.channelConfigs.octo.schema.properties.accounts
+        .additionalProperties.properties;
+    expect(accountProps.onBehalfOf.minLength).toBe(1);
+  });
+
+  it("TS-side DmworkConfigJsonSchema mirrors minLength: 1", () => {
+    const props = DmworkConfigJsonSchema.schema.properties as any;
+    expect(props.onBehalfOf.minLength).toBe(1);
+    const accountProps = props.accounts.additionalProperties.properties;
+    expect(accountProps.onBehalfOf.minLength).toBe(1);
+  });
+});

--- a/openclaw-channel-octo/src/mention-utils.ts
+++ b/openclaw-channel-octo/src/mention-utils.ts
@@ -12,6 +12,18 @@
 import type { MentionEntity, MentionPayload } from "./types.js";
 
 /**
+ * Broadcast mention tokens for the three-state mention model (PR-B / octo-server #94).
+ *
+ * Adapter-side convenience constants so the LLM, prompt builders, and any
+ * future outbound formatter share a single source of truth for what the
+ * human-facing tokens look like. The server is still the authoritative
+ * decider for what each token *means* on inbound — these only exist so
+ * outbound code paths don't hardcode the same Chinese string in N places.
+ */
+export const MENTION_HUMANS_TOKEN = "@所有人";
+export const MENTION_AIS_TOKEN = "@所有AI";
+
+/**
  * Regex pattern for matching @mentions in message content.
  *
  * 前置边界（lookbehind）：@ 前面必须是行首或非字母数字字符。

--- a/openclaw-channel-octo/src/types.ts
+++ b/openclaw-channel-octo/src/types.ts
@@ -63,7 +63,22 @@ export interface MentionEntity {
 export interface MentionPayload {
   uids?: string[];
   entities?: MentionEntity[];
+  /**
+   * Legacy "@all" flag. Server outbound double-writes this for legacy clients
+   * even after the three-state split landed (server-side semantic: all=humans).
+   * Adapter treats `all=1` as a humans-only signal (NOT ais) to match the
+   * server's authoritative decision.
+   */
   all?: boolean | number; // true or 1 = @all (API returns either depending on version)
+  /**
+   * Three-state mention (server-authoritative, PR-A landed on octo-server #94).
+   * `humans=1` → "@所有人", `ais=1` → "@所有AI". Both can co-exist.
+   * Adapter only reads these; it never decides semantics — server is the
+   * source of truth and rewrites legacy `all=1` into the canonical form
+   * before adapter sees it.
+   */
+  humans?: boolean | number;
+  ais?: boolean | number;
 }
 
 export interface ReplyPayload {

--- a/openclaw-channel-octo/src/types.ts
+++ b/openclaw-channel-octo/src/types.ts
@@ -18,6 +18,14 @@ export interface BotSendMessageReq {
   channel_type: ChannelType;
   stream_no?: string;
   payload: MessagePayload;
+  /**
+   * OBO (On-Behalf-Of) attribution. When set, the server attributes the
+   * outbound message to this uid (the grantor) instead of the calling
+   * bot. Adapter populates this from `account.config.onBehalfOf` for
+   * configured accounts; api-fetch maps the field to the over-the-wire
+   * `on_behalf_of` JSON key (see `api-fetch.ts`).
+   */
+  on_behalf_of?: string;
 }
 
 export interface BotTypingReq {
@@ -65,11 +73,14 @@ export interface MentionPayload {
   entities?: MentionEntity[];
   /**
    * Legacy "@all" flag. Server outbound double-writes this for legacy clients
-   * even after the three-state split landed (server-side semantic: all=humans).
-   * Adapter treats `all=1` as a humans-only signal (NOT ais) to match the
-   * server's authoritative decision.
+   * even after the three-state split landed (server-side semantic: `all=1`
+   * means "@所有人" → humans only, NOT ais). The adapter therefore treats
+   * `all=1` as a humans-only signal: it does NOT wake bots on its own and
+   * MUST be folded into the humans bucket, not the ais bucket. This matches
+   * the server's authoritative decision (see `inbound.ts` mention three-state
+   * read block).
    */
-  all?: boolean | number; // true or 1 = @all (API returns either depending on version)
+  all?: boolean | number; // true or 1 = @所有人 (humans-only; API returns either depending on version)
   /**
    * Three-state mention (server-authoritative, PR-A landed on octo-server #94).
    * `humans=1` → "@所有人", `ais=1` → "@所有AI". Both can co-exist.


### PR DESCRIPTION
## Summary

RFC `persona-clone` §6 (PR-B) — Adapter passthrough for the new account-level config `onBehalfOf` (Persona Clone / OBO). When set, every outbound `/v1/bot/sendMessage` request includes `on_behalf_of: <uid>` so the bot delivers messages as the real user under a server-side OBO grant.

Backend acceptance lands in PR-A (Mininglamp-OSS/octo-server#81). This PR is **backward-compatible both ways** — when `onBehalfOf` is unset/empty the request body is byte-identical to `main`, and the backend ignores the unknown field until PR-A merges.

> Note: An earlier PR `dmwork-org/dmwork-adapters#241` was opened against the wrong (frozen) repo and has been closed. This PR is the correct refile against `Mininglamp-OSS/octo-adapters` `main`, targeting the **`openclaw-channel-octo/`** subdir (NOT `openclaw-channel-dmwork/`, which is kept only for dependabot tracking per #29).

## Scope (strict, ~10 LOC core)

| File | Change |
| --- | --- |
| `openclaw-channel-octo/src/config-schema.ts` | Add optional `onBehalfOf: string` to `DmworkAccountConfig` + `DmworkConfig` + JSON Schema (account + global) |
| `openclaw-channel-octo/openclaw.plugin.json` | Mirror the same property in the manifest schema (kept in sync by `manifest-schema-sync` test) |
| `openclaw-channel-octo/src/accounts.ts` | Surface on `ResolvedDmworkAccount.config` (account override → channel default) |
| `openclaw-channel-octo/src/api-fetch.ts` | `sendMessage` + `sendMediaMessage` forward `on_behalf_of`, **omitted when unset/empty** |
| `openclaw-channel-octo/src/inbound.ts` | Pass `account.config.onBehalfOf` at the 3 send call sites: main reply, error reply, media upload |
| `openclaw-channel-octo/README.md`, `CHANGELOG.md` | Brief docs entries |
| `openclaw-channel-octo/src/api-fetch.test.ts` | 3 new unit tests: set / unset / media passthrough |

## Diff stat

```
 CHANGELOG.md                                |  3 +
 openclaw-channel-octo/README.md             |  1 +
 openclaw-channel-octo/openclaw.plugin.json  |  4 +-
 openclaw-channel-octo/src/accounts.ts       |  2 +
 openclaw-channel-octo/src/api-fetch.test.ts | 99 +++++++++++++++++++++++++++++
 openclaw-channel-octo/src/api-fetch.ts      |  4 ++
 openclaw-channel-octo/src/config-schema.ts  |  4 ++
 openclaw-channel-octo/src/inbound.ts        |  7 +-
 8 files changed, 122 insertions(+), 2 deletions(-)
```

Core production-code delta is ~10 LOC; the rest is the new test block + JSON schema + docs.

## Before / after request body

**Before (`onBehalfOf` unset — identical to `main`):**
```json
{
  "channel_id": "group1",
  "channel_type": 2,
  "payload": {
    "type": 1,
    "content": "hello"
  }
}
```

**After (with `onBehalfOf: "yu_uid"`):**
```json
{
  "channel_id": "group1",
  "channel_type": 2,
  "on_behalf_of": "yu_uid",
  "payload": {
    "type": 1,
    "content": "hello"
  }
}
```

## Compatibility

- `onBehalfOf` unset/`""` → request body **byte-identical** to `main` (covered by unit test).
- Backend currently ignores unknown `on_behalf_of` field; behavior switches on only after PR-A (`Mininglamp-OSS/octo-server#81`) lands.
- No schema migration, no auth change, no breaking API change.

## Out of scope

- ❌ Backend protocol changes (PR-A — Mininglamp-OSS/octo-server#81)
- ❌ Other adapters; `openclaw-channel-dmwork/` is intentionally **not** modified (legacy / dependabot-tracking only per #29)
- ❌ Persona prompt template (lives in OpenClaw account config, not the adapter)

## Tests

- `npm run type-check` — clean
- `npm test` — **751/751 pass** (748 pre-existing + 3 new `onBehalfOf` tests)

## Review tier

`low-risk` — single subdir, no auth/schema/infra impact, ~10 LOC core, full backward compat.
ReviewBot `codex-review` optional; @yujiawei / @Jerry-Xin formal Approve required per Titan workflow.

Fixes #34
