### PR TITLE
chore: add CODEOWNERS (adapters-maintainers)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# Code owners for octo-adapters
+# Managed via GitHub Team membership — do not edit directly.
+# To change reviewers, update the team: @Mininglamp-OSS/adapters-maintainers
+
+* @Mininglamp-OSS/adapters-maintainers


### PR DESCRIPTION
Add CODEOWNERS file pointing to `@Mininglamp-OSS/adapters-maintainers`.

This is part of the sub-maintainer team setup. All code review assignments will be managed via team membership going forward — no need to edit this file when members change.

/cc @lml2468