### PR TITLE
chore: add @Mininglamp-OSS/adapters-maintainers to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # Default owners
-* @Mininglamp-OSS/maintainers
+* @Mininglamp-OSS/maintainers @Mininglamp-OSS/adapters-maintainers
 
 # Adapter implementations
-/openclaw-channel-octo/ @Mininglamp-OSS/maintainers
-/openclaw-channel-dmwork/ @Mininglamp-OSS/maintainers
+/openclaw-channel-octo/ @Mininglamp-OSS/maintainers @Mininglamp-OSS/adapters-maintainers
+/openclaw-channel-dmwork/ @Mininglamp-OSS/maintainers @Mininglamp-OSS/adapters-maintainers


### PR DESCRIPTION
Update `.github/CODEOWNERS` to add sub-maintainer team `@Mininglamp-OSS/adapters-maintainers` alongside the existing `@Mininglamp-OSS/maintainers`.

Future member changes only require updating team membership — no CODEOWNERS edits needed.

/cc @lml2468