### PR TITLE
fix(ci): replace negation filter with positive-pattern filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,12 +39,18 @@ jobs:
         id: filter
         if: github.event_name == 'pull_request'
         with:
+          # Positive patterns only — no negation, no predicate-quantifier needed.
+          # code=true when at least one changed file matches a source pattern.
+          # Docs-only PRs won't match any pattern -> code=false -> jobs skipped.
+          # (skipped jobs count as passing for required-check branch protection).
           filters: |
             code:
-              - '**'
-              - '!**/*.md'
-              - '!docs/**'
-              - '!.github/ISSUE_TEMPLATE/**'
+              - 'openclaw-channel-octo/**'
+              - 'openclaw-channel-dmwork/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - '*.config.*'
+              - '.github/workflows/**'
 
   build:
     needs: [changes]


### PR DESCRIPTION
## Summary

Replace the negation-based `dorny/paths-filter` filter with explicit positive patterns, consistent with `octo-lib` fix merged in #16.

**Previous (negation-based, flagged as ambiguous):**
```yaml
filters: |
  code:
    - '**'
    - '!**/*.md'
    - '!docs/**'
    - '!.github/ISSUE_TEMPLATE/**'
```

**New (positive patterns, unambiguous):**
```
openclaw-channel-octo/**, openclaw-channel-dmwork/**, package.json, pnpm-lock.yaml, *.config.*, .github/workflows/**
```

**Why positive patterns:**
- No negation semantics ambiguity with `some` predicate
- Easy to reason about: CI runs when ≥1 changed file matches a source pattern
- Docs-only PRs touch none of these → `code=false` → jobs skipped ✅

**Related:** octo-lib PR #16 (same fix, already reviewed and merged)