### PR TITLE
feat(octo): persona clone responds to @所有人 as grantor identity

### DIFF
--- a/openclaw-channel-octo/openclaw.plugin.json
+++ b/openclaw-channel-octo/openclaw.plugin.json
@@ -1,58 +1,126 @@
 {
-  "id": "openclaw-channel-octo",
-  "channels": [
-    "octo"
-  ],
-  "skills": [
-    "./skills"
-  ],
-  "configSchema": {
-    "type": "object",
-    "additionalProperties": false,
-    "properties": {}
-  },
-  "channelConfigs": {
-    "octo": {
-      "schema": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+    "id": "openclaw-channel-octo",
+    "channels": [
+        "octo"
+    ],
+    "skills": [
+        "./skills"
+    ],
+    "configSchema": {
         "type": "object",
-        "properties": {
-          "name": { "type": "string" },
-          "enabled": { "type": "boolean" },
-          "botToken": { "type": "string" },
-          "apiUrl": { "type": "string" },
-          "wsUrl": { "type": "string" },
-          "cdnUrl": { "type": "string" },
-          "pollIntervalMs": { "type": "number", "minimum": 500 },
-          "heartbeatIntervalMs": { "type": "number", "minimum": 5000 },
-          "requireMention": { "type": "boolean" },
-          "ignoreMentionAll": { "type": "boolean" },
-          "botUid": { "type": "string" },
-          "historyLimit": { "type": "number", "minimum": 1, "maximum": 100 },
-          "historyPromptTemplate": { "type": "string" },
-          "accounts": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "object",
-              "properties": {
-                "name": { "type": "string" },
-                "enabled": { "type": "boolean" },
-                "botToken": { "type": "string" },
-                "apiUrl": { "type": "string" },
-                "wsUrl": { "type": "string" },
-                "cdnUrl": { "type": "string" },
-                "pollIntervalMs": { "type": "number", "minimum": 500 },
-                "heartbeatIntervalMs": { "type": "number", "minimum": 5000 },
-                "requireMention": { "type": "boolean" },
-                "ignoreMentionAll": { "type": "boolean" },
-                "botUid": { "type": "string" },
-                "historyLimit": { "type": "number", "minimum": 1, "maximum": 100 },
-                "historyPromptTemplate": { "type": "string" }
-              }
+        "additionalProperties": false,
+        "properties": {}
+    },
+    "channelConfigs": {
+        "octo": {
+            "schema": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "enabled": {
+                        "type": "boolean"
+                    },
+                    "botToken": {
+                        "type": "string"
+                    },
+                    "apiUrl": {
+                        "type": "string"
+                    },
+                    "wsUrl": {
+                        "type": "string"
+                    },
+                    "cdnUrl": {
+                        "type": "string"
+                    },
+                    "pollIntervalMs": {
+                        "type": "number",
+                        "minimum": 500
+                    },
+                    "heartbeatIntervalMs": {
+                        "type": "number",
+                        "minimum": 5000
+                    },
+                    "requireMention": {
+                        "type": "boolean"
+                    },
+                    "ignoreMentionAll": {
+                        "type": "boolean"
+                    },
+                    "botUid": {
+                        "type": "string"
+                    },
+                    "historyLimit": {
+                        "type": "number",
+                        "minimum": 1,
+                        "maximum": 100
+                    },
+                    "historyPromptTemplate": {
+                        "type": "string"
+                    },
+                    "accounts": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "botToken": {
+                                    "type": "string"
+                                },
+                                "apiUrl": {
+                                    "type": "string"
+                                },
+                                "wsUrl": {
+                                    "type": "string"
+                                },
+                                "cdnUrl": {
+                                    "type": "string"
+                                },
+                                "pollIntervalMs": {
+                                    "type": "number",
+                                    "minimum": 500
+                                },
+                                "heartbeatIntervalMs": {
+                                    "type": "number",
+                                    "minimum": 5000
+                                },
+                                "requireMention": {
+                                    "type": "boolean"
+                                },
+                                "ignoreMentionAll": {
+                                    "type": "boolean"
+                                },
+                                "botUid": {
+                                    "type": "string"
+                                },
+                                "historyLimit": {
+                                    "type": "number",
+                                    "minimum": 1,
+                                    "maximum": 100
+                                },
+                                "historyPromptTemplate": {
+                                    "type": "string"
+                                },
+                                "onBehalfOf": {
+                                    "type": "string",
+                                    "description": "Persona clone: grantor uid — bot acts on behalf of this human"
+                                }
+                            }
+                        }
+                    },
+                    "onBehalfOf": {
+                        "type": "string",
+                        "description": "Persona clone: grantor uid — bot acts on behalf of this human"
+                    }
+                }
             }
-          }
         }
-      }
     }
-  }
 }

--- a/openclaw-channel-octo/src/accounts.ts
+++ b/openclaw-channel-octo/src/accounts.ts
@@ -23,6 +23,7 @@ export type ResolvedDmworkAccount = {
     ignoreMentionAll?: boolean;
     historyLimit?: number;  // 群聊历史消息条数限制
     historyPromptTemplate?: string;  // Template for group history context injection
+    onBehalfOf?: string;  // Persona clone: grantor uid
   };
 };
 
@@ -90,6 +91,7 @@ export function resolveDmworkAccount(params: {
       ignoreMentionAll: accountConfig.ignoreMentionAll ?? channel.ignoreMentionAll,
       historyLimit: accountConfig.historyLimit ?? channel.historyLimit ?? 20,
       historyPromptTemplate: accountConfig.historyPromptTemplate ?? channel.historyPromptTemplate,
+      onBehalfOf: accountConfig.onBehalfOf ?? channel.onBehalfOf,
     },
   };
 }

