### PR TITLE
fix(accounts): tolerate case-insensitive accountId lookup

### DIFF
--- a/openclaw-channel-octo/src/__tests__/accounts.test.ts
+++ b/openclaw-channel-octo/src/__tests__/accounts.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { resolveDmworkAccount } from "../accounts.js";
+
+/**
+ * Unit tests for resolveDmworkAccount account-id case-insensitive fallback.
+ *
+ * Background: OpenClaw's routing layer normalizes accountId to lowercase via
+ * normalizeAccountId (canonicalizeAccountId in openclaw/dist/account-id-*.js),
+ * but botfather generates mixed-case bot IDs (e.g. "27pBwzf2F6bfa5cd142_bot").
+ * Without a case-insensitive fallback, outbound paths that re-resolve account
+ * from the lowercased ID would miss the mixed-case config key and throw
+ * "botToken is not configured", silently dropping replies.
+ */
+
+const MIXED_CASE_ID = "27pBwzf2F6bfa5cd142_bot";
+const LOWERCASE_ID = "27pbwzf2f6bfa5cd142_bot";
+const OTHER_MIXED_CASE_ID = "27pBwJ4bfWKed86272a_bot";
+
+function buildCfg(accounts: Record<string, unknown>): unknown {
+  return {
+    channels: {
+      octo: {
+        accounts,
+      },
+    },
+  };
+}
+
+describe("resolveDmworkAccount", () => {
+  describe("strict (case-sensitive) match — primary path", () => {
+    it("returns account config when accountId matches the configured key exactly", () => {
+      const cfg = buildCfg({
+        [MIXED_CASE_ID]: { botToken: "bf_strict_match", apiUrl: "https://im.example.com/api" },
+      });
+
+      const account = resolveDmworkAccount({ cfg: cfg as never, accountId: MIXED_CASE_ID });
+
+      expect(account.config.botToken).toBe("bf_strict_match");
+      expect(account.config.apiUrl).toBe("https://im.example.com/api");
+      expect(account.configured).toBe(true);
+    });
+  });
+
+  describe("case-insensitive fallback — bridges OpenClaw lowercase routing", () => {
+    it("resolves a mixed-case configured account when given its lowercase form", () => {
+      const cfg = buildCfg({
+        [MIXED_CASE_ID]: { botToken: "bf_case_insensitive", apiUrl: "https://im.example.com/api" },
+      });
+
+      const account = resolveDmworkAccount({ cfg: cfg as never, accountId: LOWERCASE_ID });
+
+      expect(account.config.botToken).toBe("bf_case_insensitive");
+      expect(account.config.apiUrl).toBe("https://im.example.com/api");
+      expect(account.configured).toBe(true);
+    });
+
+    it("matches the correct account when multiple mixed-case accounts coexist", () => {
+      const cfg = buildCfg({
+        [MIXED_CASE_ID]: { botToken: "bf_first", apiUrl: "https://first.example.com/api" },
+        [OTHER_MIXED_CASE_ID]: { botToken: "bf_second", apiUrl: "https://second.example.com/api" },
+      });
+
+      const first = resolveDmworkAccount({ cfg: cfg as never, accountId: MIXED_CASE_ID.toLowerCase() });
+      const second = resolveDmworkAccount({ cfg: cfg as never, accountId: OTHER_MIXED_CASE_ID.toLowerCase() });
+
+      expect(first.config.botToken).toBe("bf_first");
+      expect(second.config.botToken).toBe("bf_second");
+    });
+  });
+
+  describe("missing account — fallback to top-level channel config", () => {
+    it("falls back to top-level channel config when accountId is not found in any case", () => {
+      const cfg = {
+        channels: {
+          octo: {
+            botToken: "bf_top_level",
+            apiUrl: "https://top-level.example.com/api",
+          },
+        },
+      };
+
+      const account = resolveDmworkAccount({ cfg: cfg as never, accountId: "nonexistent_account" });
+
+      expect(account.config.botToken).toBe("bf_top_level");
+      expect(account.config.apiUrl).toBe("https://top-level.example.com/api");
+    });
+
+    it("returns undefined botToken when neither account nor top-level config has it", () => {
+      const cfg = buildCfg({
+        [MIXED_CASE_ID]: { apiUrl: "https://im.example.com/api" },
+      });
+
+      const account = resolveDmworkAccount({ cfg: cfg as never, accountId: "totally_different" });
+
+      expect(account.config.botToken).toBeUndefined();
+      expect(account.configured).toBe(false);
+    });
+  });
+});

