### PR TITLE
feat(openclaw-channel-octo): install via ClawHub (clawhub:octo) with legacy npm cleanup

### DIFF
--- a/openclaw-channel-octo/README.md
+++ b/openclaw-channel-octo/README.md
@@ -35,7 +35,8 @@ npx -y openclaw-channel-octo bind \
 `install` flags:
 
 - `--force`: reinstall even if already installed
-- `--dev`: install the `@dev` dist-tag instead of `@latest`
+- `--from <spec>`: install from a local tarball or alternate `openclaw plugins install` spec (pre-publish local testing)
+- `--dev` / `--next`: deprecated in v2.0.0+ (ClawHub installs use a single channel; use `--from` for pre-release testing)
 
 ## CLI Commands
 

--- a/openclaw-channel-octo/cli/doctor.ts
+++ b/openclaw-channel-octo/cli/doctor.ts
@@ -183,32 +183,28 @@ export async function runDoctorChecks(params: {
         detail: `${versionLabel}${sourceNote}`,
       });
     } else if (fix) {
-      // Not installed (or broken/partial). Use detectScenario() for precise fix.
+      // Not installed (or broken/partial). Defer to runInstall for full
+      // scenario handling — it covers legacy-to-octo / rebrand / legacy /
+      // deadlock / broken / fresh with the correct CLAWHUB_INSTALL_SPEC
+      // and transactional rollback. Doctor used to inline a partial subset
+      // (only legacy/deadlock/broken) and passed PLUGIN_ID as install spec,
+      // which broke after PLUGIN_ID's semantics changed from npm name to
+      // ClawHub plugin id "octo".
       try {
-        const scenario = detectScenario();
-        if (scenario === "legacy") {
-          const { runLegacyMigrationForUpdate } = await import("./install.js");
-          runLegacyMigrationForUpdate(PLUGIN_ID, true);
-        } else if (scenario === "deadlock") {
-          const { runDeadlockRepairForUpdate } = await import("./install.js");
-          runDeadlockRepairForUpdate(PLUGIN_ID, true);
-        } else if (scenario === "broken") {
-          cleanupBrokenInstall();
-          pluginsInstall(PLUGIN_ID, true);
-        } else {
-          pluginsInstall(PLUGIN_ID, true);
-        }
+        const { runInstall } = await import("./install.js");
+        await runInstall({ force: true });
         pluginState = resolvePluginState(PLUGIN_ID);
         checks.push({
           name: "Plugin installed",
           status: "FIXED",
           detail: `Installed v${pluginState.version ?? "unknown"}`,
         });
-      } catch {
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : String(err);
         checks.push({
           name: "Plugin installed",
           status: "FAIL",
-          detail: "Not installed (auto-install failed)",
+          detail: `Auto-install failed: ${errMsg}`,
         });
         return summarize(checks);
       }

--- a/openclaw-channel-octo/cli/doctor.ts
+++ b/openclaw-channel-octo/cli/doctor.ts
@@ -238,7 +238,7 @@ export async function runDoctorChecks(params: {
           name: "Plugin enabled",
           status: "FAIL",
           detail:
-            "No (auto-fix failed; run `openclaw plugins enable ${PLUGIN_ID}`)",
+            `No (auto-fix failed; run \`openclaw plugins enable ${PLUGIN_ID}\`)`,
         });
       }
     } else {
@@ -247,7 +247,7 @@ export async function runDoctorChecks(params: {
         status: "WARN",
         detail:
           "No — installed but disabled. Run `openclaw-channel-octo doctor --fix` " +
-          "or `openclaw plugins enable ${PLUGIN_ID}`.",
+          `or \`openclaw plugins enable ${PLUGIN_ID}\`.`,
       });
     }
   }

--- a/openclaw-channel-octo/cli/index.ts
+++ b/openclaw-channel-octo/cli/index.ts
@@ -14,7 +14,7 @@ import {
 } from "./doctor.js";
 import { runUninstall } from "./uninstall.js";
 import { runRemoveAccount } from "./remove-account.js";
-import { ensureOpenClawCompat, PLUGIN_ID } from "./utils.js";
+import { ensureOpenClawCompat, NPM_PACKAGE_NAME, PLUGIN_ID } from "./utils.js";
 import { getOpenClawVersionStrict, resolvePluginState } from "./openclaw-cli.js";
 import { PLUGIN_VERSION } from "../src/version.js";
 
@@ -55,8 +55,9 @@ program
 
     console.log(`${b}openclaw-channel-octo-cli:${r} ${g}${PLUGIN_VERSION}${r}`);
     console.log(`${b}openclaw:${r} ${g}${openclawVersion}${r}`);
-    console.log(`${b}openclaw-channel-octo:${r} ${g}${installedVersion}${r}`);
-    console.log(`${b}plugin package:${r} ${g}${PLUGIN_ID}${r}`);
+    console.log(`${b}installed plugin id:${r} ${g}${PLUGIN_ID}${r} (ClawHub)`);
+    console.log(`${b}installed plugin version:${r} ${g}${installedVersion}${r}`);
+    console.log(`${b}npm package:${r} ${g}${NPM_PACKAGE_NAME}${r}`);
     console.log();
     console.log(`${b}Environment:${r}`);
     console.log(`${b}OS:${r} ${g}${process.platform} ${process.arch}${r}`);
@@ -69,10 +70,14 @@ program
   .command("install")
   .description("Install or update the Octo plugin")
   .option("--force", "Force reinstall", false)