--- a/openclaw-channel-octo/src/api-fetch.ts
+++ b/openclaw-channel-octo/src/api-fetch.ts
@@ -77,6 +77,7 @@ export async function sendMediaMessage(params: {
   height?: number;
   mentionUids?: string[];
   mentionEntities?: MentionEntity[];
+  onBehalfOf?: string;
   signal?: AbortSignal;
 }): Promise<SendMessageResult | undefined> {
   const payload: Record<string, unknown> = {
@@ -112,6 +113,7 @@ export async function sendMediaMessage(params: {
     channel_id: params.channelId,
     channel_type: params.channelType,
     payload,
+    ...(params.onBehalfOf ? { on_behalf_of: params.onBehalfOf } : {}),
   }, params.signal);
 }
 

--- a/openclaw-channel-octo/src/api-fetch.ts
+++ b/openclaw-channel-octo/src/api-fetch.ts
@@ -215,6 +215,7 @@ export async function sendMessage(params: {
   mentionEntities?: MentionEntity[];
   mentionAll?: boolean;
   replyMsgId?: string;
+  onBehalfOf?: string;
   signal?: AbortSignal;
 }): Promise<SendMessageResult | undefined> {
   const payload: Record<string, unknown> = {
@@ -247,6 +248,7 @@ export async function sendMessage(params: {
     channel_id: params.channelId,
     channel_type: params.channelType,
     payload,
+    ...(params.onBehalfOf ? { on_behalf_of: params.onBehalfOf } : {}),
   }, params.signal);
 }
 
@@ -255,11 +257,13 @@ export async function sendTyping(params: {
   botToken: string;
   channelId: string;
   channelType: ChannelType;
+  onBehalfOf?: string;
   signal?: AbortSignal;
 }): Promise<void> {
   await postJson(params.apiUrl, params.botToken, "/v1/bot/typing", {
     channel_id: params.channelId,
     channel_type: params.channelType,
+    ...(params.onBehalfOf ? { on_behalf_of: params.onBehalfOf } : {}),
   }, params.signal);
 }
 

--- a/openclaw-channel-octo/src/config-schema.ts
+++ b/openclaw-channel-octo/src/config-schema.ts
@@ -14,6 +14,7 @@ export interface DmworkAccountConfig {
   botUid?: string;
   historyLimit?: number;  // 群聊历史消息条数限制（默认20）
   historyPromptTemplate?: string;  // Template for group history context injection
+  onBehalfOf?: string;  // Persona clone: grantor uid — bot acts on behalf of this human
 }
 
 export interface DmworkConfig {
@@ -30,6 +31,7 @@ export interface DmworkConfig {
   botUid?: string;
   historyLimit?: number;  // 群聊历史消息条数限制（默认20）
   historyPromptTemplate?: string;  // Template for group history context injection
+  onBehalfOf?: string;  // Persona clone: grantor uid — bot acts on behalf of this human
   accounts?: Record<string, DmworkAccountConfig | undefined>;
 }
 
@@ -73,6 +75,7 @@ export const DmworkConfigJsonSchema = {
             botUid: { type: "string" },
             historyLimit: { type: "number", minimum: 1, maximum: 100 },
             historyPromptTemplate: { type: "string" },
+            onBehalfOf: { type: "string" },
           },
         },
       },

--- a/openclaw-channel-octo/src/config-schema.ts
+++ b/openclaw-channel-octo/src/config-schema.ts
@@ -57,6 +57,7 @@ export const DmworkConfigJsonSchema = {
       botUid: { type: "string" },
       historyLimit: { type: "number", minimum: 1, maximum: 100 },
       historyPromptTemplate: { type: "string" },
+      onBehalfOf: { type: "string" },
       accounts: {
         type: "object",
         additionalProperties: {

--- a/openclaw-channel-octo/src/inbound.test.ts
+++ b/openclaw-channel-octo/src/inbound.test.ts
@@ -2388,3 +2388,257 @@ describe("OBO v2 relevance filter + ignoreMentionAll (PR#61 R8)", () => {
     ).toBe(false);
   });
 });
+
+/**
+ * Tests for OBO v2 detection + relevance filter ordering (PR#61 R10).
+ *
+ * Jerry-Xin + lml2468 R10 found: at d46efad8, `recordInboundSession` was
+ * fired BEFORE the OBO v2 relevance filter, so irrelevant OBO v2 fan-out
+ * messages (e.g. AI-only) were already persisted to the bot's DM session
+ * with the grantor — including any `obo_system_hint` from the payload as
+ * GroupSystemPrompt. This violated the group-path early-return contract
+ * (~inbound.ts:1300), where non-mention group messages return BEFORE
+ * finalizeInboundContext / recordInboundSession.
+ *
+ * The fix moves the `isOBOv2` computation and the relevance filter
+ * BEFORE finalizeInboundContext / recordInboundSession in inbound.ts.
+ * These tests guard against regressing the ordering.
+ */
+describe("OBO v2 detection + filter ordering vs recordInboundSession (PR#61 R10)", () => {
+  type ObovPayload = {
+    obo_origin_channel_id?: string;
+    obo_origin_channel_type?: number;
+    obo_respond_as?: string;
+    obo_grantor_uid?: string;
+    obo_system_hint?: string;
+    mention?: {
+      ais?: boolean | number;
+      humans?: boolean | number;
+      all?: boolean | number;
+      uids?: string[];
+    };
+  };
+  type Account = { onBehalfOf?: string; ignoreMentionAll?: boolean };
+  type Message = { from_uid: string; payload?: ObovPayload };
+
+  type Sinks = {
+    recordInboundSession: ReturnType<typeof vi.fn>;
+    finalizeInboundContext: ReturnType<typeof vi.fn>;
+  };
+
+  /**
+   * Mirrors the post-fix control flow at inbound.ts (~L1582-L1700):
+   * 1) compute `isOBOv2` BEFORE finalizeInboundContext
+   * 2) run the relevance filter BEFORE finalizeInboundContext
+   * 3) early-return WITHOUT recordInboundSession for irrelevant OBO v2
+   * 4) only then call finalizeInboundContext + recordInboundSession
+   */
+  function simulateInbound(
+    message: Message,
+    account: Account,
+    sinks: Sinks,
+  ): { dispatched: boolean; rejected: boolean; skipped: boolean } {
+    const oboV2OriginChannel = message.payload?.obo_origin_channel_id;
+    const oboV2RespondAs =
+      message.payload?.obo_respond_as ?? message.payload?.obo_grantor_uid;
+    const grantorUid = account.onBehalfOf;
+    const isOBOv2 = Boolean(
+      typeof oboV2OriginChannel === "string" &&
+      oboV2OriginChannel.length > 0 &&
+      typeof oboV2RespondAs === "string" &&
+      oboV2RespondAs.length > 0 &&
+      grantorUid &&
+      message.from_uid === grantorUid,
+    );
+
+    let rejected = false;
+    if (
+      !isOBOv2 &&
+      typeof oboV2OriginChannel === "string" &&
+      oboV2OriginChannel.length > 0
+    ) {
+      rejected = true;
+    }
+
+    if (isOBOv2) {
+      const m = message.payload?.mention;
+      const ais = m?.ais === true || m?.ais === 1;
+      const humans = m?.humans === true || m?.humans === 1;
+      const all = m?.all === true || m?.all === 1;
+      const uids: string[] = Array.isArray(m?.uids) ? m!.uids! : [];
+      const grantorInUids =
+        typeof grantorUid === "string" &&
+        grantorUid.length > 0 &&
+        uids.includes(grantorUid);
+      const ignoreBroadcast = account.ignoreMentionAll === true;
+      const broadcastRelevant = !ignoreBroadcast && (humans || all);
+      const noMentionFallback =
+        !ais && !humans && !all && uids.length === 0;
+      const relevant = broadcastRelevant || grantorInUids || noMentionFallback;
+      if (!relevant) {
+        // Early return BEFORE finalizeInboundContext / recordInboundSession.
+        return { dispatched: false, rejected, skipped: true };
+      }
+    }
+
+    // Only relevant messages reach the persistence path.
+    sinks.finalizeInboundContext({
+      // OBO v2 payloads injected obo_system_hint as GroupSystemPrompt before
+      // the fix; with the fix this code path is only reached when relevant.
+      GroupSystemPrompt:
+        isOBOv2 && typeof message.payload?.obo_system_hint === "string"
+          ? message.payload.obo_system_hint
+          : undefined,
+    });
+    sinks.recordInboundSession();
+    return { dispatched: true, rejected, skipped: false };
+  }
+
+  const grantorUid = "admin";
+  const otherUid = "alice";
+  const baseAccount: Account = { onBehalfOf: grantorUid, ignoreMentionAll: true };
+
+  function makeSinks(): Sinks {
+    return {
+      recordInboundSession: vi.fn(),
+      finalizeInboundContext: vi.fn(),
+    };
+  }
+
+  it("irrelevant OBO v2 (mention.ais=1, ignoreMentionAll=true) → recordInboundSession is NOT called", () => {
+    const sinks = makeSinks();
+    const message: Message = {
+      from_uid: grantorUid,
+      payload: {
+        obo_origin_channel_id: "g_origin",
+        obo_origin_channel_type: ChannelType.Group,
+        obo_respond_as: grantorUid,
+        obo_system_hint: "You are admin's persona clone.",
+        mention: { ais: 1 },
+      },
+    };
+    const result = simulateInbound(message, baseAccount, sinks);
+    expect(result.skipped).toBe(true);
+    expect(result.dispatched).toBe(false);
+    // Critical regression guard: no session record, no system-hint persistence.
+    expect(sinks.recordInboundSession).not.toHaveBeenCalled();
+    expect(sinks.finalizeInboundContext).not.toHaveBeenCalled();
+  });
+
+  it("irrelevant OBO v2 (mention.humans=1 + ignoreMentionAll=true broadcast suppressed) → recordInboundSession is NOT called", () => {
+    const sinks = makeSinks();
+    const message: Message = {
+      from_uid: grantorUid,
+      payload: {
+        obo_origin_channel_id: "g_origin",
+        obo_origin_channel_type: ChannelType.Group,
+        obo_respond_as: grantorUid,
+        obo_system_hint: "You are admin's persona clone.",
+        mention: { humans: 1, ais: 1 },
+      },
+    };
+    const result = simulateInbound(message, baseAccount, sinks);
+    expect(result.skipped).toBe(true);
+    expect(sinks.recordInboundSession).not.toHaveBeenCalled();
+    expect(sinks.finalizeInboundContext).not.toHaveBeenCalled();
+  });
+
+  it("relevant OBO v2 (explicit grantor uid mention) → recordInboundSession IS called and GroupSystemPrompt is persisted", () => {
+    const sinks = makeSinks();
+    const message: Message = {
+      from_uid: grantorUid,
+      payload: {
+        obo_origin_channel_id: "g_origin",
+        obo_origin_channel_type: ChannelType.Group,
+        obo_respond_as: grantorUid,
+        obo_system_hint: "You are admin's persona clone.",
+        mention: { ais: 1, uids: [grantorUid] },
+      },
+    };
+    const result = simulateInbound(message, baseAccount, sinks);
+    expect(result.skipped).toBe(false);
+    expect(result.dispatched).toBe(true);
+    expect(sinks.finalizeInboundContext).toHaveBeenCalledTimes(1);
+    expect(sinks.recordInboundSession).toHaveBeenCalledTimes(1);
+    const ctx = sinks.finalizeInboundContext.mock.calls[0][0];
+    expect(ctx.GroupSystemPrompt).toBe("You are admin's persona clone.");
+  });
+
+  it("non-OBO v2 (forged obo fields from non-grantor sender) → recordInboundSession IS called as plain DM (warn logged), no GroupSystemPrompt", () => {
+    const sinks = makeSinks();
+    const message: Message = {
+      from_uid: otherUid,
+      payload: {
+        obo_origin_channel_id: "g_origin",
+        obo_origin_channel_type: ChannelType.Group,
+        obo_respond_as: grantorUid,
+        obo_system_hint: "trying to inject system prompt",
+        mention: { ais: 1 },
+      },
+    };
+    const result = simulateInbound(message, baseAccount, sinks);
+    // Non-grantor sender → not OBO v2 → relevance filter does not apply, so
+    // it goes to recordInboundSession as a normal DM. But the obo_system_hint
+    // must NOT leak as GroupSystemPrompt (sender is not the grantor).
+    expect(result.rejected).toBe(true);
+    expect(result.dispatched).toBe(true);
+    expect(sinks.recordInboundSession).toHaveBeenCalledTimes(1);
+    const ctx = sinks.finalizeInboundContext.mock.calls[0][0];
+    expect(ctx.GroupSystemPrompt).toBeUndefined();
+  });
+
+  /**
+   * Source-ordering regression guard: read inbound.ts and verify that the
+   * `recordInboundSession` call is AFTER the OBO v2 relevance-filter early
+   * return. This is the structural invariant R10 enforces — if a future
+   * patch reorders the calls back to the buggy d46efad8 layout, this test
+   * fails immediately.
+   */
+  it("source-order invariant: recordInboundSession appears AFTER the OBO v2 relevance-filter early return", () => {
+    const fs = require("node:fs") as typeof import("node:fs");
+    const path = require("node:path") as typeof import("node:path");
+    const src = fs.readFileSync(
+      path.join(__dirname, "inbound.ts"),
+      "utf8",
+    );
+
+    const lines = src.split("\n");
+    // First `if (isOBOv2)` block in the inbound function gates the early
+    // return that R10 introduces.
+    let firstIsObovBlockLine = -1;
+    let firstReturnAfterIsObov = -1;
+    let recordInboundSessionLine = -1;
+    let finalizeInboundContextLine = -1;
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (firstIsObovBlockLine < 0 && /^\s*if\s*\(\s*isOBOv2\s*\)/.test(line)) {
+        firstIsObovBlockLine = i;
+      }
+      if (
+        firstIsObovBlockLine >= 0 &&
+        firstReturnAfterIsObov < 0 &&
+        /^\s*return;\s*$/.test(line) &&
+        i > firstIsObovBlockLine
+      ) {
+        firstReturnAfterIsObov = i;
+      }
+      if (
+        finalizeInboundContextLine < 0 &&
+        /finalizeInboundContext\(/.test(line)
+      ) {
+        finalizeInboundContextLine = i;
+      }
+      if (
+        recordInboundSessionLine < 0 &&
+        /recordInboundSession\(/.test(line)
+      ) {
+        recordInboundSessionLine = i;
+      }
+    }
+
+    expect(firstIsObovBlockLine).toBeGreaterThan(0);
+    expect(firstReturnAfterIsObov).toBeGreaterThan(firstIsObovBlockLine);
+    expect(finalizeInboundContextLine).toBeGreaterThan(firstReturnAfterIsObov);
+    expect(recordInboundSessionLine).toBeGreaterThan(finalizeInboundContextLine);
+  });
+});

--- a/openclaw-channel-octo/src/inbound.test.ts
+++ b/openclaw-channel-octo/src/inbound.test.ts
@@ -2088,3 +2088,56 @@ describe("OBO v2 sender identity validation (GH#63)", () => {
     expect(warn).toHaveBeenCalledTimes(1);
   });
 });