--- a/openclaw-channel-octo/src/accounts.ts
+++ b/openclaw-channel-octo/src/accounts.ts
@@ -56,7 +56,21 @@ export function resolveDmworkAccount(params: {
 }): ResolvedDmworkAccount {
   const accountId = params.accountId ?? DEFAULT_ACCOUNT_ID;
   const channel = getChannelConfig<DmworkAccountConfig>(params.cfg);
-  const accountConfig = channel.accounts?.[accountId] ?? channel;
+  // Strict lookup first; fall back to case-insensitive match because OpenClaw's
+  // routing layer normalizes accountId to lowercase via normalizeAccountId
+  // (canonicalizeAccountId in openclaw/dist/account-id-*.js), while botfather
+  // generates mixed-case bot IDs (e.g. "27pBwzf2F6bfa5cd142_bot"). Without the
+  // fallback, outbound paths that re-resolve account from the lowercased ID
+  // miss the mixed-case config key and throw "botToken is not configured",
+  // silently dropping replies. Long-term, botfather should produce lowercase
+  // IDs to match OpenClaw's contract; this bridges the gap and keeps working
+  // for historical mixed-case bot IDs already in production.
+  const accountConfig =
+    channel.accounts?.[accountId]
+    ?? Object.entries(channel.accounts ?? {}).find(
+      ([key]) => key.toLowerCase() === accountId.toLowerCase(),
+    )?.[1]
+    ?? channel;
 
   const botToken = accountConfig.botToken ?? channel.botToken;
   const apiUrl = accountConfig.apiUrl ?? channel.apiUrl ?? DEFAULT_API_URL;


### PR DESCRIPTION
## Summary

Fix silent outbound reply drops when bot accountId contains uppercase characters.

OpenClaw's routing layer normalizes `accountId` to lowercase via `normalizeAccountId`, but botfather generates mixed-case bot IDs (e.g. `27pBwzf2F6bfa5cd142_bot`). The strict lookup in `resolveDmworkAccount` fails to match the mixed-case config key when given the lowercase routing-normalized form, falls through to the top-level channel config (which has no `botToken`), and throws `Octo botToken is not configured`. The error only surfaces in OpenClaw's debug-level file log; the user's IM client receives nothing.

This affects every agent-driven reply that goes through the followup queue / route-reply path (e.g. image-processing replies, long async replies). Short synchronous replies that go through the plugin `deliver` callback path are unaffected (that path uses the cached inbound `account` config, which preserves the original mixed-case key).

## Related Issue

Fixes #54

## Changes

- `openclaw-channel-octo/src/accounts.ts`: add case-insensitive fallback in `resolveDmworkAccount`. The strict lookup remains the primary O(1) path; the fallback only runs when the strict lookup misses. Account count is small (typically <10), so the `Object.entries(...).find(...)` cost is negligible.
- `openclaw-channel-octo/src/__tests__/accounts.test.ts`: add 5 unit tests covering: strict match (primary path), case-insensitive fallback (bridge), case-insensitive fallback with multiple coexisting mixed-case accounts (correctness), missing-key top-level fallback (backward-compat), and missing botToken (returns `configured: false`).

## Testing

- [x] `npm run type-check` passes
- [x] `npm test` passes (755/755 tests, including 5 new ones in `accounts.test.ts`)
- [x] Manually verified on local gateway: with the fix applied to `~/.openclaw/npm/node_modules/openclaw-channel-octo/dist/src/accounts.js`, mixed-case bot IDs (`27pBwzf2F6bfa5cd142_bot`) successfully deliver agent replies through the route-reply path. Without the fix, `outbound.sendText` throws `Octo botToken is not configured` and the reply is silently dropped (debug-log evidence in #54).

## Long-Term Direction (out of scope for this PR)

The deeper architectural alignment is for botfather to generate lowercase bot IDs to match OpenClaw's contract (`canonicalizeAccountId` in `openclaw/dist/account-id-*.js`). This PR is a plugin-side bridge — it remains useful for historical mixed-case bot IDs already in production even after botfather is migrated.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes (5 new unit tests in `accounts.test.ts`)
- [x] Updated documentation (no doc changes needed for an internal bug fix)
- [x] Followed commit message conventions (Conventional Commits: `fix(accounts): ...`)