-  .option("--next", "Install the @next pre-release dist-tag (use during rc/beta cycles)", false)
+  .option(
+    "--next",
+    "[v2.0.0+ no-op] Previously selected npm @next dist-tag. ClawHub installs use a single channel; use --from <tarball> for pre-release testing.",
+    false,
+  )
   .option(
     "--from <spec>",
-    "Override install spec (tarball path or alternate npm spec). Pre-publish local testing.",
+    "Override install spec (tarball path or alternate `openclaw plugins install` spec). Pre-publish local testing.",
   )
   .addOption(new Option("--dev").hideHelp().default(false))
   .action(async (opts) => {
@@ -88,7 +93,11 @@ program
 program
   .command("update")
   .description("Update the Octo plugin (alias for install)")
-  .option("--next", "Update to the @next pre-release dist-tag", false)
+  .option(
+    "--next",
+    "[v2.0.0+ no-op] Previously selected npm @next dist-tag. ClawHub installs use a single channel; use `install --from <tarball>` for pre-release testing.",
+    false,
+  )
   .addOption(new Option("--dev").hideHelp().default(false))
   .action(async (opts) => {
     await runUpdate({ dev: opts.dev, next: opts.next });

--- a/openclaw-channel-octo/cli/install-migration.test.ts
+++ b/openclaw-channel-octo/cli/install-migration.test.ts
@@ -527,7 +527,7 @@ describe("runInstall — rebrand scenario (openclaw-channel-dmwork → octo)", (
         state.cfg.plugins.entries["octo"] = { enabled: true };
         state.cfg.plugins.installs["octo"] = { source: "npm", version: "1.0.0" };
         state.extDirs.add("octo");
-        inspectMap["openclaw-channel-octo"] = { plugin: { id: "octo", version: "1.0.0", enabled: true } };
+        inspectMap["octo"] = { plugin: { id: "octo", version: "1.0.0", enabled: true } };
         return "";
       }
       if (a[0] === "plugins" && (a[1] === "enable" || a[1] === "disable")) return "";
@@ -702,7 +702,7 @@ describe("runInstall — legacy-to-octo scenario (very-legacy 'dmwork' → octo)
         state.cfg.plugins.entries["octo"] = { enabled: true };
         state.cfg.plugins.installs["octo"] = { source: "npm", version: "1.0.0" };
         state.extDirs.add("octo");
-        inspectMap["openclaw-channel-octo"] = { plugin: { id: "octo", version: "1.0.0", enabled: true } };
+        inspectMap["octo"] = { plugin: { id: "octo", version: "1.0.0", enabled: true } };
         return "";
       }
       if (a[0] === "plugins" && a[1] === "uninstall") {
@@ -772,7 +772,7 @@ describe("runInstall — legacy-to-octo scenario (very-legacy 'dmwork' → octo)
         state.cfg.plugins.entries["octo"] = { enabled: true };
         state.cfg.plugins.installs["octo"] = { source: "npm", version: "1.0.0" };
         state.extDirs.add("octo");
-        inspectMap["openclaw-channel-octo"] = { plugin: { id: "octo", version: "1.0.0", enabled: true } };
+        inspectMap["octo"] = { plugin: { id: "octo", version: "1.0.0", enabled: true } };
         return "";
       }
       if (a[0] === "plugins" && a[1] === "uninstall") {
@@ -860,7 +860,7 @@ describe("runInstall — deadlock scenario (channels.octo without plugin)", () =
         state.cfg.plugins.entries["octo"] = { enabled: true };
         state.cfg.plugins.installs["octo"] = { source: "npm", version: "1.0.0" };
         state.extDirs.add("octo");
-        inspectMap["openclaw-channel-octo"] = { plugin: { id: "octo", version: "1.0.0", enabled: true } };
+        inspectMap["octo"] = { plugin: { id: "octo", version: "1.0.0", enabled: true } };
         return "";
       }
       if (a[0] === "plugins" && (a[1] === "enable" || a[1] === "disable")) return "";

--- a/openclaw-channel-octo/cli/install-migration.test.ts
+++ b/openclaw-channel-octo/cli/install-migration.test.ts
@@ -2,12 +2,13 @@
  * Phase B migration tests.
  *
  * Two scenarios share the same runMigration() implementation:
- *   - rebrand:        openclaw-channel-dmwork → openclaw-channel-octo
- *   - legacy-to-octo: very-legacy "dmwork" plugin id → openclaw-channel-octo
+ *   - rebrand:        openclaw-channel-dmwork → ClawHub octo (plugin id "octo")
+ *   - legacy-to-octo: very-legacy "dmwork" plugin id → ClawHub octo
  *
- * Both transform channels.dmwork → channels.octo and rewrite bindings'
- * match.channel from "dmwork" to "octo". Tests assert the command sequence
- * (via execFileSync mock) and final config state (via fs writeFileSync mock).
+ * Both install via CLAWHUB_INSTALL_SPEC ("clawhub:octo"), transform
+ * channels.dmwork → channels.octo, and rewrite bindings' match.channel from
+ * "dmwork" to "octo". Tests assert the command sequence (via execFileSync
+ * mock) and final config state (via fs writeFileSync mock).
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";

--- a/openclaw-channel-octo/cli/install-migration.test.ts
+++ b/openclaw-channel-octo/cli/install-migration.test.ts
@@ -208,25 +208,25 @@ describe("runInstall — rebrand scenario (openclaw-channel-dmwork → octo)", (
     const origExecImpl = mockExecFileSync.getMockImplementation();
     mockExecFileSync.mockImplementation((cmd: any, args: any) => {
       const a = args as string[];
-      if (a[0] === "plugins" && a[1] === "install" && a[2]?.startsWith("openclaw-channel-octo")) {
+      if (a[0] === "plugins" && a[1] === "install" && a[2] === "clawhub:octo") {
         // Side effect: octo install populates entries/installs/dir
         state.cfg.plugins ??= {};
         state.cfg.plugins.entries ??= {};
-        state.cfg.plugins.entries["openclaw-channel-octo"] = { enabled: true };
+        state.cfg.plugins.entries["octo"] = { enabled: true };
         state.cfg.plugins.installs ??= {};
-        state.cfg.plugins.installs["openclaw-channel-octo"] = { source: "npm", version: "1.0.0" };
+        state.cfg.plugins.installs["octo"] = { source: "npm", version: "1.0.0" };
         state.cfg.plugins.allow ??= [];
-        if (!state.cfg.plugins.allow.includes("openclaw-channel-octo")) {
-          state.cfg.plugins.allow.push("openclaw-channel-octo");
+        if (!state.cfg.plugins.allow.includes("octo")) {
+          state.cfg.plugins.allow.push("octo");
         }
-        state.extDirs.add("openclaw-channel-octo");
+        state.extDirs.add("octo");
         return "";
       }
       // After install, inspect octo should succeed too — re-dispatch via opts
-      if (a[0] === "plugins" && a[1] === "inspect" && a[2] === "openclaw-channel-octo") {
+      if (a[0] === "plugins" && a[1] === "inspect" && a[2] === "octo") {
         if (state.cfg.plugins?.entries?.["openclaw-channel-octo"]) {
           return JSON.stringify({
-            plugin: { id: "openclaw-channel-octo", version: "1.0.0", enabled: true },
+            plugin: { id: "octo", version: "1.0.0", enabled: true },
           });
         }
       }
@@ -239,8 +239,8 @@ describe("runInstall — rebrand scenario (openclaw-channel-dmwork → octo)", (
     const ops = calledOps();
     // Sequence: disable legacy → install octo → enable octo → uninstall legacy
     const disableIdx = ops.findIndex((o) => /^plugins disable openclaw-channel-dmwork$/.test(o));
-    const installIdx = ops.findIndex((o) => /^plugins install openclaw-channel-octo/.test(o));
-    const enableIdx = ops.findIndex((o) => /^plugins enable openclaw-channel-octo$/.test(o));
+    const installIdx = ops.findIndex((o) => /^plugins install clawhub:octo/.test(o));
+    const enableIdx = ops.findIndex((o) => /^plugins enable octo$/.test(o));
     const uninstallIdx = ops.findIndex((o) => /^plugins uninstall openclaw-channel-dmwork/.test(o));
 
     expect(disableIdx).toBeGreaterThanOrEqual(0);
@@ -281,15 +281,15 @@ describe("runInstall — rebrand scenario (openclaw-channel-dmwork → octo)", (
     const origExecImpl = mockExecFileSync.getMockImplementation();
     mockExecFileSync.mockImplementation((cmd: any, args: any) => {
       const a = args as string[];
-      if (a[0] === "plugins" && a[1] === "install" && a[2]?.startsWith("openclaw-channel-octo")) {
-        state.cfg.plugins.entries["openclaw-channel-octo"] = { enabled: true };
-        state.cfg.plugins.installs["openclaw-channel-octo"] = { source: "npm", version: "1.0.0" };
-        state.extDirs.add("openclaw-channel-octo");
+      if (a[0] === "plugins" && a[1] === "install" && a[2] === "clawhub:octo") {
+        state.cfg.plugins.entries["octo"] = { enabled: true };
+        state.cfg.plugins.installs["octo"] = { source: "npm", version: "1.0.0" };
+        state.extDirs.add("octo");
         return "";
       }
-      if (a[0] === "plugins" && a[1] === "inspect" && a[2] === "openclaw-channel-octo"
+      if (a[0] === "plugins" && a[1] === "inspect" && a[2] === "octo"
           && state.cfg.plugins?.entries?.["openclaw-channel-octo"]) {
-        return JSON.stringify({ plugin: { id: "openclaw-channel-octo", version: "1.0.0", enabled: true } });
+        return JSON.stringify({ plugin: { id: "octo", version: "1.0.0", enabled: true } });
       }
       return origExecImpl!(cmd, args, undefined as any) as any;
     });
@@ -308,21 +308,21 @@ describe("runInstall — rebrand scenario (openclaw-channel-dmwork → octo)", (
     const state = setupFs({
       cfg: {
         plugins: {
-          entries: { "openclaw-channel-octo": { enabled: true } },
-          installs: { "openclaw-channel-octo": { source: "npm", version: "1.0.0" } },
+          entries: { "octo": { enabled: true } },
+          installs: { "octo": { source: "clawhub", version: "1.0.0" } },
         },
         channels: {
           octo: { accounts: { b1: { botToken: "bf_b1" } } },
         },
         bindings: [{ agentId: "a1", match: { channel: "octo", accountId: "b1" } }],
       },
-      extDirs: ["openclaw-channel-octo"],
+      extDirs: ["octo"],
     });
     await applyFsMocks(state);
 
     mockOpenclawCli({
       inspect: {
-        "openclaw-channel-octo": { plugin: { id: "openclaw-channel-octo", version: "1.0.0", enabled: true } },
+        "octo": { plugin: { id: "octo", version: "1.0.0", enabled: true } },
       },
     });
 
@@ -347,13 +347,13 @@ describe("runInstall — rebrand scenario (openclaw-channel-dmwork → octo)", (
         },
         bindings: [{ agentId: "a1", match: { channel: "dmwork", accountId: "b1" } }],
       },
-      extDirs: ["openclaw-channel-octo"],
+      extDirs: ["octo"],
     });
     await applyFsMocks(state);
 
     mockOpenclawCli({
       inspect: {
-        "openclaw-channel-octo": { plugin: { id: "openclaw-channel-octo", version: "1.0.0", enabled: true } },
+        "octo": { plugin: { id: "octo", version: "1.0.0", enabled: true } },
       },
     });
 
@@ -362,7 +362,7 @@ describe("runInstall — rebrand scenario (openclaw-channel-dmwork → octo)", (
 
     const ops = calledOps();
     // pluginsInstall should NOT be called (octo already healthy → migration skips reinstall)
-    const installCalls = ops.filter((o) => /^plugins install openclaw-channel-octo/.test(o));
+    const installCalls = ops.filter((o) => /^plugins install clawhub:octo/.test(o));
     expect(installCalls.length).toBe(0);
     // Data migration still happens
     expect(state.cfg.channels?.octo?.accounts?.b1?.botToken).toBe("bf_b1");
@@ -393,7 +393,7 @@ describe("runInstall — rebrand scenario (openclaw-channel-dmwork → octo)", (
     mockOpenclawCli({
       inspect: {
         "openclaw-channel-dmwork": { plugin: { id: "openclaw-channel-dmwork", version: "0.6.4", enabled: true } },
-        "openclaw-channel-octo": { plugin: { id: "openclaw-channel-octo", version: "1.0.0", enabled: true } },
+        "octo": { plugin: { id: "octo", version: "1.0.0", enabled: true } },
       },
     });
 
@@ -435,15 +435,15 @@ describe("runInstall — rebrand scenario (openclaw-channel-dmwork → octo)", (
     const origImpl = mockExecFileSync.getMockImplementation();
     mockExecFileSync.mockImplementation((cmd: any, args: any) => {
       const a = args as string[];
-      if (a[0] === "plugins" && a[1] === "install" && a[2]?.startsWith("openclaw-channel-octo")) {
-        state.cfg.plugins.entries["openclaw-channel-octo"] = { enabled: true };
-        state.cfg.plugins.installs["openclaw-channel-octo"] = { source: "npm", version: "1.0.0" };
-        state.extDirs.add("openclaw-channel-octo");
+      if (a[0] === "plugins" && a[1] === "install" && a[2] === "clawhub:octo") {
+        state.cfg.plugins.entries["octo"] = { enabled: true };
+        state.cfg.plugins.installs["octo"] = { source: "npm", version: "1.0.0" };
+        state.extDirs.add("octo");
         return "";
       }
-      if (a[0] === "plugins" && a[1] === "inspect" && a[2] === "openclaw-channel-octo"
+      if (a[0] === "plugins" && a[1] === "inspect" && a[2] === "octo"
           && state.cfg.plugins?.entries?.["openclaw-channel-octo"]) {
-        return JSON.stringify({ plugin: { id: "openclaw-channel-octo", version: "1.0.0", enabled: true } });
+        return JSON.stringify({ plugin: { id: "octo", version: "1.0.0", enabled: true } });
       }
       return origImpl!(cmd, args, undefined as any) as any;
     });
@@ -475,7 +475,7 @@ describe("runInstall — rebrand scenario (openclaw-channel-dmwork → octo)", (
       inspect: {
         "openclaw-channel-dmwork": { plugin: { id: "openclaw-channel-dmwork", version: "0.6.4", enabled: true } },
       },
-      failOn: { match: /^plugins install openclaw-channel-octo/ },
+      failOn: { match: /^plugins install clawhub:octo/ },
     });
 
     const { runInstall } = await loadInstall();
@@ -483,7 +483,7 @@ describe("runInstall — rebrand scenario (openclaw-channel-dmwork → octo)", (
 
     const ops = calledOps();
     // Rollback: pluginsEnable(legacy) called after install failure
-    const installFailIdx = ops.findIndex((o) => /^plugins install openclaw-channel-octo/.test(o));
+    const installFailIdx = ops.findIndex((o) => /^plugins install clawhub:octo/.test(o));
     const reEnableIdx = ops.findIndex(
       (o, i) => i > installFailIdx && /^plugins enable openclaw-channel-dmwork$/.test(o),
     );
@@ -523,11 +523,11 @@ describe("runInstall — rebrand scenario (openclaw-channel-dmwork → octo)", (
         e.stderr = "EBUSY";
         throw e;
       }
-      if (a[0] === "plugins" && a[1] === "install" && a[2]?.startsWith("openclaw-channel-octo")) {
-        state.cfg.plugins.entries["openclaw-channel-octo"] = { enabled: true };
-        state.cfg.plugins.installs["openclaw-channel-octo"] = { source: "npm", version: "1.0.0" };
-        state.extDirs.add("openclaw-channel-octo");
-        inspectMap["openclaw-channel-octo"] = { plugin: { id: "openclaw-channel-octo", version: "1.0.0", enabled: true } };
+      if (a[0] === "plugins" && a[1] === "install" && a[2] === "clawhub:octo") {
+        state.cfg.plugins.entries["octo"] = { enabled: true };
+        state.cfg.plugins.installs["octo"] = { source: "npm", version: "1.0.0" };
+        state.extDirs.add("octo");
+        inspectMap["openclaw-channel-octo"] = { plugin: { id: "octo", version: "1.0.0", enabled: true } };
         return "";
       }
       if (a[0] === "plugins" && (a[1] === "enable" || a[1] === "disable")) return "";
@@ -543,7 +543,7 @@ describe("runInstall — rebrand scenario (openclaw-channel-dmwork → octo)", (
     expect(state.cfg.channels?.octo?.accounts?.b1?.botToken).toBe("bf_b1");
     expect(state.cfg.bindings[0].match.channel).toBe("octo");
     // octo install still in place (no rollback)
-    expect(state.cfg.plugins.entries["openclaw-channel-octo"]?.enabled).toBe(true);
+    expect(state.cfg.plugins.entries["octo"]?.enabled).toBe(true);
   });
 
   it("4.20 fallback: unknown command for plugins disable/enable falls back to cfg edit", async () => {
@@ -571,15 +571,15 @@ describe("runInstall — rebrand scenario (openclaw-channel-dmwork → octo)", (
     const origImpl = mockExecFileSync.getMockImplementation();
     mockExecFileSync.mockImplementation((cmd: any, args: any) => {
       const a = args as string[];
-      if (a[0] === "plugins" && a[1] === "install" && a[2]?.startsWith("openclaw-channel-octo")) {
-        state.cfg.plugins.entries["openclaw-channel-octo"] = { enabled: true };
-        state.cfg.plugins.installs["openclaw-channel-octo"] = { source: "npm", version: "1.0.0" };
-        state.extDirs.add("openclaw-channel-octo");
+      if (a[0] === "plugins" && a[1] === "install" && a[2] === "clawhub:octo") {
+        state.cfg.plugins.entries["octo"] = { enabled: true };
+        state.cfg.plugins.installs["octo"] = { source: "npm", version: "1.0.0" };
+        state.extDirs.add("octo");
         return "";
       }
-      if (a[0] === "plugins" && a[1] === "inspect" && a[2] === "openclaw-channel-octo"
+      if (a[0] === "plugins" && a[1] === "inspect" && a[2] === "octo"
           && state.cfg.plugins?.entries?.["openclaw-channel-octo"]) {
-        return JSON.stringify({ plugin: { id: "openclaw-channel-octo", version: "1.0.0", enabled: true } });
+        return JSON.stringify({ plugin: { id: "octo", version: "1.0.0", enabled: true } });
       }
       return origImpl!(cmd, args, undefined as any) as any;
     });
@@ -592,7 +592,7 @@ describe("runInstall — rebrand scenario (openclaw-channel-dmwork → octo)", (
     expect(state.cfg.plugins.entries["openclaw-channel-dmwork"]).toBeUndefined();
     expect(state.cfg.plugins.installs?.["openclaw-channel-dmwork"]).toBeUndefined();
     expect(state.extDirs.has("openclaw-channel-dmwork")).toBe(false);
-    expect(state.cfg.plugins.entries["openclaw-channel-octo"]?.enabled).toBe(true);
+    expect(state.cfg.plugins.entries["octo"]?.enabled).toBe(true);
     expect(state.cfg.channels?.octo?.accounts?.b1?.botToken).toBe("bf_b1");
   });
 
@@ -628,16 +628,16 @@ describe("runInstall — rebrand scenario (openclaw-channel-dmwork → octo)", (
         if (!r) { const e: any = new Error("not found"); e.stderr = "not found"; throw e; }
         return JSON.stringify(r);
       }
-      if (a[0] === "plugins" && a[1] === "install" && a[2]?.startsWith("openclaw-channel-octo")) {
-        state.cfg.plugins.entries["openclaw-channel-octo"] = { enabled: true };
-        state.cfg.plugins.installs["openclaw-channel-octo"] = { source: "npm", version: "1.0.0" };
-        state.extDirs.add("openclaw-channel-octo");
-        inspectMap["openclaw-channel-octo"] = { plugin: { id: "openclaw-channel-octo", version: "1.0.0", enabled: true } };
+      if (a[0] === "plugins" && a[1] === "install" && a[2] === "clawhub:octo") {
+        state.cfg.plugins.entries["octo"] = { enabled: true };
+        state.cfg.plugins.installs["octo"] = { source: "clawhub", version: "1.0.0" };
+        state.extDirs.add("octo");
+        inspectMap["octo"] = { plugin: { id: "octo", version: "1.0.0", enabled: true } };
         return "";
       }
       // pluginsEnable(octo) throws an UNEXPECTED error (not unknown-command,
       // not not-installed) — should propagate and trigger rollback.
-      if (op === "plugins enable openclaw-channel-octo") {
+      if (op === "plugins enable octo") {
         const e: any = new Error("permission denied");
         e.stderr = "permission denied";
         throw e;
@@ -698,11 +698,11 @@ describe("runInstall — legacy-to-octo scenario (very-legacy 'dmwork' → octo)
         if (!r) { const e: any = new Error("not found"); e.stderr = "not found"; throw e; }
         return JSON.stringify(r);
       }
-      if (a[0] === "plugins" && a[1] === "install" && a[2]?.startsWith("openclaw-channel-octo")) {
-        state.cfg.plugins.entries["openclaw-channel-octo"] = { enabled: true };
-        state.cfg.plugins.installs["openclaw-channel-octo"] = { source: "npm", version: "1.0.0" };
-        state.extDirs.add("openclaw-channel-octo");
-        inspectMap["openclaw-channel-octo"] = { plugin: { id: "openclaw-channel-octo", version: "1.0.0", enabled: true } };
+      if (a[0] === "plugins" && a[1] === "install" && a[2] === "clawhub:octo") {
+        state.cfg.plugins.entries["octo"] = { enabled: true };
+        state.cfg.plugins.installs["octo"] = { source: "npm", version: "1.0.0" };
+        state.extDirs.add("octo");
+        inspectMap["openclaw-channel-octo"] = { plugin: { id: "octo", version: "1.0.0", enabled: true } };
         return "";
       }
       if (a[0] === "plugins" && a[1] === "uninstall") {
@@ -768,11 +768,11 @@ describe("runInstall — legacy-to-octo scenario (very-legacy 'dmwork' → octo)
         if (!r) { const e: any = new Error("not found"); e.stderr = "not found"; throw e; }
         return JSON.stringify(r);
       }
-      if (a[0] === "plugins" && a[1] === "install" && a[2]?.startsWith("openclaw-channel-octo")) {
-        state.cfg.plugins.entries["openclaw-channel-octo"] = { enabled: true };
-        state.cfg.plugins.installs["openclaw-channel-octo"] = { source: "npm", version: "1.0.0" };
-        state.extDirs.add("openclaw-channel-octo");
-        inspectMap["openclaw-channel-octo"] = { plugin: { id: "openclaw-channel-octo", version: "1.0.0", enabled: true } };
+      if (a[0] === "plugins" && a[1] === "install" && a[2] === "clawhub:octo") {
+        state.cfg.plugins.entries["octo"] = { enabled: true };
+        state.cfg.plugins.installs["octo"] = { source: "npm", version: "1.0.0" };
+        state.extDirs.add("octo");
+        inspectMap["openclaw-channel-octo"] = { plugin: { id: "octo", version: "1.0.0", enabled: true } };
         return "";
       }
       if (a[0] === "plugins" && a[1] === "uninstall") {
@@ -853,14 +853,14 @@ describe("runInstall — deadlock scenario (channels.octo without plugin)", () =
         if (!r) { const e: any = new Error("not found"); e.stderr = "not found"; throw e; }
         return JSON.stringify(r);
       }
-      if (a[0] === "plugins" && a[1] === "install" && a[2]?.startsWith("openclaw-channel-octo")) {
+      if (a[0] === "plugins" && a[1] === "install" && a[2] === "clawhub:octo") {
         // Side effect: at this point, channels.octo and bindings(channel=octo)
         // must ALREADY be removed (asserted below). pluginsInstall populates
         // plugin records.
-        state.cfg.plugins.entries["openclaw-channel-octo"] = { enabled: true };
-        state.cfg.plugins.installs["openclaw-channel-octo"] = { source: "npm", version: "1.0.0" };
-        state.extDirs.add("openclaw-channel-octo");
-        inspectMap["openclaw-channel-octo"] = { plugin: { id: "openclaw-channel-octo", version: "1.0.0", enabled: true } };
+        state.cfg.plugins.entries["octo"] = { enabled: true };
+        state.cfg.plugins.installs["octo"] = { source: "npm", version: "1.0.0" };
+        state.extDirs.add("octo");
+        inspectMap["openclaw-channel-octo"] = { plugin: { id: "octo", version: "1.0.0", enabled: true } };
         return "";
       }
       if (a[0] === "plugins" && (a[1] === "enable" || a[1] === "disable")) return "";
@@ -878,7 +878,7 @@ describe("runInstall — deadlock scenario (channels.octo without plugin)", () =
     const origImpl = mockExecFileSync.getMockImplementation();
     mockExecFileSync.mockImplementation((cmd: any, args: any) => {
       const a = args as string[];
-      if (a[0] === "plugins" && a[1] === "install" && a[2]?.startsWith("openclaw-channel-octo")) {
+      if (a[0] === "plugins" && a[1] === "install" && a[2] === "clawhub:octo") {
         // At install time, neither channels.octo nor bindings(channel=octo)
         // should be in cfg yet — they were temporarily removed.
         stateAtInstall.hadChannel = Boolean(state.cfg.channels?.octo);
@@ -905,6 +905,6 @@ describe("runInstall — deadlock scenario (channels.octo without plugin)", () =
     expect(restoredBindings[0].match.accountId).toBe("mybot");
 
     // Assertion 3: plugin is now installed and enabled
-    expect(state.cfg.plugins.entries["openclaw-channel-octo"]?.enabled).toBe(true);
+    expect(state.cfg.plugins.entries["octo"]?.enabled).toBe(true);
   });
 });

--- a/openclaw-channel-octo/cli/install.test.ts
+++ b/openclaw-channel-octo/cli/install.test.ts
@@ -481,4 +481,95 @@ describe("runInstall — update scenario", () => {
     // Gateway must have been restarted (didChange = true via cleanup)
     expect(didCallGatewayRestart(calls)).toBe(true);
   });
+
+  it("legacy npm cleanup preserves channels.octo + bindings(channel=octo) (P0-2 regression)", async () => {
+    // PR #37 review P0-2: `openclaw plugins uninstall openclaw-channel-octo`
+    // ALSO removes channels.octo as a side effect (both plugins own channel
+    // id "octo"). Without save/restore, user bot accounts vanish after the
+    // supposedly-successful migration.
+    //
+    // This test simulates that side effect: the uninstall mock writes a cfg
+    // with channels.octo removed. The fix saves channels.octo + bindings(octo)
+    // before uninstall and restores them after, so the final cfg must still
+    // contain the user's bot account + binding.
+    const fs = await import("node:fs");
+    const mockReadFileSync = vi.mocked(fs.readFileSync);
+    const mockWriteFileSync = vi.mocked(fs.writeFileSync);
+    const mockExistsSync = vi.mocked(fs.existsSync);
+
+    // Stateful cfg so save→uninstall(removes channels.octo)→restore round-trips.
+    const state: any = {
+      plugins: {
+        entries: {
+          "openclaw-channel-octo": { enabled: true },
+          octo: { enabled: true },
+        },
+        installs: {
+          "openclaw-channel-octo": { source: "npm", version: "1.0.0" },
+          octo: { source: "clawhub", version: "1.0.7" },
+        },
+        allow: ["openclaw-channel-octo", "octo"],
+      },
+      channels: {
+        octo: {
+          accounts: {
+            mybot: { botToken: "bf_user_secret", apiUrl: "https://im.example/api", name: "mybot" },
+          },
+        },
+      },
+      bindings: [
+        { agentId: "agent1", match: { channel: "octo", accountId: "mybot" } },
+      ],
+    };
+    mockReadFileSync.mockImplementation((path) => {
+      if (String(path).endsWith("openclaw.json")) return JSON.stringify(state);
+      return "{}";
+    });
+    mockWriteFileSync.mockImplementation((path: any, data: any) => {
+      const p = String(path);
+      if (p.endsWith("openclaw.json.tmp") || p.endsWith("openclaw.json")) {
+        try { Object.assign(state, JSON.parse(String(data))); } catch { /* ignore */ }
+      }
+    });
+    mockExistsSync.mockImplementation((path) => String(path).endsWith("extensions/octo"));
+
+    const { runInstall } = await loadInstall();
+
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const a = args as string[];
+      if (a[0] === "config" && a[1] === "file") return "/home/user/.openclaw/openclaw.json";
+      if (a[0] === "--version") return "OpenClaw 2026.5.7\n";
+      if (a[0] === "plugins" && a[1] === "inspect") {
+        const id = a[2];
+        if (id === "openclaw-channel-octo") {
+          return JSON.stringify({ plugin: { id: "openclaw-channel-octo", version: "1.0.0", enabled: true } });
+        }
+        return inspectDispatch(a, {
+          id: "octo", version: "1.0.7", latestVersion: "1.0.7", enabled: true,
+        });
+      }
+      // Simulate OpenClaw's side effect: uninstall removes channels.<channelId>.
+      // This is the bug that P0-2 protects against; the save/restore code in
+      // runInstall should keep the user's bot account alive across this.
+      if (a[0] === "plugins" && a[1] === "uninstall" && a[2] === "openclaw-channel-octo") {
+        delete state.channels?.octo;
+        state.bindings = (state.bindings ?? []).filter((b: any) => b?.match?.channel !== "octo");
+        return "";
+      }
+      if (a[0] === "plugins" && a[1] === "disable") return "";
+      if (a[0] === "gateway" && a[1] === "restart") return "";
+      return "";
+    });
+
+    await runInstall({ force: false, dev: false });
+
+    // P0-2 assertion: user's bot account survived the migration
+    expect(state.channels?.octo?.accounts?.mybot?.botToken).toBe("bf_user_secret");
+    expect(state.channels?.octo?.accounts?.mybot?.apiUrl).toBe("https://im.example/api");
+    // Binding also survived
+    expect(state.bindings).toHaveLength(1);
+    expect(state.bindings[0].match.channel).toBe("octo");
+    expect(state.bindings[0].match.accountId).toBe("mybot");
+    expect(state.bindings[0].agentId).toBe("agent1");
+  });
 });

--- a/openclaw-channel-octo/cli/install.test.ts
+++ b/openclaw-channel-octo/cli/install.test.ts
@@ -1,3 +1,23 @@
+/**
+ * runInstall — non-migration scenarios:
+ *   - update (already healthy, compare via openclaw plugins inspect --json)
+ *   - --force, --from, --dev / --next (deprecated warn + latest fallback)
+ *   - 4.20 hardening (plugins.allow self-heal)
+ *
+ * v2.0.0 changes vs v1.x:
+ *   - Plugin id is now "octo" (ClawHub plugin id), not "openclaw-channel-octo"
+ *   - Install spec is "clawhub:octo", not "openclaw-channel-octo"
+ *   - latest-version source: `openclaw plugins inspect octo --json` (via
+ *     OpenClaw's built-in ClawHub client) instead of `npm view ...@<tag>`
+ *   - --dev / --next are no-ops that warn + fall back to ClawHub @latest
+ *   - Entry-point cleanup of legacy npm `openclaw-channel-octo` plugin (deferred
+ *     until ClawHub install verifies healthy)
+ *
+ * Plugin id dispatch in mocks: `inspect openclaw-channel-octo` returns
+ * not-found by default so the legacy npm cleanup path no-ops; tests that
+ * exercise the cleanup path override this explicitly.
+ */
+
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { execFileSync } from "node:child_process";
 
@@ -20,24 +40,21 @@ vi.mock("node:fs", async (importOriginal) => {
 
 const mockExecFileSync = vi.mocked(execFileSync);
 
-// Helpers to mock module internals via execFileSync dispatch
-function mockOpenClawVersion(version: string) {
-  // openclaw --version returns version string
-  return version;
-}
-
 async function loadInstall() {
   vi.resetModules();
   return await import("./install.js");
 }
 
-// We test by observing which commands are executed via execFileSync
 function getCalledArgs(): string[][] {
   return mockExecFileSync.mock.calls.map((c) => c[1] as string[]);
 }
 
 function didCallPluginsInstall(calls: string[][]): boolean {
   return calls.some((args) => args[0] === "plugins" && args[1] === "install");
+}
+
+function didCallPluginsUpdate(calls: string[][]): boolean {
+  return calls.some((args) => args[0] === "plugins" && args[1] === "update");
 }
 
 function didCallGatewayRestart(calls: string[][]): boolean {
@@ -47,6 +64,20 @@ function didCallGatewayRestart(calls: string[][]): boolean {
 function pluginsInstallSpec(calls: string[][]): string | undefined {
   const call = calls.find((args) => args[0] === "plugins" && args[1] === "install");
   return call?.[2];
+}
+
+/**
+ * Default dispatch for `plugins inspect`. Returns octo plugin metadata when
+ * args[2] === "octo"; returns not-found for the legacy npm name so the entry
+ * cleanup path no-ops. Override per-test for cleanup-path scenarios.
+ */
+function inspectDispatch(args: string[], octoData: object): string {
+  const id = args[2];
+  if (id === "openclaw-channel-octo") {
+    throw new Error("Plugin not found: openclaw-channel-octo");
+  }
+  // Default (id === "octo" or empty): return octo metadata
+  return JSON.stringify({ plugin: octoData });
 }
 
 describe("runInstall — update scenario", () => {
@@ -59,16 +90,18 @@ describe("runInstall — update scenario", () => {
 
     mockExecFileSync.mockImplementation((_cmd, args) => {
       const a = args as string[];
-      // openclaw config file
       if (a[0] === "config" && a[1] === "file") return "/home/user/.openclaw/openclaw.json";
-      // openclaw --version
       if (a[0] === "--version") return "OpenClaw 2026.4.15\n";
-      // plugins inspect
       if (a[0] === "plugins" && a[1] === "inspect") {
-        return JSON.stringify({ plugin: { id: "openclaw-channel-octo", version: "0.6.0", enabled: true } });
+        // getLatestClawHubVersion (id=octo, --json) returns plugin.latestVersion;
+        // detectScenario inspect (id=octo) returns current plugin metadata.
+        return inspectDispatch(a, {
+          id: "octo",
+          version: "0.6.0",
+          latestVersion: "0.6.0",
+          enabled: true,
+        });
       }
-      // npm view (targetVersion)
-      if (a[0] === "view") return "0.6.0\n";
       return "";
     });
 
@@ -79,7 +112,7 @@ describe("runInstall — update scenario", () => {
     expect(didCallGatewayRestart(calls)).toBe(false);
   });
 
-  it("--force: installs without checking version, then restarts", async () => {
+  it("--force: installs with ClawHub spec, then restarts", async () => {
     const { runInstall } = await loadInstall();
 
     mockExecFileSync.mockImplementation((_cmd, args) => {
@@ -87,13 +120,14 @@ describe("runInstall — update scenario", () => {
       if (a[0] === "config" && a[1] === "file") return "/home/user/.openclaw/openclaw.json";
       if (a[0] === "--version") return "OpenClaw 2026.4.15\n";
       if (a[0] === "plugins" && a[1] === "inspect") {
-        return JSON.stringify({ plugin: { id: "openclaw-channel-octo", version: "0.6.0", enabled: true } });
+        return inspectDispatch(a, {
+          id: "octo",
+          version: "0.6.0",
+          latestVersion: "0.6.0",
+          enabled: true,
+        });
       }
-      // npm view should NOT be called for --force
-      if (a[0] === "view") throw new Error("npm view should not be called with --force");
-      // gateway restart
       if (a[0] === "gateway" && a[1] === "restart") return "";
-      // plugins install
       if (a[0] === "plugins" && a[1] === "install") return "";
       return "";
     });
@@ -102,11 +136,15 @@ describe("runInstall — update scenario", () => {
 
     const calls = getCalledArgs();
     expect(didCallPluginsInstall(calls)).toBe(true);
-    expect(pluginsInstallSpec(calls)).toBe("openclaw-channel-octo");
+    expect(pluginsInstallSpec(calls)).toBe("clawhub:octo");
     expect(didCallGatewayRestart(calls)).toBe(true);
   });
 
-  it("npm view fails: no install, no restart", async () => {
+  it("no latestVersion locally: delegates to `openclaw plugins update`", async () => {
+    // v2.0.0+: when inspect doesn't report latestVersion (e.g. older OpenClaw
+    // doesn't track ClawHub upstream), fall back to `openclaw plugins update`
+    // which queries ClawHub via OpenClaw's built-in client. If already latest,
+    // it's a no-op and we skip the gateway restart.
     const { runInstall } = await loadInstall();
 
     mockExecFileSync.mockImplementation((_cmd, args) => {
@@ -114,20 +152,32 @@ describe("runInstall — update scenario", () => {
       if (a[0] === "config" && a[1] === "file") return "/home/user/.openclaw/openclaw.json";
       if (a[0] === "--version") return "OpenClaw 2026.4.15\n";
       if (a[0] === "plugins" && a[1] === "inspect") {
-        return JSON.stringify({ plugin: { id: "openclaw-channel-octo", version: "0.6.0", enabled: true } });
+        // No latestVersion field → triggers the pluginsUpdate fallback path.
+        return inspectDispatch(a, {
+          id: "octo",
+          version: "0.6.0",
+          enabled: true,
+        });
       }
-      if (a[0] === "view") throw new Error("ENOTFOUND registry.npmjs.org");
+      if (a[0] === "plugins" && a[1] === "update") return "";
       return "";
     });
 
     await runInstall({ force: false, dev: false });
 
     const calls = getCalledArgs();
+    // Delegated to plugins update, not plugins install
     expect(didCallPluginsInstall(calls)).toBe(false);
+    expect(didCallPluginsUpdate(calls)).toBe(true);
+    // No change → no restart
     expect(didCallGatewayRestart(calls)).toBe(false);
   });
 
-  it("--dev: uses openclaw-channel-octo@dev spec", async () => {
+  it("--dev: warns then falls back to ClawHub @latest spec", async () => {
+    // v2.0.0+: --dev / --next are no-op flags that warn the user. ClawHub's
+    // release model differs from npm dist-tags; for pre-release testing use
+    // --from <tarball>.
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => { /* noop */ });
     const { runInstall } = await loadInstall();
 
     mockExecFileSync.mockImplementation((_cmd, args) => {
@@ -135,10 +185,13 @@ describe("runInstall — update scenario", () => {
       if (a[0] === "config" && a[1] === "file") return "/home/user/.openclaw/openclaw.json";
       if (a[0] === "--version") return "OpenClaw 2026.4.15\n";
       if (a[0] === "plugins" && a[1] === "inspect") {
-        return JSON.stringify({ plugin: { id: "openclaw-channel-octo", version: "0.6.0", enabled: true } });
+        return inspectDispatch(a, {
+          id: "octo",
+          version: "0.5.21",
+          latestVersion: "0.6.0",
+          enabled: true,
+        });
       }
-      // npm view openclaw-channel-octo@dev
-      if (a[0] === "view" && a[1]?.includes("@dev")) return "0.6.0-dev.abc123\n";
       if (a[0] === "plugins" && a[1] === "install") return "";
       if (a[0] === "gateway" && a[1] === "restart") return "";
       return "";
@@ -146,16 +199,18 @@ describe("runInstall — update scenario", () => {
 
     await runInstall({ force: false, dev: true });
 
+    expect(warnSpy.mock.calls.some((c) => String(c[0]).includes("--dev / --next"))).toBe(true);
+
     const calls = getCalledArgs();
     expect(didCallPluginsInstall(calls)).toBe(true);
-    expect(pluginsInstallSpec(calls)).toBe("openclaw-channel-octo@dev");
+    expect(pluginsInstallSpec(calls)).toBe("clawhub:octo");
     expect(didCallGatewayRestart(calls)).toBe(true);
+
+    warnSpy.mockRestore();
   });
 
-  it("--next: uses openclaw-channel-octo@next spec and queries @next dist-tag", async () => {
-    // Regression: without --next, `npx -y openclaw-channel-octo@next install`
-    // would have OpenClaw fetch @latest (defeating the smoke test). --next
-    // forces both the npm view query and the pluginsInstall spec to @next.
+  it("--next: warns then falls back to ClawHub @latest spec", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => { /* noop */ });
     const { runInstall } = await loadInstall();
 
     mockExecFileSync.mockImplementation((_cmd, args) => {
@@ -163,12 +218,12 @@ describe("runInstall — update scenario", () => {
       if (a[0] === "config" && a[1] === "file") return "/home/user/.openclaw/openclaw.json";
       if (a[0] === "--version") return "OpenClaw 2026.5.7\n";
       if (a[0] === "plugins" && a[1] === "inspect") {
-        return JSON.stringify({ plugin: { id: "openclaw-channel-octo", version: "1.0.0-rc.0", enabled: true } });
-      }
-      // npm view openclaw-channel-octo@next — must be queried (not @latest)
-      if (a[0] === "view" && a[1] === "openclaw-channel-octo@next") return "1.0.0-rc.1\n";
-      if (a[0] === "view" && a[1] === "openclaw-channel-octo@latest") {
-        throw new Error("must not query @latest when --next is set");
+        return inspectDispatch(a, {
+          id: "octo",
+          version: "1.0.0-rc.0",
+          latestVersion: "1.0.0",
+          enabled: true,
+        });
       }
       if (a[0] === "plugins" && a[1] === "install") return "";
       if (a[0] === "gateway" && a[1] === "restart") return "";
@@ -177,17 +232,17 @@ describe("runInstall — update scenario", () => {
 
     await runInstall({ force: false, dev: false, next: true });
 
+    expect(warnSpy.mock.calls.some((c) => String(c[0]).includes("--dev / --next"))).toBe(true);
+
     const calls = getCalledArgs();
     expect(didCallPluginsInstall(calls)).toBe(true);
-    // pluginsInstall must use @next spec, not bare
-    expect(pluginsInstallSpec(calls)).toBe("openclaw-channel-octo@next");
-    // npm view must query @next
-    const viewCalls = calls.filter((c) => c[0] === "view");
-    expect(viewCalls.some((c) => c[1] === "openclaw-channel-octo@next")).toBe(true);
+    expect(pluginsInstallSpec(calls)).toBe("clawhub:octo");
     expect(didCallGatewayRestart(calls)).toBe(true);
+
+    warnSpy.mockRestore();
   });
 
-  it("new version available: installs and restarts", async () => {
+  it("new version available: installs ClawHub spec and restarts", async () => {
     const { runInstall } = await loadInstall();
 
     mockExecFileSync.mockImplementation((_cmd, args) => {
@@ -195,9 +250,13 @@ describe("runInstall — update scenario", () => {
       if (a[0] === "config" && a[1] === "file") return "/home/user/.openclaw/openclaw.json";
       if (a[0] === "--version") return "OpenClaw 2026.4.15\n";
       if (a[0] === "plugins" && a[1] === "inspect") {
-        return JSON.stringify({ plugin: { id: "openclaw-channel-octo", version: "0.5.21", enabled: true } });
+        return inspectDispatch(a, {
+          id: "octo",
+          version: "0.5.21",
+          latestVersion: "0.6.0",
+          enabled: true,
+        });
       }
-      if (a[0] === "view") return "0.6.0\n";
       if (a[0] === "plugins" && a[1] === "install") return "";
       if (a[0] === "gateway" && a[1] === "restart") return "";
       return "";
@@ -207,7 +266,7 @@ describe("runInstall — update scenario", () => {
 
     const calls = getCalledArgs();
     expect(didCallPluginsInstall(calls)).toBe(true);
-    expect(pluginsInstallSpec(calls)).toBe("openclaw-channel-octo");
+    expect(pluginsInstallSpec(calls)).toBe("clawhub:octo");
     expect(didCallGatewayRestart(calls)).toBe(true);
   });
 
@@ -223,9 +282,9 @@ describe("runInstall — update scenario", () => {
       if (String(path).endsWith("openclaw.json")) {
         return JSON.stringify({
           plugins: {
-            entries: { "openclaw-channel-octo": { enabled: false } },
+            entries: { octo: { enabled: false } },
             installs: {
-              "openclaw-channel-octo": { source: "npm", version: "0.6.0" },
+              octo: { source: "clawhub", version: "0.6.0" },
             },
           },
         });
@@ -240,9 +299,13 @@ describe("runInstall — update scenario", () => {
       if (a[0] === "config" && a[1] === "file") return "/home/user/.openclaw/openclaw.json";
       if (a[0] === "--version") return "OpenClaw 2026.4.15\n";
       if (a[0] === "plugins" && a[1] === "inspect") {
-        return JSON.stringify({ plugin: { id: "openclaw-channel-octo", version: "0.6.0", enabled: false } });
+        return inspectDispatch(a, {
+          id: "octo",
+          version: "0.6.0",
+          latestVersion: "0.6.0",
+          enabled: false,
+        });
       }
-      if (a[0] === "view") return "0.6.0\n";
       return "";
     });
 
@@ -258,11 +321,11 @@ describe("runInstall — update scenario", () => {
     expect(enabledWrite).toBeDefined();
   });
 
-  it("--from <spec>: pluginsInstall uses the override spec, npm view is skipped", async () => {
+  it("--from <spec>: pluginsInstall uses the override spec, version check is skipped", async () => {
     // Pre-publish local testing affordance: --from ./tarball.tgz makes the
-    // pluginsInstall step receive the tarball path instead of the bare npm
-    // name (which would 404 before publish). Update-scenario version
-    // comparison is also bypassed (tarball install is unconditional).
+    // pluginsInstall step receive the tarball path instead of the bare
+    // ClawHub spec. Update-scenario version comparison is also bypassed
+    // (tarball install is unconditional).
     const { runInstall } = await loadInstall();
 
     mockExecFileSync.mockImplementation((_cmd, args) => {
@@ -270,22 +333,23 @@ describe("runInstall — update scenario", () => {
       if (a[0] === "config" && a[1] === "file") return "/home/user/.openclaw/openclaw.json";
       if (a[0] === "--version") return "OpenClaw 2026.5.7\n";
       if (a[0] === "plugins" && a[1] === "inspect") {
-        return JSON.stringify({ plugin: { id: "openclaw-channel-octo", version: "1.0.0-rc.0", enabled: true } });
-      }
-      // npm view must NOT be called when --from overrides the spec
-      if (a[0] === "view") {
-        throw new Error("npm view must not run when --from is set");
+        return inspectDispatch(a, {
+          id: "octo",
+          version: "1.0.0-rc.0",
+          latestVersion: "1.0.0-rc.0",
+          enabled: true,
+        });
       }
       if (a[0] === "plugins" && a[1] === "install") return "";
       if (a[0] === "gateway" && a[1] === "restart") return "";
       return "";
     });
 
-    await runInstall({ from: "./openclaw-channel-octo-1.0.0-rc.1.tgz" });
+    await runInstall({ from: "./openclaw-channel-octo-2.0.0-rc.1.tgz" });
 
     const calls = getCalledArgs();
     expect(didCallPluginsInstall(calls)).toBe(true);
-    expect(pluginsInstallSpec(calls)).toBe("./openclaw-channel-octo-1.0.0-rc.1.tgz");
+    expect(pluginsInstallSpec(calls)).toBe("./openclaw-channel-octo-2.0.0-rc.1.tgz");
     expect(didCallGatewayRestart(calls)).toBe(true);
   });
 
@@ -293,7 +357,7 @@ describe("runInstall — update scenario", () => {
     // OpenClaw 4.20 default config has no plugins.allow field at all.
     // Phase B's ensurePluginsAllow used to bail when the array was missing,
     // leaving 4.20 users with the "plugins.allow is empty" warn on every
-    // gateway restart. Now we create the array and add PLUGIN_ID.
+    // gateway restart. Now we create the array and add PLUGIN_ID (="octo").
     const fs = await import("node:fs");
     const mockReadFileSync = vi.mocked(fs.readFileSync);
     const mockWriteFileSync = vi.mocked(fs.writeFileSync);
@@ -301,9 +365,9 @@ describe("runInstall — update scenario", () => {
     // Track current state so writes are visible to subsequent reads.
     const state = {
       plugins: {
-        entries: { "openclaw-channel-octo": { enabled: true } },
+        entries: { octo: { enabled: true } },
         installs: {
-          "openclaw-channel-octo": { source: "npm", version: "0.6.0" },
+          octo: { source: "clawhub", version: "0.6.0" },
         },
         // NOTE: no `allow` field — simulating fresh 4.20 cfg
       },
@@ -326,9 +390,13 @@ describe("runInstall — update scenario", () => {
       if (a[0] === "config" && a[1] === "file") return "/home/user/.openclaw/openclaw.json";
       if (a[0] === "--version") return "OpenClaw 2026.4.20\n";
       if (a[0] === "plugins" && a[1] === "inspect") {
-        return JSON.stringify({ plugin: { id: "openclaw-channel-octo", version: "0.6.0", enabled: true } });
+        return inspectDispatch(a, {
+          id: "octo",
+          version: "0.6.0",
+          latestVersion: "0.6.0",
+          enabled: true,
+        });
       }
-      if (a[0] === "view") return "0.6.0\n"; // already at target → no install
       return "";
     });
 
@@ -337,6 +405,80 @@ describe("runInstall — update scenario", () => {
     // Final state must contain plugins.allow with octo in it
     const finalCfg = state as any;
     expect(Array.isArray(finalCfg.plugins.allow)).toBe(true);
-    expect(finalCfg.plugins.allow).toContain("openclaw-channel-octo");
+    expect(finalCfg.plugins.allow).toContain("octo");
+  });
+
+  it("legacy npm openclaw-channel-octo installed: cleanup after ClawHub install verifies healthy", async () => {
+    // v2.0.0 transactional cleanup: when entry-point detects the legacy npm
+    // `openclaw-channel-octo` plugin, defer uninstall until AFTER the ClawHub
+    // install completes + isHealthyInstall("octo") returns true. Prevents a
+    // broken state if ClawHub install fails midway.
+    const fs = await import("node:fs");
+    const mockReadFileSync = vi.mocked(fs.readFileSync);
+    const mockExistsSync = vi.mocked(fs.existsSync);
+
+    // Pretend the user has the legacy npm plugin: entries + installs both
+    // record "openclaw-channel-octo" + the ClawHub octo plugin is also healthy
+    // (extension dir + entries.octo + installs.octo all present).
+    mockReadFileSync.mockImplementation((path) => {
+      if (String(path).endsWith("openclaw.json")) {
+        return JSON.stringify({
+          plugins: {
+            entries: {
+              "openclaw-channel-octo": { enabled: true },
+              octo: { enabled: true },
+            },
+            installs: {
+              "openclaw-channel-octo": { source: "npm", version: "1.0.0" },
+              octo: { source: "clawhub", version: "1.0.7" },
+            },
+            allow: ["openclaw-channel-octo", "octo"],
+          },
+        });
+      }
+      return "{}";
+    });
+    mockExistsSync.mockImplementation((path) => {
+      // pretend extensions/octo exists so isHealthyInstall("octo") returns true
+      return String(path).endsWith("extensions/octo");
+    });
+
+    const { runInstall } = await loadInstall();
+
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const a = args as string[];
+      if (a[0] === "config" && a[1] === "file") return "/home/user/.openclaw/openclaw.json";
+      if (a[0] === "--version") return "OpenClaw 2026.5.7\n";
+      if (a[0] === "plugins" && a[1] === "inspect") {
+        const id = a[2];
+        if (id === "openclaw-channel-octo") {
+          // Legacy npm plugin IS installed (this is the cleanup-path scenario)
+          return JSON.stringify({
+            plugin: { id: "openclaw-channel-octo", version: "1.0.0", enabled: true },
+          });
+        }
+        return inspectDispatch(a, {
+          id: "octo",
+          version: "1.0.7",
+          latestVersion: "1.0.7",
+          enabled: true,
+        });
+      }
+      if (a[0] === "plugins" && a[1] === "uninstall") return "";
+      if (a[0] === "plugins" && a[1] === "disable") return "";
+      if (a[0] === "gateway" && a[1] === "restart") return "";
+      return "";
+    });
+
+    await runInstall({ force: false, dev: false });
+
+    const calls = getCalledArgs();
+    // Cleanup: legacy npm openclaw-channel-octo must be uninstalled
+    const uninstallCalls = calls.filter(
+      (a) => a[0] === "plugins" && a[1] === "uninstall" && a[2] === "openclaw-channel-octo",
+    );
+    expect(uninstallCalls.length).toBeGreaterThan(0);
+    // Gateway must have been restarted (didChange = true via cleanup)
+    expect(didCallGatewayRestart(calls)).toBe(true);
   });
 });

--- a/openclaw-channel-octo/cli/install.ts
+++ b/openclaw-channel-octo/cli/install.ts
@@ -168,7 +168,8 @@ export async function runInstall(opts: InstallOptions): Promise<void> {
       break;
     case "rebrand":
     case "legacy-warn":
-      // Phase B: full migration from openclaw-channel-dmwork to openclaw-channel-octo.
+      // Phase B: full migration from openclaw-channel-dmwork to the ClawHub
+      // octo plugin (plugin id = "octo", installed to ~/.openclaw/extensions/octo/).
       runRebrandMigration(spec, quiet, opts.force);
       didChange = true;
       break;
@@ -300,11 +301,12 @@ export async function runInstall(opts: InstallOptions): Promise<void> {
 // ---------------------------------------------------------------------------
 // Phase B: unified migration
 //
-// Both rebrand (openclaw-channel-dmwork → openclaw-channel-octo) and
-// legacy-to-octo (very-legacy "dmwork" → openclaw-channel-octo) go through
-// runMigration() with a different `legacyPluginId` parameter. Channel config
-// and bindings always live under the same legacy channel id ("dmwork"), so
-// data migration is identical.
+// Both rebrand (openclaw-channel-dmwork → ClawHub octo) and legacy-to-octo
+// (very-legacy "dmwork" → ClawHub octo) go through runMigration() with a
+// different `legacyPluginId` parameter. The target install spec is always
+// `CLAWHUB_INSTALL_SPEC` (= "clawhub:octo") and the post-install plugin id
+// is `PLUGIN_ID` (= "octo"). Channel config and bindings always live under
+// the same legacy channel id ("dmwork"), so data migration is identical.
 // ---------------------------------------------------------------------------
 
 interface MigrationContext {

--- a/openclaw-channel-octo/cli/install.ts
+++ b/openclaw-channel-octo/cli/install.ts
@@ -260,9 +260,21 @@ export async function runInstall(opts: InstallOptions): Promise<void> {
   //   - ClawHub install OK but uninstall fails → throw (loud), because leaving
   //     both plugins live causes duplicate channel "octo" registration. User
   //     must manually clean up: `openclaw plugins uninstall <NPM_PACKAGE_NAME>`.
+  //
+  // P0-2 (PR #37 review): `openclaw plugins uninstall` ALSO removes
+  // `channels.<channelId>` config as a side effect (see cli/uninstall.ts:2-4
+  // and cli/openclaw-cli.ts:647-650). Since both the legacy npm plugin and the
+  // new ClawHub plugin own `channel.id = "octo"`, uninstalling the legacy npm
+  // plugin will wipe `channels.octo` along with it — including any bot accounts
+  // the user just migrated. We save channels.octo + bindings(channel=octo)
+  // before uninstall and restore them after, mirroring the runMigration pattern.
   // ---------------------------------------------------------------------------
   if (oldNpmSnapshot.installed) {
     if (isHealthyInstall(PLUGIN_ID)) {
+      // SAVE channels.octo + bindings BEFORE uninstall (uninstall removes them)
+      const savedChannelConfig = saveChannelConfigFromFile(CHANNEL_ID);
+      const savedBindings = saveBindingsFromFile(CHANNEL_ID);
+
       if (oldNpmSnapshot.enabled === true) {
         try {
           pluginsDisable(NPM_PACKAGE_NAME);
@@ -270,6 +282,17 @@ export async function runInstall(opts: InstallOptions): Promise<void> {
       }
       try {
         pluginsUninstall(NPM_PACKAGE_NAME, true);
+
+        // RESTORE channels.octo + bindings (openclaw uninstall removed them as
+        // a side effect; we kept a snapshot above)
+        if (savedChannelConfig) {
+          restoreChannelConfigToFile(savedChannelConfig, CHANNEL_ID);
+          console.log(`  Preserved channels.${CHANNEL_ID} config across legacy uninstall.`);
+        }
+        if (savedBindings.length > 0) {
+          restoreBindingsToFile(savedBindings, CHANNEL_ID, CHANNEL_ID);
+          console.log(`  Preserved ${savedBindings.length} bindings(channel=${CHANNEL_ID}) across legacy uninstall.`);
+        }
         console.log(`Uninstalled legacy ${NPM_PACKAGE_NAME} (replaced by ClawHub octo).`);
         didChange = true;
       } catch (err) {

--- a/openclaw-channel-octo/cli/install.ts
+++ b/openclaw-channel-octo/cli/install.ts
@@ -144,7 +144,10 @@ export async function runInstall(opts: InstallOptions): Promise<void> {
   // v2.0.0+ installs via ClawHub (`clawhub:octo`) instead of npm.
   // --dev / --next: ClawHub dist-tag semantics differ from npm; not supported
   // in v2.0.0. Use --from with a local tarball for pre-release testing.
-  if (opts.dev || opts.next) {
+  // Gate the warning on !opts.from — when --from overrides the spec, --dev/--next
+  // are silently ignored per the doc comment on InstallOptions.next, so warning
+  // about them adds noise without action (P2, PR #37 review).
+  if ((opts.dev || opts.next) && !opts.from) {
     console.warn(
       "Warning: --dev / --next are not supported in v2.0.0+ " +
       "(ClawHub installs use a different release model). " +
@@ -658,7 +661,10 @@ function runDeadlockRepair(spec: string, quiet: boolean): void {
 
   try {
     console.log(`  Installing ${PLUGIN_ID}...`);
-    pluginsInstall(spec, quiet);
+    // P2 (PR #37): pass force=true to be consistent with other recovery paths
+    // (broken / cleanup) — deadlock repair may leave a partial extension dir
+    // from a previous crashed attempt that bare install would refuse to overwrite.
+    pluginsInstall(spec, quiet, true);
   } catch (err) {
     console.error("  Install failed! Restoring config...");
     try { copyFileSync(backupPath, configPath); } catch { /* best effort */ }

--- a/openclaw-channel-octo/cli/install.ts
+++ b/openclaw-channel-octo/cli/install.ts
@@ -58,7 +58,7 @@ import {
   ensureOpenClawCompat,
 } from "./utils.js";
 
-function getLatestClawHubVersion(): string | null {
+export function getLatestClawHubVersion(): string | null {
   // Try OpenClaw's built-in ClawHub client first (no external `clawhub`
   // binary dependency). Falls back to standalone `clawhub` if available.
   // Returns null on any failure — caller treats null as "skip version check".

--- a/openclaw-channel-octo/cli/install.ts
+++ b/openclaw-channel-octo/cli/install.ts
@@ -36,6 +36,7 @@ import {
   pluginsInspect,
   pluginsInstall,
   pluginsUninstall,
+  pluginsUpdate,
   readConfigFromFile,
   removeBindingsFromFile,
   removeChannelConfigFromFile,
@@ -48,18 +49,38 @@ import {
 } from "./openclaw-cli.js";
 import {
   CHANNEL_ID,
+  CLAWHUB_INSTALL_SPEC,
   LEGACY_CHANNEL_ID,
   LEGACY_PLUGIN_ID,
+  NPM_PACKAGE_NAME,
   PLUGIN_ID,
   VERY_LEGACY_PLUGIN_ID,
   ensureOpenClawCompat,
 } from "./utils.js";
 
-function getLatestNpmVersion(tag: string): string | null {
+function getLatestClawHubVersion(): string | null {
+  // Try OpenClaw's built-in ClawHub client first (no external `clawhub`
+  // binary dependency). Falls back to standalone `clawhub` if available.
+  // Returns null on any failure — caller treats null as "skip version check".
   try {
-    return runCmd("npm", ["view", `${PLUGIN_ID}@${tag}`, "version"], {
+    const out = runCmd("openclaw", ["plugins", "inspect", PLUGIN_ID, "--json"], {
       stdio: ["pipe", "pipe", "pipe"],
-    }).trim();
+    });
+    const jsonStart = out.indexOf("{");
+    if (jsonStart >= 0) {
+      const data = JSON.parse(out.slice(jsonStart));
+      const latest = data?.plugin?.latestVersion ?? data?.latestVersion ?? null;
+      if (latest) return latest;
+    }
+  } catch { /* try clawhub fallback */ }
+  try {
+    const out = runCmd("clawhub", ["package", "inspect", PLUGIN_ID, "--json"], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const jsonStart = out.indexOf("{");
+    if (jsonStart < 0) return null;
+    const data = JSON.parse(out.slice(jsonStart));
+    return data?.package?.latestVersion ?? null;
   } catch {
     return null;
   }
@@ -69,27 +90,27 @@ export interface InstallOptions {
   force?: boolean;
   dev?: boolean;
   /**
-   * Install the @next pre-release dist-tag instead of @latest.
+   * [v2.0.0+ no-op] Previously selected the npm @next dist-tag.
    *
-   * Use during rc/beta cycles: `npx -y openclaw-channel-octo@next install --next`
-   * ensures the OpenClaw plugin install also resolves to the @next version
-   * (without --next, the npx CLI is @next but pluginsInstall would let
-   * OpenClaw fetch @latest, defeating the smoke test).
+   * v2.0.0 installs from ClawHub via `clawhub:octo`. ClawHub's release model
+   * uses a single channel without npm dist-tag equivalents, so this flag now
+   * triggers a warning and falls back to ClawHub @latest. For pre-release
+   * testing, use --from with a local tarball.
    */
   next?: boolean;
   /**
    * Override the install spec passed to `openclaw plugins install`.
    * Accepts anything OpenClaw's plugins-install accepts: a tarball path,
-   * a directory path, an alternate npm spec, etc.
+   * a directory path, or any alternate spec (clawhub:..., openclaw-..., etc.).
    *
    * Primary use: pre-publish local testing. Build a tarball with `npm pack`
    * and pass it here so the migration's pluginsInstall step doesn't try to
-   * fetch a package that isn't on npm yet.
+   * fetch a package from ClawHub yet.
    *
-   *   node bin/octo.js install --from ./openclaw-channel-octo-1.0.0-rc.1.tgz
+   *   node bin/octo.js install --from ./openclaw-channel-octo-2.0.0-rc.1.tgz
    *
-   * When set, --dev and --next are ignored for spec resolution. Update-scenario
-   * version comparison is also skipped (tarball install is unconditional).
+   * When set, --dev and --next are ignored. Update-scenario version comparison
+   * is also skipped (tarball install is unconditional).
    */
   from?: string;
 }
@@ -97,23 +118,46 @@ export interface InstallOptions {
 export async function runInstall(opts: InstallOptions): Promise<void> {
   ensureOpenClawCompat();
 
+  // ---------------------------------------------------------------------------
+  // v2.0.0 npm→ClawHub migration: detect (NOT yet uninstall) any pre-2.0 npm
+  // install of this very package. We defer the actual uninstall until AFTER
+  // the ClawHub install completes + verifies healthy — preventing a broken
+  // state where the user loses the npm plugin but the ClawHub install fails.
+  //
+  // v1.x of openclaw-channel-octo installed itself as an npm plugin in
+  // ~/.openclaw/npm/node_modules/openclaw-channel-octo (plugin id ==
+  // NPM_PACKAGE_NAME). v2.x installs the ClawHub plugin (plugin id == PLUGIN_ID
+  // == "octo") into ~/.openclaw/extensions/octo. Both register channel id
+  // "octo", so leaving the v1.x install after ClawHub install would
+  // double-register the channel.
+  // ---------------------------------------------------------------------------
+  const oldNpmSnapshot = capturePluginState(NPM_PACKAGE_NAME);
+  if (oldNpmSnapshot.installed) {
+    console.log(
+      `Detected legacy npm-installed ${NPM_PACKAGE_NAME} v${oldNpmSnapshot.version ?? "?"}. ` +
+      `Will replace with ClawHub octo after install verifies healthy.`,
+    );
+  }
+
   const scenario = detectScenario();
-  // Tag/spec selection: --from > --dev > --next > default (latest).
-  const tag = opts.dev ? "dev" : opts.next ? "next" : "latest";
-  const spec = opts.from
-    ? opts.from
-    : opts.dev ? `${PLUGIN_ID}@dev`
-    : opts.next ? `${PLUGIN_ID}@next`
-    : PLUGIN_ID;
+  // Spec selection: --from > CLAWHUB_INSTALL_SPEC (default).
+  // v2.0.0+ installs via ClawHub (`clawhub:octo`) instead of npm.
+  // --dev / --next: ClawHub dist-tag semantics differ from npm; not supported
+  // in v2.0.0. Use --from with a local tarball for pre-release testing.
+  if (opts.dev || opts.next) {
+    console.warn(
+      "Warning: --dev / --next are not supported in v2.0.0+ " +
+      "(ClawHub installs use a different release model). " +
+      "Falling back to ClawHub @latest. " +
+      "For pre-release testing use --from <tarball>.",
+    );
+  }
+  const spec = opts.from ?? CLAWHUB_INSTALL_SPEC;
   const quiet = false;
   let didChange = false;
 
-  // Display label for "(dev)", "(next)", or "(from <path>)" in log lines.
-  const tagLabel = opts.from
-    ? ` (from ${opts.from})`
-    : opts.dev ? " (dev)"
-    : opts.next ? " (next)"
-    : "";
+  // Display label for "(from <path>)" in log lines.
+  const tagLabel = opts.from ? ` (from ${opts.from})` : "";
 
   switch (scenario) {
     case "legacy-to-octo":
@@ -133,8 +177,8 @@ export async function runInstall(opts: InstallOptions): Promise<void> {
       const currentVersion = inspect?.plugin?.version ?? "unknown";
 
       if (opts.force || opts.from) {
-        // --from skips version comparison: tarball install is unconditional
-        // because npm registry doesn't know about the tarball's contents.
+        // --from skips version comparison: local tarball install is unconditional
+        // because the remote registry can't know the tarball's contents.
         console.log(`Force installing Octo plugin${tagLabel}...`);
         pluginsInstall(spec, quiet, true);
         console.log("Plugin installed successfully.");
@@ -142,11 +186,26 @@ export async function runInstall(opts: InstallOptions): Promise<void> {
         break;
       }
 
-      const targetVersion = getLatestNpmVersion(tag);
+      const targetVersion = getLatestClawHubVersion();
 
       if (!targetVersion) {
-        console.log(`Cannot reach npm registry to check ${tag} version.`);
-        console.log(`Current version: v${currentVersion}`);
+        // No version info available — delegate to OpenClaw's plugins update
+        // which queries ClawHub via its built-in client and no-ops if already
+        // at latest. Safer than skipping silently.
+        console.log(`Cannot determine latest version locally. Delegating to \`openclaw plugins update\`...`);
+        try {
+          pluginsUpdate(PLUGIN_ID, quiet);
+          const after = pluginsInspect(PLUGIN_ID);
+          const newVersion = after?.plugin?.version ?? currentVersion;
+          if (newVersion !== currentVersion) {
+            console.log(`Octo plugin updated: v${currentVersion} → v${newVersion}.`);
+            didChange = true;
+          } else {
+            console.log(`Octo plugin v${currentVersion} is up to date.`);
+          }
+        } catch (err) {
+          console.warn(`Update check failed: ${(err as Error).message}. Current version: v${currentVersion}.`);
+        }
         break;
       }
 
@@ -188,6 +247,45 @@ export async function runInstall(opts: InstallOptions): Promise<void> {
   // observed to be reset to false on third-party plugins.
   ensurePluginsAllow();
   ensurePluginEnabled();
+
+  // ---------------------------------------------------------------------------
+  // v2.0.0 npm→ClawHub migration step 2: AFTER ClawHub install succeeds +
+  // verifies healthy, uninstall the legacy npm plugin. Doing this AFTER (not
+  // before) prevents a broken state if the ClawHub install fails midway.
+  //
+  // Transaction guarantees:
+  //   - ClawHub install failed → legacy npm plugin stays in place; user keeps
+  //     working state. Warn + tell user to re-run install once issue resolved.
+  //   - ClawHub install OK but uninstall fails → throw (loud), because leaving
+  //     both plugins live causes duplicate channel "octo" registration. User
+  //     must manually clean up: `openclaw plugins uninstall <NPM_PACKAGE_NAME>`.
+  // ---------------------------------------------------------------------------
+  if (oldNpmSnapshot.installed) {
+    if (isHealthyInstall(PLUGIN_ID)) {
+      if (oldNpmSnapshot.enabled === true) {
+        try {
+          pluginsDisable(NPM_PACKAGE_NAME);
+        } catch { /* best effort — uninstall below will still remove it */ }
+      }
+      try {
+        pluginsUninstall(NPM_PACKAGE_NAME, true);
+        console.log(`Uninstalled legacy ${NPM_PACKAGE_NAME} (replaced by ClawHub octo).`);
+        didChange = true;
+      } catch (err) {
+        throw new Error(
+          `Failed to uninstall legacy ${NPM_PACKAGE_NAME} after ClawHub install: ${(err as Error).message}\n` +
+          `This would leave duplicate "octo" channel registrations. ` +
+          `Manual cleanup required: openclaw plugins uninstall ${NPM_PACKAGE_NAME} --force`,
+        );
+      }
+    } else {
+      console.warn(
+        `Warning: detected legacy ${NPM_PACKAGE_NAME} but ClawHub octo install did not verify as healthy.\n` +
+        `Legacy plugin left in place to preserve current functionality.\n` +
+        `Re-run \`npx openclaw-channel-octo install\` after addressing the install issue.`,
+      );
+    }
+  }
 
   if (!didChange) return;
 

--- a/openclaw-channel-octo/cli/openclaw-cli.ts
+++ b/openclaw-channel-octo/cli/openclaw-cli.ts
@@ -8,7 +8,7 @@ import { execFileSync, execSync } from "node:child_process";
 import { readFileSync, writeFileSync, copyFileSync, existsSync, rmSync, readdirSync, statSync, renameSync } from "node:fs";
 import { homedir } from "node:os";
 import { resolve } from "node:path";
-import { CHANNEL_ID, PLUGIN_ID, LEGACY_PLUGIN_ID, LEGACY_CHANNEL_ID, VERY_LEGACY_PLUGIN_ID } from "../src/constants.js";
+import { CHANNEL_ID, PLUGIN_ID, NPM_PACKAGE_NAME, LEGACY_PLUGIN_ID, LEGACY_CHANNEL_ID, VERY_LEGACY_PLUGIN_ID } from "../src/constants.js";
 
 /**
  * Find the user's globally installed openclaw, skipping the npx environment.
@@ -909,7 +909,11 @@ export function cleanupStaleStageDirectories(): string[] {
         for (const p of [pkgPath, altPkgPath]) {
           try {
             const pkg = JSON.parse(readFileSync(p, "utf-8"));
-            if (pkg.name === PLUGIN_ID) {
+            // Match either the npm package name or the ClawHub plugin id —
+            // staged dirs may use either depending on install source
+            // (P2, PR #37 review: PLUGIN_ID semantic shift made the previous
+            // single-comparison check dead code for staged npm installs).
+            if (pkg.name === NPM_PACKAGE_NAME || pkg.name === PLUGIN_ID) {
               isDmwork = true;
               break;
             }

--- a/openclaw-channel-octo/cli/utils.ts
+++ b/openclaw-channel-octo/cli/utils.ts
@@ -11,6 +11,7 @@ import { createInterface } from "node:readline";
 import { getOpenClawVersion, getOpenClawVersionStrict } from "./openclaw-cli.js";
 import {
   PLUGIN_ID, CHANNEL_ID,
+  NPM_PACKAGE_NAME, CLAWHUB_INSTALL_SPEC,
   LEGACY_PLUGIN_ID, LEGACY_CHANNEL_ID, VERY_LEGACY_PLUGIN_ID,
   stripChannelPrefix,
   getChannelConfig, getChannelConfigFor,
@@ -23,6 +24,7 @@ import {
 
 export {
   PLUGIN_ID, CHANNEL_ID,
+  NPM_PACKAGE_NAME, CLAWHUB_INSTALL_SPEC,
   LEGACY_PLUGIN_ID, LEGACY_CHANNEL_ID, VERY_LEGACY_PLUGIN_ID,
   stripChannelPrefix,
   getChannelConfig, getChannelConfigFor,

--- a/openclaw-channel-octo/index.ts
+++ b/openclaw-channel-octo/index.ts
@@ -9,7 +9,6 @@
  */
 
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { execFileSync } from "node:child_process";
 import { dmworkPlugin } from "./src/channel.js";
 import { setDmworkRuntime } from "./src/runtime.js";
 import { getGroupMdForPrompt } from "./src/group-md.js";
@@ -34,11 +33,14 @@ import {
 import {
   PLUGIN_ID,
   CHANNEL_ID,
+  CLAWHUB_INSTALL_SPEC,
+  NPM_PACKAGE_NAME,
   LEGACY_CHANNEL_ID,
   RECOMMENDED_DM_SCOPE,
   validateAccountId,
   channelConfigPath,
 } from "./cli/utils.js";
+import { getLatestClawHubVersion } from "./cli/install.js";
 
 // ---------------------------------------------------------------------------
 // Command handlers (reused by /octo_* main and /dmwork_* legacy aliases)
@@ -60,9 +62,10 @@ async function handleInfo() {
   const installedVersion = inspect?.plugin?.version ?? "not installed";
   return {
     text: [
-      `${PLUGIN_ID}: ${installedVersion}`,
+      `installed plugin id: ${PLUGIN_ID} (ClawHub)`,
+      `installed plugin version: ${installedVersion}`,
       `openclaw: ${openclawVersion}`,
-      `plugin package: ${PLUGIN_ID}`,
+      `npm package: ${NPM_PACKAGE_NAME}`,
     ].join("\n"),
   };
 }
@@ -75,7 +78,8 @@ async function handleInstall(ctx: any) {
     if (inspect?.plugin && !force) {
       return { text: `Octo plugin already installed (v${inspect.plugin.version}). Use --force to reinstall.` };
     }
-    pluginsInstall(PLUGIN_ID, true, force);
+    // v2.0.0+: install via ClawHub (plugin id "octo") rather than npm name.
+    pluginsInstall(CLAWHUB_INSTALL_SPEC, true, force);
     gatewayRestart(true);
     const after = pluginsInspect(PLUGIN_ID);
     return { text: `Octo plugin installed (v${after?.plugin?.version ?? "unknown"}). Gateway restarted.` };
@@ -91,13 +95,16 @@ async function handleUpdate() {
       return { text: "Octo plugin is not installed. Use /octo_install first.", isError: true };
     }
     const currentVersion = inspect.plugin.version;
-    const targetVersion = execFileSync("npm", ["view", `${PLUGIN_ID}@latest`, "version"], {
-      encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"],
-    }).trim();
+    // v2.0.0+: query ClawHub registry (not npmjs) for latest. PLUGIN_ID is the
+    // ClawHub plugin id "octo", NOT an npm package name.
+    const targetVersion = getLatestClawHubVersion();
+    if (!targetVersion) {
+      return { text: `Cannot reach ClawHub registry to check latest version. Current: v${currentVersion}.`, isError: true };
+    }
     if (currentVersion === targetVersion) {
       return { text: `Already up to date (v${currentVersion}).` };
     }
-    pluginsInstall(`${PLUGIN_ID}@latest`, true, true);
+    pluginsInstall(CLAWHUB_INSTALL_SPEC, true, true);
     gatewayRestart(true);
     return { text: `Updated: v${currentVersion} -> v${targetVersion}. Gateway restarted.` };
   } catch (e) {

--- a/openclaw-channel-octo/src/channel.ts
+++ b/openclaw-channel-octo/src/channel.ts
@@ -296,12 +296,19 @@ async function checkForUpdates(
     if (resp.ok) {
       const data = await resp.json() as { package?: { latestVersion?: string } };
       const latest = data?.package?.latestVersion;
-      if (latest && latest !== localVersion) {
+      // Sanitize remote value before interpolating into a log line: a hostile
+      // or corrupted ClawHub response could inject newlines / terminal escape
+      // sequences. Only accept a SemVer-like string before logging
+      // (P2 security_sensitive, PR #37 review).
+      const isSemverLike = typeof latest === "string" && /^\d+\.\d+\.\d+(?:[-+][A-Za-z0-9.-]+)?$/.test(latest);
+      if (isSemverLike && latest !== localVersion) {
         log?.info?.(
           `octo: new version available: ${latest} (current: ${localVersion}). ` +
           `Run: openclaw plugins install clawhub:octo --force ` +
           `(or upgrade via: npx openclaw-channel-octo install)`,
         );
+      } else if (latest && !isSemverLike) {
+        log?.debug?.(`octo: ClawHub returned unexpected latest version format; ignoring`);
       }
     } else if (resp.status === 404) {
       log?.debug?.(`octo: ClawHub returned 404 for octo (not published yet)`);

--- a/openclaw-channel-octo/src/channel.ts
+++ b/openclaw-channel-octo/src/channel.ts
@@ -289,25 +289,29 @@ async function checkForUpdates(
   log?: { info?: (msg: string) => void; error?: (msg: string) => void; warn?: (msg: string) => void; debug?: (msg: string) => void },
 ): Promise<void> {
   try {
-    // Check npm version
+    // v2.0.0+: plugin is distributed via ClawHub (plugin id = "octo"), not npm.
+    // Use ClawHub's public registry API for version check.
     const localVersion = PLUGIN_VERSION;
-    const resp = await fetch("https://registry.npmjs.org/openclaw-channel-octo/latest");
+    const resp = await fetch("https://clawhub.ai/api/v1/packages/octo");
     if (resp.ok) {
-      const data = await resp.json() as { version?: string };
-      if (data.version && data.version !== localVersion) {
-        log?.info?.(`octo: new version available: ${data.version} (current: ${localVersion}). Run: npm install openclaw-channel-octo@latest`);
+      const data = await resp.json() as { package?: { latestVersion?: string } };
+      const latest = data?.package?.latestVersion;
+      if (latest && latest !== localVersion) {
+        log?.info?.(
+          `octo: new version available: ${latest} (current: ${localVersion}). ` +
+          `Run: openclaw plugins install clawhub:octo --force ` +
+          `(or upgrade via: npx openclaw-channel-octo install)`,
+        );
       }
     } else if (resp.status === 404) {
-      // Phase A: package not yet published to npm. Silently ignore.
-      // Once published in Phase B this branch becomes unreachable.
-      log?.debug?.(`octo: registry returned 404 for openclaw-channel-octo (not published yet)`);
+      log?.debug?.(`octo: ClawHub returned 404 for octo (not published yet)`);
     }
   } catch (err) {
     log?.debug?.(`octo: version check failed: ${String(err)}`);
   }
 
   // Skills are distributed via the plugin's skills/ directory (openclaw.plugin.json "skills" field).
-  // No runtime fetch needed — openclaw loads skills from ~/.openclaw/extensions/openclaw-channel-octo/skills/ automatically.
+  // No runtime fetch needed — openclaw loads skills from ~/.openclaw/extensions/octo/skills/ automatically.
 }
 
 /** Resolve correct accountId for outbound context using group→account mapping */

--- a/openclaw-channel-octo/src/constants.ts
+++ b/openclaw-channel-octo/src/constants.ts
@@ -7,8 +7,22 @@
  * (`cli/*.ts`). Runtime code MUST NOT import from `cli/`.
  */
 
-export const PLUGIN_ID = "openclaw-channel-octo";
+/**
+ * Target plugin id after install — matches the ClawHub plugin id `octo`
+ * (Mininglamp-OSS/openclaw-channel-octo standalone repo, published to ClawHub).
+ * Used by cli/* for plugin inspect / enable / cleanup operations.
+ */
+export const PLUGIN_ID = "octo";
 export const CHANNEL_ID = "octo";
+
+/** The npm package name (this very package). Used as the install spec when
+ * publishing to npm, and as a legacy plugin id to detect+cleanup when an older
+ * version (1.x) was installed via `openclaw plugins install openclaw-channel-octo`.
+ */
+export const NPM_PACKAGE_NAME = "openclaw-channel-octo";
+
+/** Spec passed to `openclaw plugins install <spec>` to install from ClawHub. */
+export const CLAWHUB_INSTALL_SPEC = "clawhub:octo";
 
 // LEGACY-COMPAT: legacy identifiers used only by Phase B migration code and
 // Phase A's legacy-warn / dual-prefix compatibility paths.


### PR DESCRIPTION
## Summary

Reroute `npx openclaw-channel-octo install` to install the ClawHub plugin (plugin id `octo`) instead of the npm package itself. Preserves the existing dmwork→octo rebrand migration path; adds transactional cleanup of any pre-2.0 npm-installed `openclaw-channel-octo` plugin to avoid duplicate `octo` channel registration after install.

Plugin runtime code unchanged in this PR (kept for now — to be deprecated in a later phase that publishes only the CLI shim to npm and consolidates plugin code into `Mininglamp-OSS/openclaw-channel-octo`).

## Related Issue

N/A

## Changes

- **`src/constants.ts`**: `PLUGIN_ID` semantic shift `"openclaw-channel-octo"` → `"octo"` (ClawHub plugin id); add `NPM_PACKAGE_NAME` and `CLAWHUB_INSTALL_SPEC`
- **`cli/install.ts`**:
  - spec defaults to `CLAWHUB_INSTALL_SPEC` (`"clawhub:octo"`)
  - `getLatestClawHubVersion` via `openclaw plugins inspect --json` (no external `clawhub` binary dep), falls back to standalone `clawhub` CLI
  - `--dev` / `--next` deprecated: warn + fall back to latest (ClawHub release model differs from npm dist-tags)
  - Transactional legacy npm cleanup: detect at entry → install ClawHub → verify `isHealthyInstall(PLUGIN_ID)` → uninstall legacy → throw on uninstall failure (loud, avoids silent double-registration)
- **`cli/doctor.ts`**: `--fix` delegates to `runInstall({ force: true })` for full scenario coverage; surfaces `err.message` in failure detail
- **`src/channel.ts`**: runtime version check uses ClawHub registry (`https://clawhub.ai/api/v1/packages/octo`); upgrade prompt uses `openclaw plugins install clawhub:octo --force` or `npx openclaw-channel-octo install`
- **`cli/index.ts`**: `info` shows installed plugin id (`octo`) + npm package name; install/update `--next` help updated to `[v2.0.0+ no-op]`
- **`README.md`**: `--dev` / `--next` flag deprecation notice
- **Tests**: 749/749 pass — `install.test.ts` rewritten for new behavior + transactional cleanup test; `install-migration.test.ts` updated to assert `clawhub:octo` spec and `octo` plugin id

## Testing

- [x] Unit tests added/updated
- [x] Manually verified

### Automated

- `npm run build` — passes
- `npm test` — 749/749 pass
- codex review (4 rounds) — Ready to ship; 0 BLOCKER / 0 MAJOR remaining

### E2E (local OpenClaw 2026.5.18 + ClawHub octo 1.0.7)

- **Scenario 1: fresh install** — no prior plugin → `npx ... install` → `~/.openclaw/extensions/octo/` populated, `openclaw channels list --all` shows Octo as installable
- **Scenario 2: dmwork → octo rebrand** — `openclaw-channel-dmwork` v0.6.4 + `channels.dmwork.*` + dmwork bindings → `npx ... install` → `channels.dmwork` migrated to `channels.octo`, bindings rewritten to `channel=octo`, dmwork plugin uninstalled, feishu channel unaffected
- **Scenario 3: dmwork → octo + IM end-to-end** — sent a message to the migrated bot in OpenClaw IM, received correct response (proves channel + binding migration is functionally correct)
- **Scenario 4: npm rebrand → ClawHub** — npm `openclaw-channel-octo` v1.0.0 (plugin id `openclaw-channel-octo`) + `channels.octo.*` already configured + binding → `npx ... install` → deadlock-repair path (channels.octo exists but `PLUGIN_ID=octo` not yet installed) → ClawHub octo installed → `channels.octo` + bindings restored intact → legacy npm plugin uninstalled only after `isHealthyInstall` verified (transactional)

## Release plan

Version intentionally not bumped in this PR; merging will publish `@dev` (no impact on stable users). A future formal `v2.0.0` release requires bumping `package.json` + `CHANGELOG.md`, and `npm deprecate openclaw-channel-octo@'<2.0.0'` is recommended to nudge legacy users.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)