### PR TITLE
chore: improve dependabot config — add labels, groups, timezone, PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,29 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "tuesday"
+      timezone: "Asia/Shanghai"
     commit-message:
       prefix: "chore(ci)"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    open-pull-requests-limit: 5
 
   - package-ecosystem: "npm"
     directory: "/openclaw-channel-octo"
     schedule:
       interval: "weekly"
+      day: "tuesday"
+      timezone: "Asia/Shanghai"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+


### PR DESCRIPTION
Align dependabot config with org-wide standard:

- Add `open-pull-requests-limit: 5` to control PR volume
- Add `labels` for triage routing
- Add `groups` to batch minor/patch npm updates
- Pin schedule to Tuesday, Asia/Shanghai timezone
- Add commit-message prefix for npm ecosystem

Part of org CI/CD governance hardening (Phase 2).