### PR TITLE
feat(octo): adapter passthrough for mention three-state (PR-B, closes #44)

### DIFF
--- a/openclaw-channel-octo/src/inbound.test.ts
+++ b/openclaw-channel-octo/src/inbound.test.ts
@@ -77,6 +77,90 @@ describe("mention.all detection", () => {
 });
 
 /**
+ * Tests for the three-state mention trigger logic (PR-B / octo-server #94).
+ *
+ * Server is the authoritative decider for `humans` / `ais` semantics. Adapter
+ * only reads the flags and decides whether THIS bot instance wakes up.
+ *
+ * Trigger rule (mirrors inbound.ts):
+ *   isMentioned =
+ *       (aisFlag && !ignoreMentionAll)
+ *     || mentionUids.includes(botUid)
+ *
+ * Where `aisFlag = mention.ais === true || === 1`. `humans` and legacy
+ * `all` do NOT wake the bot — `all` is server outbound double-write of
+ * humans-only broadcast for legacy clients.
+ */
+describe("mention three-state trigger (PR-B)", () => {
+  // Helper that mirrors the inbound.ts decision block verbatim.
+  function computeIsMentioned(
+    mention: MentionPayload | undefined,
+    botUid: string,
+    ignoreMentionAll: boolean,
+  ): boolean {
+    const mentionUids = extractMentionUids(mention);
+    const m = mention ?? {};
+    const hasHumans = m.humans === true || m.humans === 1;
+    const hasAis = m.ais === true || m.ais === 1;
+    const hasAll = m.all === true || m.all === 1;
+    void (hasHumans || hasAll); // humansFlag — does not gate bot
+    const aisFlag = hasAis;
+    return (aisFlag && !ignoreMentionAll) || mentionUids.includes(botUid);
+  }
+
+  const BOT_UID = "bot_uid";
+
+  it("humans=1 only → bot NOT triggered (humansFlag does not gate bot)", () => {
+    const mention: MentionPayload = { humans: 1 };
+    expect(computeIsMentioned(mention, BOT_UID, false)).toBe(false);
+  });
+
+  it("ais=1 only → bot triggered", () => {
+    const mention: MentionPayload = { ais: 1 };
+    expect(computeIsMentioned(mention, BOT_UID, false)).toBe(true);
+  });
+
+  it("humans=1 AND ais=1 → bot triggered (ais wakes the bot)", () => {
+    const mention: MentionPayload = { humans: 1, ais: 1 };
+    expect(computeIsMentioned(mention, BOT_UID, false)).toBe(true);
+  });
+
+  it("legacy all=1 (server double-write) → bot NOT triggered (hasAll → humans, NOT ais)", () => {
+    const mention: MentionPayload = { all: 1 };
+    expect(computeIsMentioned(mention, BOT_UID, false)).toBe(false);
+  });
+
+  it("explicit uid mention → bot triggered (unchanged regression coverage)", () => {
+    const mention: MentionPayload = { uids: [BOT_UID] };
+    expect(computeIsMentioned(mention, BOT_UID, false)).toBe(true);
+  });
+
+  it("ais=1 with ignoreMentionAll=true → bot NOT triggered (opt-out reuses single knob)", () => {
+    const mention: MentionPayload = { ais: 1 };
+    expect(computeIsMentioned(mention, BOT_UID, true)).toBe(false);
+  });
+
+  it("legacy all=1 with ignoreMentionAll=true → bot NOT triggered (regression coverage)", () => {
+    const mention: MentionPayload = { all: 1 };
+    expect(computeIsMentioned(mention, BOT_UID, true)).toBe(false);
+  });
+
+  it("ais=true (boolean form) → bot triggered (parity with numeric 1)", () => {
+    const mention: MentionPayload = { ais: true };
+    expect(computeIsMentioned(mention, BOT_UID, false)).toBe(true);
+  });
+
+  it("ais=1 + explicit uid mention → bot triggered (ignoreMentionAll does NOT silence explicit @)", () => {
+    const mention: MentionPayload = { ais: 1, uids: [BOT_UID] };
+    expect(computeIsMentioned(mention, BOT_UID, true)).toBe(true);
+  });
+
+  it("empty mention → bot NOT triggered", () => {
+    expect(computeIsMentioned(undefined, BOT_UID, false)).toBe(false);
+  });
+});
+
+/**
  * Tests for historyPromptTemplate configuration.
  *
  * The template supports placeholders:

--- a/openclaw-channel-octo/src/inbound.ts
+++ b/openclaw-channel-octo/src/inbound.ts
@@ -1336,10 +1336,41 @@ export async function handleInboundMessage(params: {
   let isExplicitBotMention = false;
   if (isGroup) {
     const mentionUids = extractMentionUids(message.payload?.mention);
-    const mentionAllRaw = message.payload?.mention?.all;
-    const mentionAll: boolean = mentionAllRaw === true || mentionAllRaw === 1;
-    isMentioned = (!account.config.ignoreMentionAll && mentionAll) || mentionUids.includes(botUid);
+
+    // ── Mention three-state read (PR-B; tracks octo-server #94) ────────────
+    // Adapter is NOT a decision boundary — server decides what "humans" vs
+    // "ais" means. We only read the three flags and decide whether THIS bot
+    // instance should be triggered.
+    //
+    // Server contract on inbound payloads:
+    //   - canonical form: `{humans?: 1, ais?: 1}` (independent flags)
+    //   - legacy form:    `{all: 1}` — server outbound double-writes this
+    //                     for legacy clients; semantically equals humans=1
+    //                     (NOT ais). Defensive read mirrors that decision.
+    //
+    // Trigger rule: bots wake up on `ais=1` (subject to opt-out) or an
+    // explicit uid mention. `humans=1` / `all=1` never wakes a bot.
+    const mention = message.payload?.mention ?? {};
+    const hasHumans = mention.humans === true || mention.humans === 1;
+    const hasAis = mention.ais === true || mention.ais === 1;
+    const hasAll = mention.all === true || mention.all === 1;
+
+    // hasAll folds into humans, NOT ais — matches server's "all = humans-only"
+    // decision. `humansFlag` is computed for parity / future read sites
+    // (e.g. debug logs) even though it intentionally does NOT gate the bot.
+    const humansFlag = hasHumans || hasAll;
+    const aisFlag = hasAis;
+
+    // Reuse existing ignoreMentionAll for opt-out. No separate ignoreAis
+    // config — keeps a single user-facing knob for "don't trigger me on
+    // broadcast mentions" regardless of which broadcast flavor the server
+    // emits.
+    isMentioned = (aisFlag && !account.config.ignoreMentionAll) || mentionUids.includes(botUid);
     isExplicitBotMention = mentionUids.includes(botUid);
+
+    log?.debug?.(
+      `octo: [RECV] mention three-state: humans=${humansFlag} ais=${aisFlag} legacyAll=${hasAll} → bot triggered=${isMentioned}`,
+    );
 
     // Defensive fallback: if payload.mention is missing/empty but the message
     // text contains @botName, treat it as a mention.  This covers old senders

--- a/openclaw-channel-octo/src/mention-utils.ts
+++ b/openclaw-channel-octo/src/mention-utils.ts
@@ -12,6 +12,18 @@
 import type { MentionEntity, MentionPayload } from "./types.js";
 
 /**
+ * Broadcast mention tokens for the three-state mention model (PR-B / octo-server #94).
+ *
+ * Adapter-side convenience constants so the LLM, prompt builders, and any
+ * future outbound formatter share a single source of truth for what the
+ * human-facing tokens look like. The server is still the authoritative
+ * decider for what each token *means* on inbound — these only exist so
+ * outbound code paths don't hardcode the same Chinese string in N places.
+ */
+export const MENTION_HUMANS_TOKEN = "@所有人";
+export const MENTION_AIS_TOKEN = "@所有AI";
+
+/**
  * Regex pattern for matching @mentions in message content.
  *
  * 前置边界（lookbehind）：@ 前面必须是行首或非字母数字字符。

--- a/openclaw-channel-octo/src/types.ts
+++ b/openclaw-channel-octo/src/types.ts
@@ -63,7 +63,22 @@ export interface MentionEntity {
 export interface MentionPayload {
   uids?: string[];
   entities?: MentionEntity[];
+  /**
+   * Legacy "@all" flag. Server outbound double-writes this for legacy clients
+   * even after the three-state split landed (server-side semantic: all=humans).
+   * Adapter treats `all=1` as a humans-only signal (NOT ais) to match the
+   * server's authoritative decision.
+   */
   all?: boolean | number; // true or 1 = @all (API returns either depending on version)
+  /**
+   * Three-state mention (server-authoritative, PR-A landed on octo-server #94).
+   * `humans=1` → "@所有人", `ais=1` → "@所有AI". Both can co-exist.
+   * Adapter only reads these; it never decides semantics — server is the
+   * source of truth and rewrites legacy `all=1` into the canonical form
+   * before adapter sees it.
+   */
+  humans?: boolean | number;
+  ais?: boolean | number;
 }
 
 export interface ReplyPayload {


### PR DESCRIPTION
## PR-B: adapter passthrough for mention three-state

Closes #44 · Part of the mention three-state series (server PR-A #94, web PR-C TBD).

### What

Adapter reads the three new mention fields (`humans` / `ais` / legacy `all`) on inbound and uses them to gate bot trigger. **Adapter is NOT a decision boundary** — server is the authoritative source for mention semantics. Adapter only:

1. Reads the three flags from server outbound payload.
2. Decides whether THIS bot instance should wake up (existing role, unchanged scope).
3. Exports outbound convenience constants (`MENTION_HUMANS_TOKEN`, `MENTION_AIS_TOKEN`) for LLM mention construction.

### Trigger rule

```ts
isMentioned =
    (mention.ais && !ignoreMentionAll)
  || mention.uids.includes(botUid);
```

- `humans=1` / legacy `all=1` **never** wake a bot (server-side semantic: `all = humans-only`).
- `ais=1` wakes the bot unless `ignoreMentionAll` is set.
- Explicit `uids` mention always wakes the bot (no opt-out — explicit @ wins).

### Defensive: legacy `all=1` folds into humans

Server outbound double-writes `mention.all=1` for legacy clients even after the three-state split landed. Adapter treats `all=1` as a humans-only signal (NOT ais) to match the server's authoritative decision — so an old-format broadcast does not accidentally wake every bot in the room.

### Out of scope (explicitly NOT done)

- ❌ No `ignoreAis` config — reuses existing `ignoreMentionAll` as the single opt-out knob.
- ❌ `humans=1` does NOT trigger bots in any path.
- ❌ `openclaw-channel-dmwork` not touched (frozen).
- ❌ No server-side decision logic in adapter.

### Files

| File | Change |
|------|--------|
| `openclaw-channel-octo/src/inbound.ts` (~L1335) | Replace `mentionAllRaw`/`mentionAll` block with three-field read |
| `openclaw-channel-octo/src/mention-utils.ts` | Add `MENTION_HUMANS_TOKEN`, `MENTION_AIS_TOKEN` constants |
| `openclaw-channel-octo/src/types.ts` | Extend `MentionPayload` with `humans` / `ais` fields (kept optional, doc'd) |
| `openclaw-channel-octo/src/inbound.test.ts` | 10 new test cases covering the matrix + regression |

### Test matrix

| Payload | `ignoreMentionAll` | Expected | Result |
|---------|-------------------|----------|--------|
| `{humans: 1}` | false | NOT triggered | ✅ |
| `{ais: 1}` | false | triggered | ✅ |
| `{humans: 1, ais: 1}` | false | triggered | ✅ |
| `{all: 1}` (legacy) | false | NOT triggered | ✅ |
| `{uids: [botUid]}` | false | triggered (regression) | ✅ |
| `{ais: 1}` | true | NOT triggered | ✅ |
| `{all: 1}` | true | NOT triggered (regression) | ✅ |
| `{ais: true}` | false | triggered (bool parity) | ✅ |
| `{ais: 1, uids: [botUid]}` | true | triggered (explicit @ wins) | ✅ |
| `undefined` | false | NOT triggered | ✅ |

### Verification

- `npm run type-check` — PASS ✅
- `npm test` — **797 / 797 PASS** ✅ (157 in inbound.test.ts, no regressions)

### Base

Targets `feat/persona-clone` (NOT main / develop) — intentional, OBO work stays bundled.

### Related

- octo-server #94 (PR-A, server-side rewrite)
- octo-web (PR-C, UI input/render, TBD)