+
+/**
+ * Tests for OBO v2 effective identity authority (PR#61 R5).
+ *
+ * In the isOBOv2 branch of inbound.ts (~L1685), `effectiveOnBehalfOf` is the
+ * identity we use as `on_behalf_of` for replies/typing. It MUST come from the
+ * trusted `account.config.onBehalfOf`, not from the payload field
+ * `obo_respond_as` (which is attacker-controllable in transit). When the two
+ * disagree, we keep the configured grantor and emit a warn for visibility.
+ */
+describe("OBO v2 effective identity authority (PR#61 R5)", () => {
+  type WarnSink = { warn: (msg: string) => void; info?: (msg: string) => void };
+
+  // Mirrors the assignment at inbound.ts:1685 (post-fix).
+  function resolveEffectiveOnBehalfOf(
+    oboV2RespondAs: string | undefined,
+    configuredGrantor: string,
+    log?: WarnSink,
+  ): string {
+    const effective = configuredGrantor; // trusted source
+    if (oboV2RespondAs !== effective) {
+      log?.warn(
+        `octo: OBO v2 payload respondAs=${oboV2RespondAs} differs from configured grantor=${effective} — using configured grantor`,
+      );
+    }
+    return effective;
+  }
+
+  it("payload respondAs matches configured grantor → no warn, uses configured", () => {
+    const warn = vi.fn();
+    const eff = resolveEffectiveOnBehalfOf("admin", "admin", { warn });
+    expect(eff).toBe("admin");
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("payload respondAs differs from configured grantor → warn, uses configured", () => {
+    const warn = vi.fn();
+    const eff = resolveEffectiveOnBehalfOf("evil-spoofed-uid", "admin", { warn });
+    // Authority is configured grantor, never the payload value.
+    expect(eff).toBe("admin");
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain("payload respondAs=evil-spoofed-uid");
+    expect(warn.mock.calls[0][0]).toContain("configured grantor=admin");
+    expect(warn.mock.calls[0][0]).toContain("using configured grantor");
+  });
+
+  it("payload respondAs missing → warn, still uses configured grantor", () => {
+    const warn = vi.fn();
+    const eff = resolveEffectiveOnBehalfOf(undefined, "admin", { warn });
+    expect(eff).toBe("admin");
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/openclaw-channel-octo/src/inbound.test.ts
+++ b/openclaw-channel-octo/src/inbound.test.ts
@@ -93,7 +93,13 @@ describe("mention.humans + persona clone gating", () => {
     const mentionAis = mentionAisRaw === true || mentionAisRaw === 1;
     const mentionHumans = isMentionHumans(mention);
     const isPersonaClone = Boolean(opts.onBehalfOf);
-    return (!opts.ignoreMentionAll && mentionAll) || mentionAis || (mentionHumans && isPersonaClone && !opts.ignoreMentionAll);
+    // Mirrors the production gating in src/inbound.ts (group path, PR#61 R9):
+    // when ignoreMentionAll=true and the payload carries broadcast flags
+    // (all=1 or humans=1), the whole payload is treated as broadcast and
+    // suppressed — even if `ais=1` is also set. Pure `{ais:1}` still bypasses.
+    const isBroadcast = mentionAll || mentionHumans;
+    const suppressedByIgnore = opts.ignoreMentionAll === true && isBroadcast;
+    return !suppressedByIgnore && (mentionAll || mentionAis || (mentionHumans && isPersonaClone));
   }
 
   // Helper to determine reply identity: returns "grantor" or "self"
@@ -187,6 +193,34 @@ describe("mention.humans + persona clone gating", () => {
 
   it("persona clone + ignoreMentionAll=true + mention.ais=1 → still mentioned (ais bypasses gate)", () => {
     expect(shouldRespond({ ais: 1 }, { onBehalfOf: "admin", ignoreMentionAll: true })).toBe(true);
+  });
+
+  // PR#61 R9 / YUJ-1662: legacy @everyone payload `{all:1, ais:1}` must NOT
+  // bypass ignoreMentionAll via the `ais` flag. Mixed broadcast+AI payloads
+  // are treated as broadcast and suppressed when ignoreMentionAll=true.
+  it("R9: regular bot + ignoreMentionAll=true + {all:1, ais:1} → NOT mentioned (broadcast suppresses ais)", () => {
+    expect(shouldRespond({ all: 1, ais: 1 }, { ignoreMentionAll: true })).toBe(false);
+  });
+
+  it("R9: persona clone + ignoreMentionAll=true + {all:1, ais:1} → NOT mentioned", () => {
+    expect(shouldRespond({ all: 1, ais: 1 }, { onBehalfOf: "admin", ignoreMentionAll: true })).toBe(false);
+  });
+
+  it("R9: regular bot + ignoreMentionAll=true + {humans:1, ais:1} → NOT mentioned (broadcast suppresses ais)", () => {
+    expect(shouldRespond({ humans: 1, ais: 1 }, { ignoreMentionAll: true })).toBe(false);
+  });
+
+  it("R9: persona clone + ignoreMentionAll=true + {humans:1, ais:1} → NOT mentioned", () => {
+    expect(shouldRespond({ humans: 1, ais: 1 }, { onBehalfOf: "admin", ignoreMentionAll: true })).toBe(false);
+  });
+
+  it("R9: regular bot + ignoreMentionAll=true + pure {ais:1} → SHOULD respond (AI-only is not broadcast)", () => {
+    expect(shouldRespond({ ais: 1 }, { ignoreMentionAll: true })).toBe(true);
+  });
+
+  it("R9: ignoreMentionAll=false + {all:1, ais:1} → mentioned (no suppression when flag off)", () => {
+    expect(shouldRespond({ all: 1, ais: 1 }, {})).toBe(true);
+    expect(shouldRespond({ all: 1, ais: 1 }, { onBehalfOf: "admin" })).toBe(true);
   });
 });
 

--- a/openclaw-channel-octo/src/inbound.test.ts
+++ b/openclaw-channel-octo/src/inbound.test.ts
@@ -93,7 +93,7 @@ describe("mention.humans + persona clone gating", () => {
     const mentionAis = mentionAisRaw === true || mentionAisRaw === 1;
     const mentionHumans = isMentionHumans(mention);
     const isPersonaClone = Boolean(opts.onBehalfOf);
-    return (!opts.ignoreMentionAll && mentionAll) || mentionAis || (mentionHumans && isPersonaClone);
+    return (!opts.ignoreMentionAll && mentionAll) || mentionAis || (mentionHumans && isPersonaClone && !opts.ignoreMentionAll);
   }
 
   // Helper to determine reply identity: returns "grantor" or "self"
@@ -103,7 +103,7 @@ describe("mention.humans + persona clone gating", () => {
     const mentionHumans = isMentionHumans(mention);
     const isPersonaClone = Boolean(opts.onBehalfOf);
     const isExplicitBotMention = Boolean(opts.botUidMentioned);
-    const isHumanBroadcast = mentionHumans || (!opts.ignoreMentionAll && mentionAll);
+    const isHumanBroadcast = (!opts.ignoreMentionAll && mentionHumans) || (!opts.ignoreMentionAll && mentionAll);
     const triggered = isHumanBroadcast && isPersonaClone && !isExplicitBotMention;
     return triggered ? "grantor" : "self";
   }
@@ -166,6 +166,27 @@ describe("mention.humans + persona clone gating", () => {
     expect(replyIdentity({ humans: 1 }, {})).toBe("self");
     expect(replyIdentity({ all: 1 }, {})).toBe("self");
     expect(replyIdentity({ ais: 1 }, {})).toBe("self");
+  });
+
+  // ignoreMentionAll gating — covers mention.humans (Plan X) in addition to mention.all
+  it("persona clone + ignoreMentionAll=true + mention.humans=1 → NOT mentioned", () => {
+    expect(shouldRespond({ humans: 1 }, { onBehalfOf: "admin", ignoreMentionAll: true })).toBe(false);
+  });
+
+  it("persona clone + ignoreMentionAll=true + mention.humans=true → NOT mentioned", () => {
+    expect(shouldRespond({ humans: true }, { onBehalfOf: "admin", ignoreMentionAll: true })).toBe(false);
+  });
+
+  it("persona clone + ignoreMentionAll=true + mention.humans=1 → reply identity stays self (no human broadcast)", () => {
+    expect(replyIdentity({ humans: 1 }, { onBehalfOf: "admin", ignoreMentionAll: true })).toBe("self");
+  });
+
+  it("persona clone + ignoreMentionAll=true + mention.all=1 → reply identity stays self", () => {
+    expect(replyIdentity({ all: 1 }, { onBehalfOf: "admin", ignoreMentionAll: true })).toBe("self");
+  });
+
+  it("persona clone + ignoreMentionAll=true + mention.ais=1 → still mentioned (ais bypasses gate)", () => {
+    expect(shouldRespond({ ais: 1 }, { onBehalfOf: "admin", ignoreMentionAll: true })).toBe(true);
   });
 });
 

--- a/openclaw-channel-octo/src/inbound.test.ts
+++ b/openclaw-channel-octo/src/inbound.test.ts
@@ -1937,3 +1937,154 @@ describe("inbound message_seq cutoff tracking", () => {
     expect(map.get(sessionId)).toBe(300);
   });
 });
+
+/**
+ * Tests for OBO v2 sender identity validation (GH#63).
+ *
+ * Mirrors the isOBOv2 detection logic in inbound.ts. Only payloads sent by
+ * the configured grantor (account.config.onBehalfOf) should be honored;
+ * arbitrary senders inserting obo_origin_channel_id / obo_respond_as fields
+ * must be ignored, otherwise they could trick the persona clone into
+ * replying in another channel as the grantor.
+ */
+describe("OBO v2 sender identity validation (GH#63)", () => {
+  type OboPayload = {
+    obo_origin_channel_id?: unknown;
+    obo_origin_channel_type?: unknown;
+    obo_respond_as?: unknown;
+    obo_grantor_uid?: unknown;
+  };
+  type FakeMessage = { from_uid: string; payload?: OboPayload };
+  type FakeAccount = { config: { onBehalfOf?: string } };
+  type WarnSink = { warn: (msg: string) => void };
+
+  // Mirrors the validation block at inbound.ts:1624-1642
+  function detectOBOv2(
+    message: FakeMessage,
+    account: FakeAccount,
+    log?: WarnSink,
+  ): boolean {
+    const oboV2OriginChannel = message.payload?.obo_origin_channel_id;
+    const oboV2RespondAs =
+      message.payload?.obo_respond_as ?? message.payload?.obo_grantor_uid;
+    const grantorUid = account.config.onBehalfOf;
+    const isOBOv2 = Boolean(
+      typeof oboV2OriginChannel === "string" &&
+        (oboV2OriginChannel as string).length > 0 &&
+        typeof oboV2RespondAs === "string" &&
+        (oboV2RespondAs as string).length > 0 &&
+        grantorUid &&
+        message.from_uid === grantorUid,
+    );
+    if (
+      !isOBOv2 &&
+      typeof oboV2OriginChannel === "string" &&
+      (oboV2OriginChannel as string).length > 0
+    ) {
+      log?.warn(
+        `octo: OBO v2 payload rejected — from_uid=${message.from_uid} is not configured grantor ${grantorUid ?? "(none)"}`,
+      );
+    }
+    return isOBOv2;
+  }
+
+  it("OBO v2 from configured grantor → isOBOv2=true, no warn", () => {
+    const warn = vi.fn();
+    const ok = detectOBOv2(
+      {
+        from_uid: "admin",
+        payload: {
+          obo_origin_channel_id: "group_xyz",
+          obo_origin_channel_type: ChannelType.Group,
+          obo_respond_as: "admin",
+        },
+      },
+      { config: { onBehalfOf: "admin" } },
+      { warn },
+    );
+    expect(ok).toBe(true);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("OBO v2 from non-grantor sender → isOBOv2=false, warn logged", () => {
+    const warn = vi.fn();
+    const ok = detectOBOv2(
+      {
+        from_uid: "mallory",
+        payload: {
+          obo_origin_channel_id: "group_xyz",
+          obo_origin_channel_type: ChannelType.Group,
+          obo_respond_as: "admin",
+        },
+      },
+      { config: { onBehalfOf: "admin" } },
+      { warn },
+    );
+    expect(ok).toBe(false);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain("OBO v2 payload rejected");
+    expect(warn.mock.calls[0][0]).toContain("from_uid=mallory");
+    expect(warn.mock.calls[0][0]).toContain("admin");
+  });
+
+  it("OBO v2 with no onBehalfOf configured → OBO v2 disabled, warn logged", () => {
+    const warn = vi.fn();
+    const ok = detectOBOv2(
+      {
+        from_uid: "admin",
+        payload: {
+          obo_origin_channel_id: "group_xyz",
+          obo_origin_channel_type: ChannelType.Group,
+          obo_respond_as: "admin",
+        },
+      },
+      { config: {} },
+      { warn },
+    );
+    expect(ok).toBe(false);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain("(none)");
+  });
+
+  it("no OBO payload → isOBOv2=false, no warn (nothing to reject)", () => {
+    const warn = vi.fn();
+    const ok = detectOBOv2(
+      { from_uid: "alice", payload: {} },
+      { config: { onBehalfOf: "admin" } },
+      { warn },
+    );
+    expect(ok).toBe(false);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("OBO v2 with obo_grantor_uid fallback from grantor → isOBOv2=true", () => {
+    const warn = vi.fn();
+    const ok = detectOBOv2(
+      {
+        from_uid: "admin",
+        payload: {
+          obo_origin_channel_id: "group_xyz",
+          obo_grantor_uid: "admin",
+        },
+      },
+      { config: { onBehalfOf: "admin" } },
+      { warn },
+    );
+    expect(ok).toBe(true);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("OBO v2 missing obo_respond_as / obo_grantor_uid → isOBOv2=false, warn logged", () => {
+    const warn = vi.fn();
+    const ok = detectOBOv2(
+      {
+        from_uid: "admin",
+        payload: { obo_origin_channel_id: "group_xyz" },
+      },
+      { config: { onBehalfOf: "admin" } },
+      { warn },
+    );
+    expect(ok).toBe(false);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/openclaw-channel-octo/src/inbound.test.ts
+++ b/openclaw-channel-octo/src/inbound.test.ts
@@ -2162,3 +2162,195 @@ describe("OBO v2 effective identity authority (PR#61 R5)", () => {
     expect(warn).toHaveBeenCalledTimes(1);
   });
 });
+
+/**
+ * Tests for OBO v2 relevance filter + ignoreMentionAll (PR#61 R8 / lml2468 R2).
+ *
+ * The OBO v2 path at inbound.ts:~L1653 decides whether a fan-out payload from
+ * the configured grantor is "relevant" to the persona clone. Broadcast-style
+ * mentions (`mention.humans=1`, `mention.all=1`) must respect the account's
+ * `ignoreMentionAll` flag, mirroring the group-path semantics at
+ * inbound.ts:1223 / 1230. Explicit grantor UID mentions are NOT broadcasts —
+ * they target the grantor identity directly and remain relevant regardless
+ * of `ignoreMentionAll`.
+ */
+describe("OBO v2 relevance filter + ignoreMentionAll (PR#61 R8)", () => {
+  type MentionPayload = {
+    ais?: boolean | number;
+    humans?: boolean | number;
+    all?: boolean | number;
+    uids?: string[];
+  };
+  type Opts = {
+    grantorUid: string;
+    ignoreMentionAll?: boolean;
+  };
+
+  // Mirrors the OBO v2 relevance filter at inbound.ts (post-fix).
+  function isRelevantToPersona(
+    mention: MentionPayload | undefined,
+    opts: Opts,
+  ): boolean {
+    const origAis = mention?.ais === true || mention?.ais === 1;
+    const origHumans = mention?.humans === true || mention?.humans === 1;
+    const origAll = mention?.all === true || mention?.all === 1;
+    const origUids: string[] = Array.isArray(mention?.uids) ? mention!.uids! : [];
+    const grantorInUids =
+      typeof opts.grantorUid === "string" &&
+      opts.grantorUid.length > 0 &&
+      origUids.includes(opts.grantorUid);
+    const ignoreBroadcast = opts.ignoreMentionAll === true;
+    const broadcastRelevant = !ignoreBroadcast && (origHumans || origAll);
+    const noMentionFallback =
+      !origAis && !origHumans && !origAll && origUids.length === 0;
+    return broadcastRelevant || grantorInUids || noMentionFallback;
+  }
+
+  // Baseline: defaults (no ignoreMentionAll) still work as before.
+  it("mention.humans=1 + ignoreMentionAll unset → relevant (broadcast through)", () => {
+    expect(
+      isRelevantToPersona({ humans: 1 }, { grantorUid: "admin" }),
+    ).toBe(true);
+  });
+
+  it("mention.all=1 + ignoreMentionAll unset → relevant (legacy broadcast)", () => {
+    expect(
+      isRelevantToPersona({ all: 1 }, { grantorUid: "admin" }),
+    ).toBe(true);
+  });
+
+  // Core fix: broadcasts are gated by ignoreMentionAll.
+  it("mention.humans=1 + ignoreMentionAll=true → NOT relevant (no typing/text/media)", () => {
+    expect(
+      isRelevantToPersona(
+        { humans: 1 },
+        { grantorUid: "admin", ignoreMentionAll: true },
+      ),
+    ).toBe(false);
+  });
+
+  it("mention.humans=true + ignoreMentionAll=true → NOT relevant", () => {
+    expect(
+      isRelevantToPersona(
+        { humans: true },
+        { grantorUid: "admin", ignoreMentionAll: true },
+      ),
+    ).toBe(false);
+  });
+
+  it("mention.all=1 + ignoreMentionAll=true → NOT relevant", () => {
+    expect(
+      isRelevantToPersona(
+        { all: 1 },
+        { grantorUid: "admin", ignoreMentionAll: true },
+      ),
+    ).toBe(false);
+  });
+
+  it("mention.all=true + ignoreMentionAll=true → NOT relevant", () => {
+    expect(
+      isRelevantToPersona(
+        { all: true },
+        { grantorUid: "admin", ignoreMentionAll: true },
+      ),
+    ).toBe(false);
+  });
+
+  it("both humans+all set + ignoreMentionAll=true → NOT relevant", () => {
+    expect(
+      isRelevantToPersona(
+        { humans: 1, all: 1 },
+        { grantorUid: "admin", ignoreMentionAll: true },
+      ),
+    ).toBe(false);
+  });
+
+  // Explicit grantor mention bypasses the broadcast gate.
+  it("explicit grantor uid mention + ignoreMentionAll=true → still relevant", () => {
+    expect(
+      isRelevantToPersona(
+        { uids: ["admin"] },
+        { grantorUid: "admin", ignoreMentionAll: true },
+      ),
+    ).toBe(true);
+  });
+
+  it("explicit grantor uid mention + humans=1 + ignoreMentionAll=true → relevant (uid wins)", () => {
+    expect(
+      isRelevantToPersona(
+        { humans: 1, uids: ["admin"] },
+        { grantorUid: "admin", ignoreMentionAll: true },
+      ),
+    ).toBe(true);
+  });
+
+  // @AI-only (mention.ais=1) without humans/all/grantor mention is never
+  // relevant to the persona clone — independent of ignoreMentionAll.
+  it("mention.ais=1 only + ignoreMentionAll=true → NOT relevant (@AI not for persona)", () => {
+    expect(
+      isRelevantToPersona(
+        { ais: 1 },
+        { grantorUid: "admin", ignoreMentionAll: true },
+      ),
+    ).toBe(false);
+  });
+
+  it("mention.ais=1 + humans=1 + ignoreMentionAll=true → NOT relevant (broadcast gated, ais alone is not for persona)", () => {
+    expect(
+      isRelevantToPersona(
+        { ais: 1, humans: 1 },
+        { grantorUid: "admin", ignoreMentionAll: true },
+      ),
+    ).toBe(false);
+  });
+
+  it("mention.ais=1 + grantor uid + ignoreMentionAll=true → relevant (explicit grantor uid wins)", () => {
+    expect(
+      isRelevantToPersona(
+        { ais: 1, uids: ["admin"] },
+        { grantorUid: "admin", ignoreMentionAll: true },
+      ),
+    ).toBe(true);
+  });
+
+  // No mentions at all (plain group message) — still relevant. Mirrors the
+  // existing pre-fix behavior for the no-mention fallback.
+  it("no mention payload + ignoreMentionAll=true → relevant (no-mention fallback)", () => {
+    expect(
+      isRelevantToPersona(
+        undefined,
+        { grantorUid: "admin", ignoreMentionAll: true },
+      ),
+    ).toBe(true);
+  });
+
+  it("empty mention object + ignoreMentionAll=true → relevant (no-mention fallback)", () => {
+    expect(
+      isRelevantToPersona(
+        {},
+        { grantorUid: "admin", ignoreMentionAll: true },
+      ),
+    ).toBe(true);
+  });
+
+  // Symmetry check with the group-path semantics tests above (~L172-185).
+  it("group-path parity: ignoreMentionAll=true suppresses humans broadcast for persona clone", () => {
+    // Group path: shouldRespond({ humans: 1 }, { onBehalfOf, ignoreMentionAll: true }) === false
+    // OBO v2 path: must reach the same conclusion.
+    expect(
+      isRelevantToPersona(
+        { humans: 1 },
+        { grantorUid: "admin", ignoreMentionAll: true },
+      ),
+    ).toBe(false);
+  });
+
+  it("group-path parity: ignoreMentionAll=true suppresses all broadcast for persona clone", () => {
+    expect(
+      isRelevantToPersona(
+        { all: 1 },
+        { grantorUid: "admin", ignoreMentionAll: true },
+      ),
+    ).toBe(false);
+  });
+});

--- a/openclaw-channel-octo/src/inbound.test.ts
+++ b/openclaw-channel-octo/src/inbound.test.ts
@@ -74,6 +74,102 @@ describe("mention.all detection", () => {
 });
 
 /**
+ * Tests for mention.humans + persona clone (onBehalfOf) gating.
+ *
+ * Plan X: mention.humans=1 means @所有人 (human-only notification).
+ * Regular bots should NOT respond. Persona clone bots (onBehalfOf configured)
+ * SHOULD respond because they act on behalf of a human who is part of @所有人.
+ */
+describe("mention.humans + persona clone gating", () => {
+  function isMentionHumans(mention?: MentionPayload): boolean {
+    const raw = mention?.humans;
+    return raw === true || raw === 1;
+  }
+
+  function shouldRespond(mention: MentionPayload | undefined, opts: { onBehalfOf?: string; ignoreMentionAll?: boolean }): boolean {
+    const mentionAllRaw = mention?.all;
+    const mentionAll = mentionAllRaw === true || mentionAllRaw === 1;
+    const mentionAisRaw = mention?.ais;
+    const mentionAis = mentionAisRaw === true || mentionAisRaw === 1;
+    const mentionHumans = isMentionHumans(mention);
+    const isPersonaClone = Boolean(opts.onBehalfOf);
+    return (!opts.ignoreMentionAll && mentionAll) || mentionAis || (mentionHumans && isPersonaClone);
+  }
+
+  // Helper to determine reply identity: returns "grantor" or "self"
+  function replyIdentity(mention: MentionPayload | undefined, opts: { onBehalfOf?: string; ignoreMentionAll?: boolean; botUidMentioned?: boolean }): "grantor" | "self" {
+    const mentionAllRaw = mention?.all;
+    const mentionAll = mentionAllRaw === true || mentionAllRaw === 1;
+    const mentionHumans = isMentionHumans(mention);
+    const isPersonaClone = Boolean(opts.onBehalfOf);
+    const isExplicitBotMention = Boolean(opts.botUidMentioned);
+    const isHumanBroadcast = mentionHumans || (!opts.ignoreMentionAll && mentionAll);
+    const triggered = isHumanBroadcast && isPersonaClone && !isExplicitBotMention;
+    return triggered ? "grantor" : "self";
+  }
+
+  it("persona clone bot should respond to mention.humans=1", () => {
+    expect(shouldRespond({ humans: 1 }, { onBehalfOf: "admin" })).toBe(true);
+  });
+
+  it("persona clone bot should respond to mention.humans=true", () => {
+    expect(shouldRespond({ humans: true }, { onBehalfOf: "admin" })).toBe(true);
+  });
+
+  it("regular bot should NOT respond to mention.humans=1", () => {
+    expect(shouldRespond({ humans: 1 }, {})).toBe(false);
+  });
+
+  it("regular bot should NOT respond to mention.humans=true", () => {
+    expect(shouldRespond({ humans: true }, {})).toBe(false);
+  });
+
+  it("persona clone bot should still respond to mention.ais=1", () => {
+    expect(shouldRespond({ ais: 1 }, { onBehalfOf: "admin" })).toBe(true);
+  });
+
+  it("regular bot should respond to mention.ais=1", () => {
+    expect(shouldRespond({ ais: 1 }, {})).toBe(true);
+  });
+
+  it("mention.humans=0 should NOT trigger persona clone", () => {
+    expect(shouldRespond({ humans: 0 }, { onBehalfOf: "admin" })).toBe(false);
+  });
+
+  it("mention.humans=1 + ais=1 should trigger both types", () => {
+    expect(shouldRespond({ humans: 1, ais: 1 }, { onBehalfOf: "admin" })).toBe(true);
+    expect(shouldRespond({ humans: 1, ais: 1 }, {})).toBe(true); // ais=1 triggers regular bot
+  });
+
+  it("legacy all=1 should trigger persona clone (via mentionAll path)", () => {
+    expect(shouldRespond({ all: 1 }, { onBehalfOf: "admin" })).toBe(true);
+  });
+
+  // Identity tests
+  it("@所有人 (humans=1) → persona clone replies as grantor", () => {
+    expect(replyIdentity({ humans: 1 }, { onBehalfOf: "admin" })).toBe("grantor");
+  });
+
+  it("legacy @所有人 (all=1, server rewrite to {all:1,ais:1}) → persona clone replies as grantor", () => {
+    expect(replyIdentity({ all: 1, ais: 1 }, { onBehalfOf: "admin" })).toBe("grantor");
+  });
+
+  it("@所有AI (ais=1 only) → persona clone replies as self", () => {
+    expect(replyIdentity({ ais: 1 }, { onBehalfOf: "admin" })).toBe("self");
+  });
+
+  it("direct @james mention → persona clone replies as self", () => {
+    expect(replyIdentity({ humans: 1 }, { onBehalfOf: "admin", botUidMentioned: true })).toBe("self");
+  });
+
+  it("regular bot always replies as self regardless of mention type", () => {
+    expect(replyIdentity({ humans: 1 }, {})).toBe("self");
+    expect(replyIdentity({ all: 1 }, {})).toBe("self");
+    expect(replyIdentity({ ais: 1 }, {})).toBe("self");
+  });
+});
+
+/**
  * Tests for historyPromptTemplate configuration.
  *
  * The template supports placeholders:

--- a/openclaw-channel-octo/src/inbound.ts
+++ b/openclaw-channel-octo/src/inbound.ts
@@ -1204,7 +1204,10 @@ export async function handleInboundMessage(params: {
     const mentionUids = extractMentionUids(message.payload?.mention);
     const mentionAllRaw = message.payload?.mention?.all;
     const mentionAll: boolean = mentionAllRaw === true || mentionAllRaw === 1;
-    isMentioned = (!account.config.ignoreMentionAll && mentionAll) || mentionUids.includes(botUid);
+    // mention.ais=1 means @AI / @所有AI — bots should respond
+    const mentionAisRaw = message.payload?.mention?.ais;
+    const mentionAis: boolean = mentionAisRaw === true || mentionAisRaw === 1;
+    isMentioned = (!account.config.ignoreMentionAll && mentionAll) || mentionAis || mentionUids.includes(botUid);
     isExplicitBotMention = mentionUids.includes(botUid);
 
     // Defensive fallback: if payload.mention is missing/empty but the message
@@ -1565,7 +1568,11 @@ export async function handleInboundMessage(params: {
     MessageSid: String(message.message_id),
     Timestamp: message.timestamp ? message.timestamp * 1000 : undefined,
     GroupSubject: isGroup ? message.channel_id : undefined,
-    GroupSystemPrompt: undefined,
+    // OBO v2: inject obo_system_hint as GroupSystemPrompt so it reaches LLM
+    // as a system-level instruction (persona identity + reply context)
+    GroupSystemPrompt: (typeof message.payload?.obo_system_hint === "string" && message.payload.obo_system_hint.length > 0)
+      ? message.payload.obo_system_hint
+      : undefined,
     Provider: CHANNEL_ID,
     Surface: CHANNEL_ID,
     OriginatingChannel: CHANNEL_ID,
@@ -1583,25 +1590,72 @@ export async function handleInboundMessage(params: {
 
   statusSink?.({ lastInboundAt: Date.now(), lastError: null });
 
-  const replyChannelId = isGroup ? message.channel_id! : message.from_uid;
-  const replyChannelType = isGroup ? (message.channel_type ?? ChannelType.Group) : ChannelType.DM;
+  // OBO v2: when the payload carries `obo_origin_channel_id`, the reply should
+  // go to the origin GROUP channel (not the DM), with `on_behalf_of` set to
+  // `obo_respond_as` (the grantor). This way the bot replies in the group as
+  // the grantor, not in DM.
+  const oboV2OriginChannel = message.payload?.obo_origin_channel_id;
+  const oboV2OriginChannelType = message.payload?.obo_origin_channel_type;
+  const oboV2RespondAs = message.payload?.obo_respond_as ?? message.payload?.obo_grantor_uid;
+  const isOBOv2 = Boolean(
+    typeof oboV2OriginChannel === "string" &&
+    oboV2OriginChannel.length > 0 &&
+    typeof oboV2RespondAs === "string" &&
+    oboV2RespondAs.length > 0
+  );
 
-  // 已读回执 + 正在输入 — fire-and-forget
-  log?.info?.(`octo: sending readReceipt+typing to channel=${replyChannelId} type=${replyChannelType} apiUrl=${account.config.apiUrl}`);
-  const messageIds = message.message_id ? [message.message_id] : [];
-  sendReadReceipt({ apiUrl: account.config.apiUrl, botToken: account.config.botToken ?? "", channelId: replyChannelId, channelType: replyChannelType, messageIds })
-    .then(() => log?.info?.("octo: readReceipt sent OK"))
-    .catch((err) => log?.error?.(`octo: readReceipt failed: ${String(err)}`));
-  sendTyping({ apiUrl: account.config.apiUrl, botToken: account.config.botToken ?? "", channelId: replyChannelId, channelType: replyChannelType })
-    .then(() => log?.info?.("octo: typing sent OK"))
-    .catch((err) => log?.error?.(`octo: typing failed: ${String(err)}`));
+  let replyChannelId: string;
+  let replyChannelType: ChannelType;
+  let effectiveOnBehalfOf: string | undefined;
+
+  if (isOBOv2) {
+    const oboV2OriginFromUid = message.payload?.obo_origin_from_uid;
+    const resolvedChannelType = (typeof oboV2OriginChannelType === "number" ? oboV2OriginChannelType : ChannelType.Group) as ChannelType;
+    if (resolvedChannelType === ChannelType.DM) {
+      // DM: bot is only friends with the grantor, not the original sender.
+      // Reply to the original sender (bob) using on_behalf_of=grantor (admin).
+      // The channel is the original sender's uid — the server routes
+      // admin→bob DM via on_behalf_of, which bypasses the bot-friend gate.
+      replyChannelId = (typeof oboV2OriginFromUid === "string" && oboV2OriginFromUid.length > 0)
+        ? oboV2OriginFromUid
+        : oboV2OriginChannel as string;
+    } else {
+      // Group/Thread: reply to the origin group
+      replyChannelId = oboV2OriginChannel as string;
+    }
+    replyChannelType = resolvedChannelType;
+    effectiveOnBehalfOf = oboV2RespondAs as string;
+    log?.info?.(`octo: OBO v2 detected — reply target=${replyChannelId} type=${replyChannelType} respondAs=${effectiveOnBehalfOf} originFrom=${oboV2OriginFromUid}`);
+  } else {
+    replyChannelId = isGroup ? message.channel_id! : message.from_uid;
+    replyChannelType = isGroup ? (message.channel_type ?? ChannelType.Group) : ChannelType.DM;
+    effectiveOnBehalfOf = undefined;
+  }
 
   const apiUrl = account.config.apiUrl;
   const botToken = account.config.botToken ?? "";
 
+  // 已读回执 + 正在输入 — fire-and-forget
+  if (isOBOv2) {
+    // v2: send typing to origin group with grantor identity (skip readReceipt)
+    log?.info?.(`octo: OBO v2 — sending typing to origin group=${replyChannelId} as=${effectiveOnBehalfOf}`);
+    sendTyping({ apiUrl, botToken, channelId: replyChannelId, channelType: replyChannelType, onBehalfOf: effectiveOnBehalfOf })
+      .then(() => log?.info?.("octo: OBO v2 typing sent OK"))
+      .catch((err) => log?.error?.(`octo: OBO v2 typing failed: ${String(err)}`));
+  } else {
+    log?.info?.(`octo: sending readReceipt+typing to channel=${replyChannelId} type=${replyChannelType} apiUrl=${apiUrl}`);
+    const messageIds = message.message_id ? [message.message_id] : [];
+    sendReadReceipt({ apiUrl, botToken, channelId: replyChannelId, channelType: replyChannelType, messageIds })
+      .then(() => log?.info?.("octo: readReceipt sent OK"))
+      .catch((err) => log?.error?.(`octo: readReceipt failed: ${String(err)}`));
+    sendTyping({ apiUrl, botToken, channelId: replyChannelId, channelType: replyChannelType })
+      .then(() => log?.info?.("octo: typing sent OK"))
+      .catch((err) => log?.error?.(`octo: typing failed: ${String(err)}`));
+  }
+
   // Keep sending typing indicator while AI is processing
   const typingInterval = setInterval(() => {
-    sendTyping({ apiUrl, botToken, channelId: replyChannelId, channelType: replyChannelType }).catch(() => {});
+    sendTyping({ apiUrl, botToken, channelId: replyChannelId, channelType: replyChannelType, ...(isOBOv2 ? { onBehalfOf: effectiveOnBehalfOf } : {}) }).catch(() => {});
   }, 5000);
 
   // Buffer text across streaming deliver calls; only send once after dispatcher finishes.
@@ -1720,6 +1774,7 @@ export async function handleInboundMessage(params: {
       ...(replyMentionUids.length > 0 ? { mentionUids: replyMentionUids } : {}),
       ...(replyMentionEntities.length > 0 ? { mentionEntities: replyMentionEntities } : {}),
       mentionAll: hasAtAll || undefined,
+      ...(effectiveOnBehalfOf ? { onBehalfOf: effectiveOnBehalfOf } : {}),
     });
     statusSink?.({ lastOutboundAt: Date.now(), lastError: null });
     return result;
@@ -1798,6 +1853,7 @@ export async function handleInboundMessage(params: {
               channelId: replyChannelId,
               channelType: replyChannelType,
               content: "⚠️ 抱歉，处理您的消息时遇到了问题，请稍后重试。",
+              ...(effectiveOnBehalfOf ? { onBehalfOf: effectiveOnBehalfOf } : {}),
             });
           } catch (sendErr) {
             log?.error?.(`octo: failed to send error message: ${String(sendErr)}`);

--- a/openclaw-channel-octo/src/inbound.ts
+++ b/openclaw-channel-octo/src/inbound.ts
@@ -1624,12 +1624,22 @@ export async function handleInboundMessage(params: {
   const oboV2OriginChannel = message.payload?.obo_origin_channel_id;
   const oboV2OriginChannelType = message.payload?.obo_origin_channel_type;
   const oboV2RespondAs = message.payload?.obo_respond_as ?? message.payload?.obo_grantor_uid;
+  const grantorUid = account.config.onBehalfOf;
   const isOBOv2 = Boolean(
     typeof oboV2OriginChannel === "string" &&
     oboV2OriginChannel.length > 0 &&
     typeof oboV2RespondAs === "string" &&
-    oboV2RespondAs.length > 0
+    oboV2RespondAs.length > 0 &&
+    // Security: only trust OBO v2 fields when the message is sent by the
+    // configured grantor. Without this, any user able to put obo_* fields in
+    // their payload could trick the bot into replying in another channel as
+    // somebody else's persona.
+    grantorUid && message.from_uid === grantorUid
   );
+
+  if (!isOBOv2 && typeof oboV2OriginChannel === "string" && oboV2OriginChannel.length > 0) {
+    log?.warn?.(`octo: OBO v2 payload rejected — from_uid=${message.from_uid} is not configured grantor ${grantorUid ?? "(none)"}`);
+  }
 
   // OBO v2 relevance filter: when the fan-out message is @AI-only (mention.ais=1
   // but no grantor mention, no @所有人), the persona clone should NOT respond.

--- a/openclaw-channel-octo/src/inbound.ts
+++ b/openclaw-channel-octo/src/inbound.ts
@@ -1230,7 +1230,7 @@ export async function handleInboundMessage(params: {
 
     // Debug: log mention flags for troubleshooting persona clone routing
     if (isPersonaClone) {
-      log?.info?.(`octo: [MENTION-DEBUG] mentionAll=${mentionAll} mentionAis=${mentionAis} mentionHumans=${mentionHumans} isExplicitBot=${isExplicitBotMention} isHumanBroadcast=${isHumanBroadcast} triggeredAsGrantor=${triggeredByMentionHumans} isMentioned=${isMentioned}`);
+      log?.debug?.(`octo: [MENTION-DEBUG] mentionAll=${mentionAll} mentionAis=${mentionAis} mentionHumans=${mentionHumans} isExplicitBot=${isExplicitBotMention} isHumanBroadcast=${isHumanBroadcast} triggeredAsGrantor=${triggeredByMentionHumans} isMentioned=${isMentioned}`);
     }
 
     // Defensive fallback: if payload.mention is missing/empty but the message
@@ -1591,11 +1591,15 @@ export async function handleInboundMessage(params: {
     MessageSid: String(message.message_id),
     Timestamp: message.timestamp ? message.timestamp * 1000 : undefined,
     GroupSubject: isGroup ? message.channel_id : undefined,
-    // OBO v2: inject obo_system_hint as GroupSystemPrompt so it reaches LLM
-    // as a system-level instruction (persona identity + reply context)
-    GroupSystemPrompt: (typeof message.payload?.obo_system_hint === "string" && message.payload.obo_system_hint.length > 0)
-      ? message.payload.obo_system_hint
-      : undefined,
+    // OBO v2: inject obo_system_hint as GroupSystemPrompt ONLY when the message
+    // carries a valid OBO v2 envelope (obo_origin_channel_id + obo_respond_as).
+    // Without this gate, any sender who can set obo_system_hint in a payload
+    // could inject arbitrary system-level instructions into the LLM.
+    GroupSystemPrompt: (
+      typeof message.payload?.obo_system_hint === "string" && message.payload.obo_system_hint.length > 0 &&
+      typeof message.payload?.obo_origin_channel_id === "string" && message.payload.obo_origin_channel_id.length > 0 &&
+      typeof (message.payload?.obo_respond_as ?? message.payload?.obo_grantor_uid) === "string"
+    ) ? message.payload.obo_system_hint : undefined,
     Provider: CHANNEL_ID,
     Surface: CHANNEL_ID,
     OriginatingChannel: CHANNEL_ID,
@@ -1905,7 +1909,7 @@ export async function handleInboundMessage(params: {
     });
   } finally {
     // --- Debug: log dispatch outcome ---
-    log?.info?.(`octo: [dispatch-result] replySucceeded=${replySucceeded} bufferedText=${deliverBuffer.lastText?.length ?? 0} textSent=${deliverBuffer.textSent} effectiveOBO=${effectiveOnBehalfOf ?? 'none'}`);
+    log?.debug?.(`octo: [dispatch-result] replySucceeded=${replySucceeded} bufferedText=${deliverBuffer.lastText?.length ?? 0} textSent=${deliverBuffer.textSent} effectiveOBO=${effectiveOnBehalfOf ?? 'none'}`);
 
     // --- Final send: deliver buffered text if only blocks arrived (no final/tool) ---
     if (deliverBuffer.lastText && !deliverBuffer.textSent) {

--- a/openclaw-channel-octo/src/inbound.ts
+++ b/openclaw-channel-octo/src/inbound.ts
@@ -1592,13 +1592,17 @@ export async function handleInboundMessage(params: {
     Timestamp: message.timestamp ? message.timestamp * 1000 : undefined,
     GroupSubject: isGroup ? message.channel_id : undefined,
     // OBO v2: inject obo_system_hint as GroupSystemPrompt ONLY when the message
-    // carries a valid OBO v2 envelope (obo_origin_channel_id + obo_respond_as).
-    // Without this gate, any sender who can set obo_system_hint in a payload
-    // could inject arbitrary system-level instructions into the LLM.
+    // carries a valid OBO v2 envelope (obo_origin_channel_id + obo_respond_as)
+    // AND the sender is the configured grantor (onBehalfOf). Without the sender
+    // gate, a forged message from any uid could inject arbitrary system-level
+    // instructions into the LLM — the downstream OBO routing would be rejected,
+    // but the system prompt would already be in the session context.
     GroupSystemPrompt: (
       typeof message.payload?.obo_system_hint === "string" && message.payload.obo_system_hint.length > 0 &&
       typeof message.payload?.obo_origin_channel_id === "string" && message.payload.obo_origin_channel_id.length > 0 &&
-      typeof (message.payload?.obo_respond_as ?? message.payload?.obo_grantor_uid) === "string"
+      typeof (message.payload?.obo_respond_as ?? message.payload?.obo_grantor_uid) === "string" &&
+      // Security: only trust system hint from the configured grantor
+      Boolean(account.config.onBehalfOf) && message.from_uid === account.config.onBehalfOf
     ) ? message.payload.obo_system_hint : undefined,
     Provider: CHANNEL_ID,
     Surface: CHANNEL_ID,

--- a/openclaw-channel-octo/src/inbound.ts
+++ b/openclaw-channel-octo/src/inbound.ts
@@ -1220,7 +1220,20 @@ export async function handleInboundMessage(params: {
     // Persona clone: when the GRANTOR is @mentioned, treat it as a mention
     // for the bot too (the bot acts on the grantor's behalf).
     const grantorMentioned: boolean = !!(isPersonaClone && grantorUid && mentionUids.includes(grantorUid));
-    isMentioned = (!account.config.ignoreMentionAll && mentionAll) || mentionAis || mentionUids.includes(botUid) || (mentionHumans && isPersonaClone && !account.config.ignoreMentionAll) || grantorMentioned;
+    // Broadcast suppression (PR#61 R9 / YUJ-1662):
+    // When `ignoreMentionAll=true`, a legacy `@everyone` payload arrives as `{all:1, ais:1}`
+    // (server rewrites @所有人 to include ais=1 so AIs are also covered). Treating that as a
+    // pure AI mention would let `mentionAis` bypass `ignoreMentionAll`, which is wrong:
+    // the user's intent is "no broadcast → bot stays silent". So when broadcast flags
+    // (`all` or `humans`) are present, the whole payload is treated as broadcast and
+    // suppressed by `ignoreMentionAll`. Pure `{ais:1}` (no `all`, no `humans`) is still
+    // a deliberate AI-only mention and continues to trigger the bot.
+    // Explicit bot UID and grantor mention always work regardless of `ignoreMentionAll`.
+    const isBroadcast = mentionAll || mentionHumans;
+    const suppressedByIgnore = account.config.ignoreMentionAll && isBroadcast;
+    isMentioned = (!suppressedByIgnore && (mentionAll || mentionAis || (mentionHumans && isPersonaClone)))
+      || mentionUids.includes(botUid)
+      || grantorMentioned;
     isExplicitBotMention = mentionUids.includes(botUid);
     // Track whether the bot was triggered as the grantor's proxy.
     // When true, persona clone replies as the grantor (admin), not as itself.

--- a/openclaw-channel-octo/src/inbound.ts
+++ b/openclaw-channel-octo/src/inbound.ts
@@ -1214,15 +1214,19 @@ export async function handleInboundMessage(params: {
     const mentionHumansRaw = message.payload?.mention?.humans;
     const mentionHumans: boolean = mentionHumansRaw === true || mentionHumansRaw === 1;
     const isPersonaClone = Boolean(account.config.onBehalfOf);
-    isMentioned = (!account.config.ignoreMentionAll && mentionAll) || mentionAis || mentionUids.includes(botUid) || (mentionHumans && isPersonaClone);
+    const grantorUid = account.config.onBehalfOf;
+    // Persona clone: when the GRANTOR is @mentioned, treat it as a mention
+    // for the bot too (the bot acts on the grantor's behalf).
+    const grantorMentioned: boolean = !!(isPersonaClone && grantorUid && mentionUids.includes(grantorUid));
+    isMentioned = (!account.config.ignoreMentionAll && mentionAll) || mentionAis || mentionUids.includes(botUid) || (mentionHumans && isPersonaClone) || grantorMentioned;
     isExplicitBotMention = mentionUids.includes(botUid);
-    // Track whether the bot was triggered by a "human broadcast" (@所有人 in any form).
+    // Track whether the bot was triggered as the grantor's proxy.
     // When true, persona clone replies as the grantor (admin), not as itself.
-    // Covers both new `mention.humans=1` AND legacy `mention.all=1` (which the server
-    // rewrites to {all:1, ais:1} per Plan X). @所有AI (ais=1 only) and direct @james
+    // Covers: @admin (grantor uid mentioned), @所有人 (mention.humans=1),
+    // legacy @所有人 (mention.all=1). @所有AI (ais=1 only) and direct @james
     // mentions should still respond as the bot itself.
     const isHumanBroadcast = mentionHumans || (!account.config.ignoreMentionAll && mentionAll);
-    triggeredByMentionHumans = isHumanBroadcast && isPersonaClone && !isExplicitBotMention;
+    triggeredByMentionHumans = !!(isHumanBroadcast || grantorMentioned) && isPersonaClone && !isExplicitBotMention;
 
     // Debug: log mention flags for troubleshooting persona clone routing
     if (isPersonaClone) {
@@ -1622,6 +1626,23 @@ export async function handleInboundMessage(params: {
     typeof oboV2RespondAs === "string" &&
     oboV2RespondAs.length > 0
   );
+
+  // OBO v2 relevance filter: when the fan-out message is @AI-only (mention.ais=1
+  // but no grantor mention, no @所有人), the persona clone should NOT respond.
+  // @AI targets AI bots directly, not humans or their persona clones.
+  if (isOBOv2) {
+    const origMention = message.payload?.mention;
+    const origAis = origMention?.ais === true || origMention?.ais === 1;
+    const origHumans = origMention?.humans === true || origMention?.humans === 1;
+    const origAll = origMention?.all === true || origMention?.all === 1;
+    const origUids: string[] = Array.isArray(origMention?.uids) ? origMention.uids : [];
+    const grantorInUids = typeof oboV2RespondAs === "string" && origUids.includes(oboV2RespondAs);
+    const isRelevantToPersona = origHumans || origAll || grantorInUids || (!origAis && origUids.length === 0);
+    if (!isRelevantToPersona) {
+      log?.info?.(`octo: OBO v2 skipped — message not relevant to persona (ais=${origAis} humans=${origHumans} all=${origAll} grantorInUids=${grantorInUids})`);
+      return;
+    }
+  }
 
   let replyChannelId: string;
   let replyChannelType: ChannelType;

--- a/openclaw-channel-octo/src/inbound.ts
+++ b/openclaw-channel-octo/src/inbound.ts
@@ -66,9 +66,10 @@ export async function uploadAndSendMedia(params: {
   botToken: string;
   channelId: string;
   channelType: ChannelType;
+  onBehalfOf?: string;
   log?: ChannelLogSink;
 }): Promise<SendMessageResult | undefined> {
-  const { mediaUrl, apiUrl, botToken, channelId, channelType, log } = params;
+  const { mediaUrl, apiUrl, botToken, channelId, channelType, onBehalfOf, log } = params;
 
   const { createReadStream: fsCreateReadStream, statSync: fsStatSync, createWriteStream: fsCreateWriteStream } = await import("node:fs");
   const { basename, join: pathJoin } = await import("node:path");
@@ -173,6 +174,7 @@ export async function uploadAndSendMedia(params: {
       size: fileSize,
       width,
       height,
+      ...(onBehalfOf ? { onBehalfOf } : {}),
     });
     return result;
   } finally {
@@ -1218,14 +1220,14 @@ export async function handleInboundMessage(params: {
     // Persona clone: when the GRANTOR is @mentioned, treat it as a mention
     // for the bot too (the bot acts on the grantor's behalf).
     const grantorMentioned: boolean = !!(isPersonaClone && grantorUid && mentionUids.includes(grantorUid));
-    isMentioned = (!account.config.ignoreMentionAll && mentionAll) || mentionAis || mentionUids.includes(botUid) || (mentionHumans && isPersonaClone) || grantorMentioned;
+    isMentioned = (!account.config.ignoreMentionAll && mentionAll) || mentionAis || mentionUids.includes(botUid) || (mentionHumans && isPersonaClone && !account.config.ignoreMentionAll) || grantorMentioned;
     isExplicitBotMention = mentionUids.includes(botUid);
     // Track whether the bot was triggered as the grantor's proxy.
     // When true, persona clone replies as the grantor (admin), not as itself.
     // Covers: @admin (grantor uid mentioned), @所有人 (mention.humans=1),
     // legacy @所有人 (mention.all=1). @所有AI (ais=1 only) and direct @james
     // mentions should still respond as the bot itself.
-    const isHumanBroadcast = mentionHumans || (!account.config.ignoreMentionAll && mentionAll);
+    const isHumanBroadcast = (!account.config.ignoreMentionAll && mentionHumans) || (!account.config.ignoreMentionAll && mentionAll);
     triggeredByMentionHumans = !!(isHumanBroadcast || grantorMentioned) && isPersonaClone && !isExplicitBotMention;
 
     // Debug: log mention flags for troubleshooting persona clone routing
@@ -1879,6 +1881,7 @@ export async function handleInboundMessage(params: {
                 botToken: account.config.botToken ?? "",
                 channelId: replyChannelId,
                 channelType: replyChannelType,
+                ...(effectiveOnBehalfOf ? { onBehalfOf: effectiveOnBehalfOf } : {}),
                 log,
               });
               sentMediaUrls.add(mediaUrl);

--- a/openclaw-channel-octo/src/inbound.ts
+++ b/openclaw-channel-octo/src/inbound.ts
@@ -1200,6 +1200,7 @@ export async function handleInboundMessage(params: {
   // Compute mention flags — separate "reply gating" from "command gating"
   let isMentioned = false;
   let isExplicitBotMention = false;
+  let triggeredByMentionHumans = false;
   if (isGroup) {
     const mentionUids = extractMentionUids(message.payload?.mention);
     const mentionAllRaw = message.payload?.mention?.all;
@@ -1207,8 +1208,26 @@ export async function handleInboundMessage(params: {
     // mention.ais=1 means @AI / @所有AI — bots should respond
     const mentionAisRaw = message.payload?.mention?.ais;
     const mentionAis: boolean = mentionAisRaw === true || mentionAisRaw === 1;
-    isMentioned = (!account.config.ignoreMentionAll && mentionAll) || mentionAis || mentionUids.includes(botUid);
+    // mention.humans=1 means @所有人 (Plan X) — only persona-clone bots respond,
+    // because they act on behalf of a human who IS part of @所有人.
+    // Regular bots without onBehalfOf stay silent.
+    const mentionHumansRaw = message.payload?.mention?.humans;
+    const mentionHumans: boolean = mentionHumansRaw === true || mentionHumansRaw === 1;
+    const isPersonaClone = Boolean(account.config.onBehalfOf);
+    isMentioned = (!account.config.ignoreMentionAll && mentionAll) || mentionAis || mentionUids.includes(botUid) || (mentionHumans && isPersonaClone);
     isExplicitBotMention = mentionUids.includes(botUid);
+    // Track whether the bot was triggered by a "human broadcast" (@所有人 in any form).
+    // When true, persona clone replies as the grantor (admin), not as itself.
+    // Covers both new `mention.humans=1` AND legacy `mention.all=1` (which the server
+    // rewrites to {all:1, ais:1} per Plan X). @所有AI (ais=1 only) and direct @james
+    // mentions should still respond as the bot itself.
+    const isHumanBroadcast = mentionHumans || (!account.config.ignoreMentionAll && mentionAll);
+    triggeredByMentionHumans = isHumanBroadcast && isPersonaClone && !isExplicitBotMention;
+
+    // Debug: log mention flags for troubleshooting persona clone routing
+    if (isPersonaClone) {
+      log?.info?.(`octo: [MENTION-DEBUG] mentionAll=${mentionAll} mentionAis=${mentionAis} mentionHumans=${mentionHumans} isExplicitBot=${isExplicitBotMention} isHumanBroadcast=${isHumanBroadcast} triggeredAsGrantor=${triggeredByMentionHumans} isMentioned=${isMentioned}`);
+    }
 
     // Defensive fallback: if payload.mention is missing/empty but the message
     // text contains @botName, treat it as a mention.  This covers old senders
@@ -1629,7 +1648,9 @@ export async function handleInboundMessage(params: {
   } else {
     replyChannelId = isGroup ? message.channel_id! : message.from_uid;
     replyChannelType = isGroup ? (message.channel_type ?? ChannelType.Group) : ChannelType.DM;
-    effectiveOnBehalfOf = undefined;
+    // Persona clone: only reply as grantor when triggered by @所有人 (mention.humans=1).
+    // When the bot is directly mentioned (@James, @AI), respond as itself.
+    effectiveOnBehalfOf = (isGroup && triggeredByMentionHumans && account.config.onBehalfOf) ? account.config.onBehalfOf : undefined;
   }
 
   const apiUrl = account.config.apiUrl;
@@ -1648,14 +1669,14 @@ export async function handleInboundMessage(params: {
     sendReadReceipt({ apiUrl, botToken, channelId: replyChannelId, channelType: replyChannelType, messageIds })
       .then(() => log?.info?.("octo: readReceipt sent OK"))
       .catch((err) => log?.error?.(`octo: readReceipt failed: ${String(err)}`));
-    sendTyping({ apiUrl, botToken, channelId: replyChannelId, channelType: replyChannelType })
-      .then(() => log?.info?.("octo: typing sent OK"))
+    sendTyping({ apiUrl, botToken, channelId: replyChannelId, channelType: replyChannelType, ...(effectiveOnBehalfOf ? { onBehalfOf: effectiveOnBehalfOf } : {}) })
+      .then(() => log?.info?.(`octo: typing sent OK${effectiveOnBehalfOf ? ` (as ${effectiveOnBehalfOf})` : ""}`))
       .catch((err) => log?.error?.(`octo: typing failed: ${String(err)}`));
   }
 
   // Keep sending typing indicator while AI is processing
   const typingInterval = setInterval(() => {
-    sendTyping({ apiUrl, botToken, channelId: replyChannelId, channelType: replyChannelType, ...(isOBOv2 ? { onBehalfOf: effectiveOnBehalfOf } : {}) }).catch(() => {});
+    sendTyping({ apiUrl, botToken, channelId: replyChannelId, channelType: replyChannelType, ...(effectiveOnBehalfOf ? { onBehalfOf: effectiveOnBehalfOf } : {}) }).catch(() => {});
   }, 5000);
 
   // Buffer text across streaming deliver calls; only send once after dispatcher finishes.
@@ -1862,6 +1883,9 @@ export async function handleInboundMessage(params: {
       },
     });
   } finally {
+    // --- Debug: log dispatch outcome ---
+    log?.info?.(`octo: [dispatch-result] replySucceeded=${replySucceeded} bufferedText=${deliverBuffer.lastText?.length ?? 0} textSent=${deliverBuffer.textSent} effectiveOBO=${effectiveOnBehalfOf ?? 'none'}`);
+
     // --- Final send: deliver buffered text if only blocks arrived (no final/tool) ---
     if (deliverBuffer.lastText && !deliverBuffer.textSent) {
       deliverBuffer.textSent = true;

--- a/openclaw-channel-octo/src/inbound.ts
+++ b/openclaw-channel-octo/src/inbound.ts
@@ -1682,8 +1682,16 @@ export async function handleInboundMessage(params: {
       replyChannelId = oboV2OriginChannel as string;
     }
     replyChannelType = resolvedChannelType;
-    effectiveOnBehalfOf = oboV2RespondAs as string;
-    log?.info?.(`octo: OBO v2 detected — reply target=${replyChannelId} type=${replyChannelType} respondAs=${effectiveOnBehalfOf} originFrom=${oboV2OriginFromUid}`);
+    // Security: always use the trusted account.config.onBehalfOf as the
+    // authoritative grantor identity. `oboV2RespondAs` comes from the payload
+    // and must not be trusted as the reply identity — it is kept only for
+    // logging/debug visibility. (`isOBOv2` above already guarantees
+    // account.config.onBehalfOf is non-empty.)
+    effectiveOnBehalfOf = account.config.onBehalfOf!;
+    if (oboV2RespondAs !== effectiveOnBehalfOf) {
+      log?.warn?.(`octo: OBO v2 payload respondAs=${oboV2RespondAs} differs from configured grantor=${effectiveOnBehalfOf} — using configured grantor`);
+    }
+    log?.info?.(`octo: OBO v2 detected — reply target=${replyChannelId} type=${replyChannelType} respondAs=${effectiveOnBehalfOf} payloadRespondAs=${oboV2RespondAs} originFrom=${oboV2OriginFromUid}`);
   } else {
     replyChannelId = isGroup ? message.channel_id! : message.from_uid;
     replyChannelType = isGroup ? (message.channel_type ?? ChannelType.Group) : ChannelType.DM;

--- a/openclaw-channel-octo/src/inbound.ts
+++ b/openclaw-channel-octo/src/inbound.ts
@@ -1579,6 +1579,77 @@ export async function handleInboundMessage(params: {
   const commandBody = resolveCommandBody(rawBody, isGroup, isExplicitBotMention);
   const commandAuthorized = resolveCommandAuthorized(isGroup, isOwner(account.accountId, message.from_uid), isExplicitBotMention);
 
+  // OBO v2 detection + relevance filter (R10): Must run BEFORE
+  // finalizeInboundContext / recordInboundSession so that irrelevant
+  // OBO v2 messages (e.g. AI-only fan-out) do not leak any state —
+  // including `obo_system_hint` as GroupSystemPrompt — into the bot's
+  // DM session with the grantor. Mirrors the group-path early-return at
+  // ~L1300 (non-mention group messages return before session is recorded).
+  const oboV2OriginChannel = message.payload?.obo_origin_channel_id;
+  const oboV2OriginChannelType = message.payload?.obo_origin_channel_type;
+  const oboV2RespondAs = message.payload?.obo_respond_as ?? message.payload?.obo_grantor_uid;
+  const grantorUid = account.config.onBehalfOf;
+  const isOBOv2 = Boolean(
+    typeof oboV2OriginChannel === "string" &&
+    oboV2OriginChannel.length > 0 &&
+    typeof oboV2RespondAs === "string" &&
+    oboV2RespondAs.length > 0 &&
+    // Security: only trust OBO v2 fields when the message is sent by the
+    // configured grantor. Without this, any user able to put obo_* fields in
+    // their payload could trick the bot into replying in another channel as
+    // somebody else's persona.
+    grantorUid && message.from_uid === grantorUid
+  );
+
+  if (!isOBOv2 && typeof oboV2OriginChannel === "string" && oboV2OriginChannel.length > 0) {
+    log?.warn?.(`octo: OBO v2 payload rejected — from_uid=${message.from_uid} is not configured grantor ${grantorUid ?? "(none)"}`);
+  }
+
+  // OBO v2 relevance filter: when the fan-out message is @AI-only (mention.ais=1
+  // but no grantor mention, no @所有人), the persona clone should NOT respond.
+  // @AI targets AI bots directly, not humans or their persona clones.
+  //
+  // Mirrors the group-path semantics (see ~L1223/L1230): when
+  // `account.config.ignoreMentionAll=true`, broadcast-style mentions
+  // (`mention.humans=1`, `mention.all=1`) must NOT be treated as relevant for
+  // the persona clone. Explicit grantor UID mentions remain relevant
+  // regardless of `ignoreMentionAll`, because they target the grantor
+  // identity directly rather than the broadcast group.
+  //
+  // CRITICAL (R10): this filter MUST run before finalizeInboundContext /
+  // recordInboundSession — otherwise an irrelevant OBO v2 message would
+  // already have been persisted to the bot's DM session with the grantor,
+  // including any `obo_system_hint` as GroupSystemPrompt.
+  if (isOBOv2) {
+    const origMention = message.payload?.mention;
+    const origAis = origMention?.ais === true || origMention?.ais === 1;
+    const origHumans = origMention?.humans === true || origMention?.humans === 1;
+    const origAll = origMention?.all === true || origMention?.all === 1;
+    const origUids: string[] = Array.isArray(origMention?.uids) ? origMention.uids : [];
+    // Use the trusted configured grantor (account.config.onBehalfOf) for the
+    // explicit-mention relevance check, mirroring the group path. This is
+    // also what `effectiveOnBehalfOf` resolves to below; `oboV2RespondAs`
+    // from the payload is for diagnostic logging only.
+    const grantorInUids = typeof grantorUid === "string" && grantorUid.length > 0
+      && origUids.includes(grantorUid);
+    const ignoreBroadcast = account.config.ignoreMentionAll === true;
+    const broadcastRelevant = (!ignoreBroadcast) && (origHumans || origAll);
+    // No-mention fallback: when the payload carries no mention information at
+    // all (no ais, no humans, no all, no uids), treat the message as relevant
+    // (plain group/DM chatter the persona should see). Tightened to exclude
+    // broadcasts so that an `ignoreMentionAll`-gated humans/all does not
+    // re-enable relevance via this fallback.
+    const noMentionFallback = !origAis && !origHumans && !origAll && origUids.length === 0;
+    const isRelevantToPersona = broadcastRelevant || grantorInUids || noMentionFallback;
+    if (!isRelevantToPersona) {
+      log?.info?.(`octo: OBO v2 skipped — message not relevant to persona (ais=${origAis} humans=${origHumans} all=${origAll} grantorInUids=${grantorInUids} ignoreMentionAll=${ignoreBroadcast})`);
+      // Mirror group-path early-return: do NOT call finalizeInboundContext /
+      // recordInboundSession, so no DM session record (and no GroupSystemPrompt)
+      // is persisted for irrelevant OBO v2 fan-out messages.
+      return;
+    }
+  }
+
   const ctxPayload = core.channel.reply.finalizeInboundContext({
     Body: body,
     BodyForAgent: body,
@@ -1640,62 +1711,15 @@ export async function handleInboundMessage(params: {
   // go to the origin GROUP channel (not the DM), with `on_behalf_of` set to
   // `obo_respond_as` (the grantor). This way the bot replies in the group as
   // the grantor, not in DM.
-  const oboV2OriginChannel = message.payload?.obo_origin_channel_id;
-  const oboV2OriginChannelType = message.payload?.obo_origin_channel_type;
-  const oboV2RespondAs = message.payload?.obo_respond_as ?? message.payload?.obo_grantor_uid;
-  const grantorUid = account.config.onBehalfOf;
-  const isOBOv2 = Boolean(
-    typeof oboV2OriginChannel === "string" &&
-    oboV2OriginChannel.length > 0 &&
-    typeof oboV2RespondAs === "string" &&
-    oboV2RespondAs.length > 0 &&
-    // Security: only trust OBO v2 fields when the message is sent by the
-    // configured grantor. Without this, any user able to put obo_* fields in
-    // their payload could trick the bot into replying in another channel as
-    // somebody else's persona.
-    grantorUid && message.from_uid === grantorUid
-  );
-
-  if (!isOBOv2 && typeof oboV2OriginChannel === "string" && oboV2OriginChannel.length > 0) {
-    log?.warn?.(`octo: OBO v2 payload rejected — from_uid=${message.from_uid} is not configured grantor ${grantorUid ?? "(none)"}`);
-  }
-
-  // OBO v2 relevance filter: when the fan-out message is @AI-only (mention.ais=1
-  // but no grantor mention, no @所有人), the persona clone should NOT respond.
-  // @AI targets AI bots directly, not humans or their persona clones.
   //
-  // Mirrors the group-path semantics (see ~L1223/L1230): when
-  // `account.config.ignoreMentionAll=true`, broadcast-style mentions
-  // (`mention.humans=1`, `mention.all=1`) must NOT be treated as relevant for
-  // the persona clone. Explicit grantor UID mentions remain relevant
-  // regardless of `ignoreMentionAll`, because they target the grantor
-  // identity directly rather than the broadcast group.
-  if (isOBOv2) {
-    const origMention = message.payload?.mention;
-    const origAis = origMention?.ais === true || origMention?.ais === 1;
-    const origHumans = origMention?.humans === true || origMention?.humans === 1;
-    const origAll = origMention?.all === true || origMention?.all === 1;
-    const origUids: string[] = Array.isArray(origMention?.uids) ? origMention.uids : [];
-    // Use the trusted configured grantor (account.config.onBehalfOf) for the
-    // explicit-mention relevance check, mirroring the group path. This is
-    // also what `effectiveOnBehalfOf` resolves to below; `oboV2RespondAs`
-    // from the payload is for diagnostic logging only.
-    const grantorInUids = typeof grantorUid === "string" && grantorUid.length > 0
-      && origUids.includes(grantorUid);
-    const ignoreBroadcast = account.config.ignoreMentionAll === true;
-    const broadcastRelevant = (!ignoreBroadcast) && (origHumans || origAll);
-    // No-mention fallback: when the payload carries no mention information at
-    // all (no ais, no humans, no all, no uids), treat the message as relevant
-    // (plain group/DM chatter the persona should see). Tightened to exclude
-    // broadcasts so that an `ignoreMentionAll`-gated humans/all does not
-    // re-enable relevance via this fallback.
-    const noMentionFallback = !origAis && !origHumans && !origAll && origUids.length === 0;
-    const isRelevantToPersona = broadcastRelevant || grantorInUids || noMentionFallback;
-    if (!isRelevantToPersona) {
-      log?.info?.(`octo: OBO v2 skipped — message not relevant to persona (ais=${origAis} humans=${origHumans} all=${origAll} grantorInUids=${grantorInUids} ignoreMentionAll=${ignoreBroadcast})`);
-      return;
-    }
-  }
+  // Detection (`isOBOv2`) and the relevance filter that gates an early-return
+  // have already run BEFORE finalizeInboundContext / recordInboundSession
+  // (see R10 fix above) so that irrelevant OBO v2 fan-out messages do not
+  // leak `obo_system_hint` (as GroupSystemPrompt) into the bot's DM session.
+  // The reply-routing variables below (`replyChannelId`, `replyChannelType`,
+  // `effectiveOnBehalfOf`) are derived here using the previously-computed
+  // `isOBOv2`, `oboV2OriginChannel`, `oboV2OriginChannelType`, and
+  // `oboV2RespondAs`.
 
   let replyChannelId: string;
   let replyChannelType: ChannelType;

--- a/openclaw-channel-octo/src/inbound.ts
+++ b/openclaw-channel-octo/src/inbound.ts
@@ -1650,16 +1650,36 @@ export async function handleInboundMessage(params: {
   // OBO v2 relevance filter: when the fan-out message is @AI-only (mention.ais=1
   // but no grantor mention, no @所有人), the persona clone should NOT respond.
   // @AI targets AI bots directly, not humans or their persona clones.
+  //
+  // Mirrors the group-path semantics (see ~L1223/L1230): when
+  // `account.config.ignoreMentionAll=true`, broadcast-style mentions
+  // (`mention.humans=1`, `mention.all=1`) must NOT be treated as relevant for
+  // the persona clone. Explicit grantor UID mentions remain relevant
+  // regardless of `ignoreMentionAll`, because they target the grantor
+  // identity directly rather than the broadcast group.
   if (isOBOv2) {
     const origMention = message.payload?.mention;
     const origAis = origMention?.ais === true || origMention?.ais === 1;
     const origHumans = origMention?.humans === true || origMention?.humans === 1;
     const origAll = origMention?.all === true || origMention?.all === 1;
     const origUids: string[] = Array.isArray(origMention?.uids) ? origMention.uids : [];
-    const grantorInUids = typeof oboV2RespondAs === "string" && origUids.includes(oboV2RespondAs);
-    const isRelevantToPersona = origHumans || origAll || grantorInUids || (!origAis && origUids.length === 0);
+    // Use the trusted configured grantor (account.config.onBehalfOf) for the
+    // explicit-mention relevance check, mirroring the group path. This is
+    // also what `effectiveOnBehalfOf` resolves to below; `oboV2RespondAs`
+    // from the payload is for diagnostic logging only.
+    const grantorInUids = typeof grantorUid === "string" && grantorUid.length > 0
+      && origUids.includes(grantorUid);
+    const ignoreBroadcast = account.config.ignoreMentionAll === true;
+    const broadcastRelevant = (!ignoreBroadcast) && (origHumans || origAll);
+    // No-mention fallback: when the payload carries no mention information at
+    // all (no ais, no humans, no all, no uids), treat the message as relevant
+    // (plain group/DM chatter the persona should see). Tightened to exclude
+    // broadcasts so that an `ignoreMentionAll`-gated humans/all does not
+    // re-enable relevance via this fallback.
+    const noMentionFallback = !origAis && !origHumans && !origAll && origUids.length === 0;
+    const isRelevantToPersona = broadcastRelevant || grantorInUids || noMentionFallback;
     if (!isRelevantToPersona) {
-      log?.info?.(`octo: OBO v2 skipped — message not relevant to persona (ais=${origAis} humans=${origHumans} all=${origAll} grantorInUids=${grantorInUids})`);
+      log?.info?.(`octo: OBO v2 skipped — message not relevant to persona (ais=${origAis} humans=${origHumans} all=${origAll} grantorInUids=${grantorInUids} ignoreMentionAll=${ignoreBroadcast})`);
       return;
     }
   }

--- a/openclaw-channel-octo/src/types.ts
+++ b/openclaw-channel-octo/src/types.ts
@@ -65,6 +65,7 @@ export interface MentionPayload {
   entities?: MentionEntity[];
   all?: boolean | number; // true or 1 = @all (API returns either depending on version)
   ais?: boolean | number; // true or 1 = @AI / @所有AI
+  humans?: boolean | number; // true or 1 = @所有人 (Plan X: human-only notification)
 }
 
 export interface ReplyPayload {

--- a/openclaw-channel-octo/src/types.ts
+++ b/openclaw-channel-octo/src/types.ts
@@ -64,6 +64,7 @@ export interface MentionPayload {
   uids?: string[];
   entities?: MentionEntity[];
   all?: boolean | number; // true or 1 = @all (API returns either depending on version)
+  ais?: boolean | number; // true or 1 = @AI / @所有AI
 }
 
 export interface ReplyPayload {


### PR DESCRIPTION
## 问题

Persona clone bot (James) 在群里收到 @所有人 时不回复。方案X 把 @所有人 拆为三态 (humans/ais/all)，adapter 没有处理 persona clone 在 `mention.humans=1` 下应作为 grantor 回复的场景。

## 修复

当 bot 配置了 `onBehalfOf`（persona clone）时：
- `@所有人` (mention.humans=1) → 以 grantor (admin) 身份回复
- 老版 `@所有人` (mention.all=1) → 同样以 grantor 身份回复
- `@James` (直接 uid mention) → 以 bot 自己身份回复（不变）
- `@AI / @所有AI` (mention.ais=1) → 以 bot 自己身份回复（不变）

## 改动

- `types.ts`: MentionPayload 加 `humans` 字段
- `config-schema.ts` + `accounts.ts`: 加 `onBehalfOf` 配置项
- `inbound.ts`: mention gating + OBO identity routing
- `inbound.test.ts`: 14 个新测试覆盖 mention×identity 矩阵

## 测试 (im-test.xming.ai)

| 场景 | 预期 | 结果 |
|------|------|------|
| 群里 @admin | James 以 admin 身份回复 | ✅ |
| 群里 @所有人 | James 以 admin 身份回复 | ✅ |
| 群里 @James | James 以自己身份回复 | ✅ |
| 群里 @AI | James 以自己身份回复 | ✅ |

单元测试：136 tests passed