### PR TITLE
feat(persona): inject persona_prompt via before_prompt_build hook

### DIFF
--- a/openclaw-channel-octo/index.ts
+++ b/openclaw-channel-octo/index.ts
@@ -12,8 +12,8 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { dmworkPlugin } from "./src/channel.js";
 import { setDmworkRuntime } from "./src/runtime.js";
 import { getGroupMdForPrompt } from "./src/group-md.js";
-import { pendingInboundContext, sessionAccountMap } from "./src/inbound.js";
-import { getPersonaPromptForSession } from "./src/persona-prompt.js";
+import { pendingInboundContext, sessionAccountMap, buildSessionAccountKey } from "./src/inbound.js";
+import { resolvePersonaHintForSession } from "./src/persona-prompt.js";
 import {
   inProcessConfigReader,
   runDoctorChecks,
@@ -303,15 +303,28 @@ const plugin: {
       // when this bot is not a persona clone, the lookup returns undefined
       // and we skip.
       //
-      // The hook ctx does not expose accountId, so we resolve it through
-      // sessionAccountMap (populated by handleInboundMessage in inbound.ts).
-      // Using ctx.accountId directly returns undefined — confirmed by
-      // PR#69 review.
-      const accountIdForPersona = sessionKey ? sessionAccountMap.get(sessionKey) : undefined;
-      if (accountIdForPersona) {
-        const personaHint = getPersonaPromptForSession(accountIdForPersona);
-        if (personaHint) systemSections.push(personaHint);
-      }
+      // The hook ctx does not expose accountId, so we cannot key the
+      // persona cache by sessionKey alone — two persona-clone bots
+      // running on the same node can legitimately share a sessionKey
+      // (OpenClaw routes per-account but session keys can collide).
+      // Keying sessionAccountMap only by sessionKey lets a later inbound
+      // overwrite an earlier one and the hook then attaches the WRONG
+      // account's persona prompt — a cross-account identity leak called
+      // out in PR#69 R3 (Jerry-Xin).
+      //
+      // Fix: sessionAccountMap is composite-keyed by
+      // `${accountId}:${sessionKey}` (see inbound.ts). The resolver
+      // iterates every registered persona account and asks
+      // sessionAccountMap whether it has been seen on this sessionKey.
+      // On 0 / >1 matches we fail safe to "no persona injection".
+      const personaHint = sessionKey
+        ? resolvePersonaHintForSession({
+            sessionKey,
+            hasAccountSession: (accountId, sk) =>
+              sessionAccountMap.has(buildSessionAccountKey(accountId, sk)),
+          })
+        : undefined;
+      if (personaHint) systemSections.push(personaHint);
 
       if (contextSections.length === 0 && systemSections.length === 0) return;
       return {

--- a/openclaw-channel-octo/index.ts
+++ b/openclaw-channel-octo/index.ts
@@ -12,7 +12,7 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { dmworkPlugin } from "./src/channel.js";
 import { setDmworkRuntime } from "./src/runtime.js";
 import { getGroupMdForPrompt } from "./src/group-md.js";
-import { pendingInboundContext } from "./src/inbound.js";
+import { pendingInboundContext, sessionAccountMap } from "./src/inbound.js";
 import { getPersonaPromptForSession } from "./src/persona-prompt.js";
 import {
   inProcessConfigReader,
@@ -270,12 +270,19 @@ const plugin: {
 
     console.log('[octo] registering before_prompt_build hook');
     api.on('before_prompt_build', (_event, ctx) => {
-      const sections: string[] = [];
+      // Sections destined for the user-prompt context block (group MD,
+      // member list, inbound history). These belong to the conversation
+      // surface, not the LLM's system identity.
+      const contextSections: string[] = [];
+      // Sections destined for the LLM system prompt (persona identity).
+      // System-level identity instructions must NOT live in the user-prompt
+      // prefix or the model can treat them as quotable content.
+      const systemSections: string[] = [];
 
       // 1. Group/Thread MD — wrapped in [GROUP CONTEXT] block
       const groupMdContent = getGroupMdForPrompt(ctx);
       if (groupMdContent) {
-        sections.push(`[GROUP CONTEXT]\n${groupMdContent}\n[/GROUP CONTEXT]`);
+        contextSections.push(`[GROUP CONTEXT]\n${groupMdContent}\n[/GROUP CONTEXT]`);
       }
 
       // 2. Inbound context (member list + history) — outside [GROUP CONTEXT], keeps original format
@@ -284,24 +291,33 @@ const plugin: {
         const pending = pendingInboundContext.get(sessionKey);
         if (pending) {
           pendingInboundContext.delete(sessionKey);
-          if (pending.memberListPrefix) sections.push(pending.memberListPrefix);
-          if (pending.historyPrefix) sections.push(pending.historyPrefix);
+          if (pending.memberListPrefix) contextSections.push(pending.memberListPrefix);
+          if (pending.historyPrefix) contextSections.push(pending.historyPrefix);
         }
       }
 
       // 3. Persona prompt (GH octo-adapters#68) — for persona-clone bots
       // (account.config.onBehalfOf set), pull the active persona_prompt
-      // from the per-account cache and prepend it. The cache is hydrated
-      // by initPersonaPromptCache() in channel.ts; when this bot is not
-      // a persona clone, the lookup returns undefined and we skip.
-      const accountIdForPersona = (ctx as { accountId?: string }).accountId;
+      // from the per-account cache and prepend it to the SYSTEM prompt.
+      // The cache is hydrated by initPersonaPromptCache() in channel.ts;
+      // when this bot is not a persona clone, the lookup returns undefined
+      // and we skip.
+      //
+      // The hook ctx does not expose accountId, so we resolve it through
+      // sessionAccountMap (populated by handleInboundMessage in inbound.ts).
+      // Using ctx.accountId directly returns undefined — confirmed by
+      // PR#69 review.
+      const accountIdForPersona = sessionKey ? sessionAccountMap.get(sessionKey) : undefined;
       if (accountIdForPersona) {
         const personaHint = getPersonaPromptForSession(accountIdForPersona);
-        if (personaHint) sections.push(personaHint);
+        if (personaHint) systemSections.push(personaHint);
       }
 
-      if (sections.length === 0) return;
-      return { prependContext: sections.join('\n\n') };
+      if (contextSections.length === 0 && systemSections.length === 0) return;
+      return {
+        ...(contextSections.length > 0 ? { prependContext: contextSections.join('\n\n') } : {}),
+        ...(systemSections.length > 0 ? { prependSystemContext: systemSections.join('\n\n') } : {}),
+      };
     });
   },
 };

--- a/openclaw-channel-octo/index.ts
+++ b/openclaw-channel-octo/index.ts
@@ -13,6 +13,7 @@ import { dmworkPlugin } from "./src/channel.js";
 import { setDmworkRuntime } from "./src/runtime.js";
 import { getGroupMdForPrompt } from "./src/group-md.js";
 import { pendingInboundContext } from "./src/inbound.js";
+import { getPersonaPromptForSession } from "./src/persona-prompt.js";
 import {
   inProcessConfigReader,
   runDoctorChecks,
@@ -286,6 +287,17 @@ const plugin: {
           if (pending.memberListPrefix) sections.push(pending.memberListPrefix);
           if (pending.historyPrefix) sections.push(pending.historyPrefix);
         }
+      }
+
+      // 3. Persona prompt (GH octo-adapters#68) — for persona-clone bots
+      // (account.config.onBehalfOf set), pull the active persona_prompt
+      // from the per-account cache and prepend it. The cache is hydrated
+      // by initPersonaPromptCache() in channel.ts; when this bot is not
+      // a persona clone, the lookup returns undefined and we skip.
+      const accountIdForPersona = (ctx as { accountId?: string }).accountId;
+      if (accountIdForPersona) {
+        const personaHint = getPersonaPromptForSession(accountIdForPersona);
+        if (personaHint) sections.push(personaHint);
       }
 
       if (sections.length === 0) return;

--- a/openclaw-channel-octo/src/api-fetch.ts
+++ b/openclaw-channel-octo/src/api-fetch.ts
@@ -640,6 +640,69 @@ export async function deleteVoiceContext(params: {
   });
 }
 
+// ---- OBO Grant API (persona clone introspection) ----
+
+/**
+ * Bot-side view of its own OBO grant — used by persona clones to fetch
+ * the active `persona_prompt` so it can be injected into the LLM system
+ * prompt via the before_prompt_build hook (GH octo-adapters#68).
+ *
+ * Returned by GET /v1/bot/obo-grant (octo-server YUJ-1762). The bot is
+ * identified by its botToken; the server resolves the grant where this
+ * bot is the grantee.
+ */
+export interface BotOboGrant {
+  /** False / absent when the bot has no active grant (regular non-persona bot). */
+  has_grant: boolean;
+  grantor_uid?: string;
+  grantor_name?: string;
+  persona_prompt?: string;
+  /** Whether the grant is currently active (mode != "paused" & not revoked). */
+  active?: boolean;
+}
+
+/**
+ * GET /v1/bot/obo-grant — fetch this bot's own OBO grant info.
+ *
+ * Returns null when:
+ *  - the bot has no grant (404)
+ *  - the server reports has_grant=false
+ *  - the response is malformed
+ *
+ * Throws on transport / 5xx errors so the caller's retry-on-next-tick
+ * cadence (see persona-prompt.ts) can decide whether to log and skip.
+ */
+export async function getBotOboGrant(params: {
+  apiUrl: string;
+  botToken: string;
+}): Promise<BotOboGrant | null> {
+  const url = `${params.apiUrl.replace(/\/+$/, "")}/v1/bot/obo-grant`;
+  const resp = await fetch(url, {
+    method: "GET",
+    headers: { Authorization: `Bearer ${params.botToken}` },
+    signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
+  });
+  // 404 = no grant for this bot (regular bot, not a persona clone).
+  if (resp.status === 404) return null;
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => "");
+    throw new Error(
+      `Bot API GET /v1/bot/obo-grant failed (${resp.status}): ${text || resp.statusText}`,
+    );
+  }
+  const raw = (await resp.json().catch(() => null)) as Record<string, unknown> | null;
+  if (!raw || typeof raw !== "object") return null;
+  const hasGrant = raw.has_grant === true;
+  if (!hasGrant) return null;
+  return {
+    has_grant: true,
+    grantor_uid: typeof raw.grantor_uid === "string" ? raw.grantor_uid : undefined,
+    grantor_name: typeof raw.grantor_name === "string" ? raw.grantor_name : undefined,
+    persona_prompt: typeof raw.persona_prompt === "string" ? raw.persona_prompt : undefined,
+    active: raw.active === true,
+  };
+}
+
 /** Decoded payload from base64 message content */
 interface SyncMessagePayload {
   type?: number;

--- a/openclaw-channel-octo/src/channel.ts
+++ b/openclaw-channel-octo/src/channel.ts
@@ -35,6 +35,7 @@ import { createDmworkManagementTools } from "./agent-tools.js";
 import { getOrCreateGroupMdCache, registerBotGroupIds, getKnownGroupIds, writeGroupMdToDisk } from "./group-md.js";
 import { registerOwnerUid } from "./owner-registry.js";
 import { preloadGroupMemberCache, getGroupMembersFromCache } from "./member-cache.js";
+import { initPersonaPromptCache, stopPersonaPromptCache } from "./persona-prompt.js";
 import path from "node:path";
 import os from "node:os";
 import { mkdir, readFile, writeFile, unlink } from "node:fs/promises";
@@ -792,6 +793,20 @@ export const dmworkPlugin: ChannelPlugin<ResolvedDmworkAccount> = {
         log,
       }).catch(() => {});
 
+      // Start persona_prompt cache refresh loop for persona-clone bots
+      // (GH octo-adapters#68). No-op for regular bots. Polls
+      // GET /v1/bot/obo-grant so persona_prompt edits propagate without
+      // requiring a fan-out copy or process restart.
+      initPersonaPromptCache(
+        {
+          accountId: account.accountId,
+          apiUrl: account.config.apiUrl,
+          botToken: account.config.botToken!,
+          onBehalfOf: account.config.onBehalfOf,
+        },
+        log,
+      );
+
       // Prefetch GROUP.md and group members for all groups (fire-and-forget)
       const groupMdCache = getOrCreateGroupMdCache(account.accountId);
       (async () => {
@@ -1081,6 +1096,7 @@ export const dmworkPlugin: ChannelPlugin<ResolvedDmworkAccount> = {
           socket.disconnect();
           if (heartbeatTimer) { clearInterval(heartbeatTimer); heartbeatTimer = null; }
           if (cooldownReconnectTimer) { clearTimeout(cooldownReconnectTimer); cooldownReconnectTimer = null; }
+          stopPersonaPromptCache(account.accountId);
           ctx.setStatus({
             accountId: account.accountId,
             running: false,

--- a/openclaw-channel-octo/src/inbound.test.ts
+++ b/openclaw-channel-octo/src/inbound.test.ts
@@ -17,6 +17,7 @@ import {
   resolveCommandBody,
   resolveCommandAuthorized,
   pendingInboundContext,
+  sessionAccountMap,
   segmentHistoryEntries,
   type ResolveFileResult,
 } from "./inbound.js";
@@ -1309,6 +1310,36 @@ describe("pendingInboundContext", () => {
     pendingInboundContext.set(key, { historyPrefix: "new", memberListPrefix: "ml" });
     expect(pendingInboundContext.get(key)?.historyPrefix).toBe("new");
     expect(pendingInboundContext.get(key)?.memberListPrefix).toBe("ml");
+  });
+});
+
+describe("sessionAccountMap", () => {
+  beforeEach(() => {
+    sessionAccountMap.clear();
+  });
+
+  it("should store and retrieve accountId by sessionKey", () => {
+    const key = "octo:group:abc";
+    sessionAccountMap.set(key, "bot_account_1");
+    expect(sessionAccountMap.get(key)).toBe("bot_account_1");
+  });
+
+  it("should keep separate entries for different sessionKeys", () => {
+    sessionAccountMap.set("k1", "acct_a");
+    sessionAccountMap.set("k2", "acct_b");
+    expect(sessionAccountMap.get("k1")).toBe("acct_a");
+    expect(sessionAccountMap.get("k2")).toBe("acct_b");
+  });
+
+  it("should overwrite on repeated set for same sessionKey", () => {
+    const key = "octo:dm:reroute";
+    sessionAccountMap.set(key, "acct_old");
+    sessionAccountMap.set(key, "acct_new");
+    expect(sessionAccountMap.get(key)).toBe("acct_new");
+  });
+
+  it("returns undefined for unknown sessionKey", () => {
+    expect(sessionAccountMap.get("nope")).toBeUndefined();
   });
 });
 

--- a/openclaw-channel-octo/src/inbound.test.ts
+++ b/openclaw-channel-octo/src/inbound.test.ts
@@ -18,6 +18,7 @@ import {
   resolveCommandAuthorized,
   pendingInboundContext,
   sessionAccountMap,
+  buildSessionAccountKey,
   segmentHistoryEntries,
   type ResolveFileResult,
 } from "./inbound.js";
@@ -1313,33 +1314,57 @@ describe("pendingInboundContext", () => {
   });
 });
 
-describe("sessionAccountMap", () => {
+describe("sessionAccountMap (composite-keyed)", () => {
   beforeEach(() => {
     sessionAccountMap.clear();
   });
 
-  it("should store and retrieve accountId by sessionKey", () => {
-    const key = "octo:group:abc";
-    sessionAccountMap.set(key, "bot_account_1");
-    expect(sessionAccountMap.get(key)).toBe("bot_account_1");
+  it("buildSessionAccountKey concatenates accountId and sessionKey", () => {
+    expect(buildSessionAccountKey("acct_a", "octo:group:abc")).toBe("acct_a:octo:group:abc");
   });
 
-  it("should keep separate entries for different sessionKeys", () => {
-    sessionAccountMap.set("k1", "acct_a");
-    sessionAccountMap.set("k2", "acct_b");
-    expect(sessionAccountMap.get("k1")).toBe("acct_a");
-    expect(sessionAccountMap.get("k2")).toBe("acct_b");
+  it("stores and retrieves accountId by the composite key", () => {
+    const sessionKey = "octo:group:abc";
+    sessionAccountMap.set(buildSessionAccountKey("bot_account_1", sessionKey), "bot_account_1");
+    expect(sessionAccountMap.get(buildSessionAccountKey("bot_account_1", sessionKey))).toBe("bot_account_1");
   });
 
-  it("should overwrite on repeated set for same sessionKey", () => {
-    const key = "octo:dm:reroute";
-    sessionAccountMap.set(key, "acct_old");
-    sessionAccountMap.set(key, "acct_new");
-    expect(sessionAccountMap.get(key)).toBe("acct_new");
+  it("keeps separate entries for different sessionKeys", () => {
+    sessionAccountMap.set(buildSessionAccountKey("acct_a", "k1"), "acct_a");
+    sessionAccountMap.set(buildSessionAccountKey("acct_b", "k2"), "acct_b");
+    expect(sessionAccountMap.get(buildSessionAccountKey("acct_a", "k1"))).toBe("acct_a");
+    expect(sessionAccountMap.get(buildSessionAccountKey("acct_b", "k2"))).toBe("acct_b");
   });
 
-  it("returns undefined for unknown sessionKey", () => {
-    expect(sessionAccountMap.get("nope")).toBeUndefined();
+  it("does NOT overwrite when two accounts share the same sessionKey (multi-account isolation)", () => {
+    // 🔴 PR#69 R3 regression guard: two distinct accounts can legitimately
+    // share the same sessionKey. The composite-key map must keep both
+    // entries so the hook can disambiguate per-account; otherwise the
+    // second account's persona prompt would leak into the first account's
+    // prompt build.
+    const sharedSessionKey = "agent:default:octo:group:shared_group";
+    sessionAccountMap.set(buildSessionAccountKey("acct_persona_a", sharedSessionKey), "acct_persona_a");
+    sessionAccountMap.set(buildSessionAccountKey("acct_persona_b", sharedSessionKey), "acct_persona_b");
+    expect(sessionAccountMap.get(buildSessionAccountKey("acct_persona_a", sharedSessionKey))).toBe("acct_persona_a");
+    expect(sessionAccountMap.get(buildSessionAccountKey("acct_persona_b", sharedSessionKey))).toBe("acct_persona_b");
+    expect(sessionAccountMap.size).toBe(2);
+  });
+
+  it("overwrites on repeated set for the same (accountId, sessionKey) pair", () => {
+    const key = buildSessionAccountKey("acct_a", "octo:dm:reroute");
+    sessionAccountMap.set(key, "acct_a");
+    sessionAccountMap.set(key, "acct_a"); // idempotent
+    expect(sessionAccountMap.get(key)).toBe("acct_a");
+    expect(sessionAccountMap.size).toBe(1);
+  });
+
+  it("returns undefined for unknown composite keys", () => {
+    expect(sessionAccountMap.get(buildSessionAccountKey("acct_a", "nope"))).toBeUndefined();
+    // And: looking up by raw sessionKey alone (the old buggy access pattern)
+    // never matches a composite-keyed entry — guards against accidental
+    // regression to the pre-fix call site.
+    sessionAccountMap.set(buildSessionAccountKey("acct_a", "octo:group:x"), "acct_a");
+    expect(sessionAccountMap.get("octo:group:x")).toBeUndefined();
   });
 });
 

--- a/openclaw-channel-octo/src/inbound.ts
+++ b/openclaw-channel-octo/src/inbound.ts
@@ -29,6 +29,19 @@ import { randomUUID } from "node:crypto";
 // handleInboundMessage writes here; the hook reads and clears per sessionKey.
 export const pendingInboundContext = new Map<string, { historyPrefix: string; memberListPrefix: string }>();
 
+// Per-session accountId map. The before_prompt_build hook receives ctx.sessionKey
+// but not ctx.accountId, so we record the binding here on every inbound message
+// (right next to pendingInboundContext.set) and the hook resolves accountId by
+// looking up sessionKey. Persona-prompt injection (GH octo-adapters#68) depends
+// on this mapping — without it, getPersonaPromptForSession can never be called
+// with the correct accountId from the hook.
+//
+// Lifetime: entries are kept (not deleted) so the hook works on every prompt
+// build for the session, not just the first one after an inbound message.
+// Sessions are bounded by accounts, so the map size is bounded by the active
+// session count per account — no unbounded growth in practice.
+export const sessionAccountMap = new Map<string, string>();
+
 export type DmworkStatusSink = (patch: {
   lastInboundAt?: number;
   lastOutboundAt?: number;
@@ -1564,6 +1577,11 @@ export async function handleInboundMessage(params: {
   if (historyPrefix || memberListPrefix) {
     pendingInboundContext.set(route.sessionKey, { historyPrefix, memberListPrefix });
   }
+
+  // Record sessionKey → accountId so the before_prompt_build hook can resolve
+  // accountId from ctx.sessionKey (hook ctx does not expose accountId).
+  // Required by persona-prompt injection (GH octo-adapters#68).
+  sessionAccountMap.set(route.sessionKey, account.accountId);
 
   const finalBody = quotePrefix ? (quotePrefix + rawBody) : rawBody;
 

--- a/openclaw-channel-octo/src/inbound.ts
+++ b/openclaw-channel-octo/src/inbound.ts
@@ -29,18 +29,41 @@ import { randomUUID } from "node:crypto";
 // handleInboundMessage writes here; the hook reads and clears per sessionKey.
 export const pendingInboundContext = new Map<string, { historyPrefix: string; memberListPrefix: string }>();
 
-// Per-session accountId map. The before_prompt_build hook receives ctx.sessionKey
-// but not ctx.accountId, so we record the binding here on every inbound message
-// (right next to pendingInboundContext.set) and the hook resolves accountId by
-// looking up sessionKey. Persona-prompt injection (GH octo-adapters#68) depends
-// on this mapping — without it, getPersonaPromptForSession can never be called
-// with the correct accountId from the hook.
+// Per-(account, session) registry. The before_prompt_build hook receives
+// ctx.sessionKey but not ctx.accountId, so we record on every inbound message
+// (right next to pendingInboundContext.set) the fact that some accountId has
+// been seen on a given sessionKey. Persona-prompt injection (GH
+// octo-adapters#68) depends on this — without it, getPersonaPromptForSession
+// can never be called with the correct accountId from the hook.
+//
+// 🔴 Multi-account isolation (PR#69 R3, Jerry-Xin):
+// The map is keyed by the COMPOSITE `${accountId}:${sessionKey}`, NOT by
+// `sessionKey` alone. Two distinct bot accounts (e.g. a persona clone and a
+// regular bot, or two persona clones) running on the same OpenClaw node can
+// legitimately share the same `sessionKey` — OpenClaw routes per-account but
+// the resulting session keys can collide. Keying only by `sessionKey` means
+// the second account's inbound `.set` overwrites the first, and the hook
+// then attaches the wrong account's persona prompt — a cross-account
+// identity leak.
+//
+// With the composite key, both accounts get separate entries and the hook
+// resolves persona identity by iterating the registered persona accounts
+// and checking `sessionAccountMap.has(buildSessionAccountKey(candidate, ctx.sessionKey))`.
+// If exactly one persona account matches we use it; on 0 or >1 matches we
+// fail safe to "no persona injection" rather than risk attaching the wrong
+// identity.
 //
 // Lifetime: entries are kept (not deleted) so the hook works on every prompt
 // build for the session, not just the first one after an inbound message.
-// Sessions are bounded by accounts, so the map size is bounded by the active
-// session count per account — no unbounded growth in practice.
+// Sessions are bounded by accounts, so the map size is bounded by
+// (active accounts × active session keys per account) — no unbounded growth
+// in practice.
 export const sessionAccountMap = new Map<string, string>();
+
+/** Build the composite key used to record `(accountId, sessionKey)` pairs. */
+export function buildSessionAccountKey(accountId: string, sessionKey: string): string {
+  return `${accountId}:${sessionKey}`;
+}
 
 export type DmworkStatusSink = (patch: {
   lastInboundAt?: number;
@@ -1578,10 +1601,12 @@ export async function handleInboundMessage(params: {
     pendingInboundContext.set(route.sessionKey, { historyPrefix, memberListPrefix });
   }
 
-  // Record sessionKey → accountId so the before_prompt_build hook can resolve
-  // accountId from ctx.sessionKey (hook ctx does not expose accountId).
+  // Record (accountId, sessionKey) so the before_prompt_build hook can
+  // resolve persona identity from ctx.sessionKey (hook ctx does not expose
+  // accountId). The composite key is required for multi-account isolation —
+  // see the doc comment on sessionAccountMap above.
   // Required by persona-prompt injection (GH octo-adapters#68).
-  sessionAccountMap.set(route.sessionKey, account.accountId);
+  sessionAccountMap.set(buildSessionAccountKey(account.accountId, route.sessionKey), account.accountId);
 
   const finalBody = quotePrefix ? (quotePrefix + rawBody) : rawBody;
 

--- a/openclaw-channel-octo/src/persona-prompt.test.ts
+++ b/openclaw-channel-octo/src/persona-prompt.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import {
+  composePersonaHint,
+  getPersonaPromptForSession,
+  initPersonaPromptCache,
+  refreshPersonaPromptCache,
+  setPersonaPromptRefreshIntervalMs,
+  stopPersonaPromptCache,
+  _resetPersonaPromptCacheForTests,
+} from "./persona-prompt.js";
+import type { BotOboGrant } from "./api-fetch.js";
+
+const originalFetch = global.fetch;
+
+function mockFetchOnce(body: unknown, init: Partial<{ status: number; ok: boolean }> = {}) {
+  const status = init.status ?? 200;
+  const ok = init.ok ?? status < 400;
+  const fn = vi.fn().mockResolvedValue({
+    ok,
+    status,
+    statusText: ok ? "OK" : "Err",
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  });
+  global.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+beforeEach(() => {
+  _resetPersonaPromptCacheForTests();
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  _resetPersonaPromptCacheForTests();
+  global.fetch = originalFetch;
+});
+
+describe("composePersonaHint", () => {
+  const baseGrant: BotOboGrant = {
+    has_grant: true,
+    grantor_uid: "u_admin",
+    grantor_name: "Admin",
+    persona_prompt: "Reply concisely.",
+    active: true,
+  };
+
+  it("composes a hint matching the buildFanoutCopyReq-style prefix", () => {
+    const hint = composePersonaHint(baseGrant);
+    expect(hint).toBe(
+      `你正在以「Admin」的分身身份运作。请以 Admin 的身份回复。\n\nReply concisely.`,
+    );
+  });
+
+  it("falls back to grantor_uid when grantor_name is missing", () => {
+    const hint = composePersonaHint({ ...baseGrant, grantor_name: "" });
+    expect(hint).toContain("「u_admin」");
+    expect(hint).toContain("请以 u_admin 的身份");
+  });
+
+  it("returns undefined when persona_prompt is empty / whitespace", () => {
+    expect(composePersonaHint({ ...baseGrant, persona_prompt: "" })).toBeUndefined();
+    expect(composePersonaHint({ ...baseGrant, persona_prompt: "   " })).toBeUndefined();
+  });
+
+  it("returns undefined when grant is inactive", () => {
+    expect(composePersonaHint({ ...baseGrant, active: false })).toBeUndefined();
+  });
+
+  it("returns undefined when has_grant is false", () => {
+    expect(composePersonaHint({ has_grant: false })).toBeUndefined();
+  });
+
+  it("returns undefined when both grantor_name and grantor_uid are missing", () => {
+    expect(
+      composePersonaHint({
+        has_grant: true,
+        persona_prompt: "p",
+        active: true,
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("refreshPersonaPromptCache + getPersonaPromptForSession", () => {
+  it("populates the cache from a 200 response", async () => {
+    mockFetchOnce({
+      has_grant: true,
+      grantor_uid: "u_admin",
+      grantor_name: "Admin",
+      persona_prompt: "Be brief.",
+      active: true,
+    });
+
+    await refreshPersonaPromptCache({
+      accountId: "bot_a",
+      apiUrl: "http://api",
+      botToken: "bf_x",
+      onBehalfOf: "u_admin",
+    });
+
+    const hint = getPersonaPromptForSession("bot_a");
+    expect(hint).toContain("「Admin」");
+    expect(hint).toContain("Be brief.");
+  });
+
+  it("clears the cached hint when the server returns has_grant=false", async () => {
+    mockFetchOnce({
+      has_grant: true,
+      grantor_uid: "u_admin",
+      grantor_name: "Admin",
+      persona_prompt: "old",
+      active: true,
+    });
+    const account = {
+      accountId: "bot_b",
+      apiUrl: "http://api",
+      botToken: "bf_x",
+      onBehalfOf: "u_admin",
+    };
+    await refreshPersonaPromptCache(account);
+    expect(getPersonaPromptForSession("bot_b")).toBeDefined();
+
+    mockFetchOnce({ has_grant: false });
+    await refreshPersonaPromptCache(account);
+    expect(getPersonaPromptForSession("bot_b")).toBeUndefined();
+  });
+
+  it("treats 404 as no grant (cache cleared, no throw)", async () => {
+    mockFetchOnce({}, { status: 404, ok: false });
+    await refreshPersonaPromptCache({
+      accountId: "bot_c",
+      apiUrl: "http://api",
+      botToken: "bf_x",
+      onBehalfOf: "u_admin",
+    });
+    expect(getPersonaPromptForSession("bot_c")).toBeUndefined();
+  });
+
+  it("is a no-op when onBehalfOf is undefined", async () => {
+    const fetchSpy = mockFetchOnce({ has_grant: true });
+    await refreshPersonaPromptCache({
+      accountId: "bot_regular",
+      apiUrl: "http://api",
+      botToken: "bf_x",
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(getPersonaPromptForSession("bot_regular")).toBeUndefined();
+  });
+
+  it("swallows 5xx errors and keeps the previous cached hint", async () => {
+    mockFetchOnce({
+      has_grant: true,
+      grantor_uid: "u_admin",
+      grantor_name: "Admin",
+      persona_prompt: "stable",
+      active: true,
+    });
+    const account = {
+      accountId: "bot_d",
+      apiUrl: "http://api",
+      botToken: "bf_x",
+      onBehalfOf: "u_admin",
+    };
+    await refreshPersonaPromptCache(account);
+    const before = getPersonaPromptForSession("bot_d");
+    expect(before).toBeDefined();
+
+    // Second call: server hiccups. Old cache must remain intact and we
+    // must not throw — message processing depends on this.
+    global.fetch = vi.fn().mockRejectedValue(new Error("network down")) as unknown as typeof fetch;
+    const log = { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() };
+    await expect(refreshPersonaPromptCache(account, log)).resolves.toBeUndefined();
+    expect(getPersonaPromptForSession("bot_d")).toBe(before);
+    expect(log.warn).toHaveBeenCalledOnce();
+  });
+
+  it("sends Authorization: Bearer <botToken> to /v1/bot/obo-grant", async () => {
+    const fetchSpy = mockFetchOnce({ has_grant: false });
+    await refreshPersonaPromptCache({
+      accountId: "bot_e",
+      apiUrl: "http://api/",
+      botToken: "bf_secret",
+      onBehalfOf: "u_admin",
+    });
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe("http://api/v1/bot/obo-grant");
+    expect(init.method).toBe("GET");
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      "Bearer bf_secret",
+    );
+  });
+});
+
+describe("initPersonaPromptCache (timer behavior)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setPersonaPromptRefreshIntervalMs(1000);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("performs an initial fetch + periodic refreshes at the configured interval", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({
+        has_grant: true,
+        grantor_uid: "u_admin",
+        grantor_name: "Admin",
+        persona_prompt: "p",
+        active: true,
+      }),
+      text: async () => "",
+    });
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    initPersonaPromptCache({
+      accountId: "bot_t",
+      apiUrl: "http://api",
+      botToken: "bf_x",
+      onBehalfOf: "u_admin",
+    });
+
+    // initial fetch is scheduled microtask; flush it
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+
+    stopPersonaPromptCache("bot_t");
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it("does NOT start a timer when onBehalfOf is undefined", async () => {
+    const fetchSpy = vi.fn();
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    initPersonaPromptCache({
+      accountId: "bot_plain",
+      apiUrl: "http://api",
+      botToken: "bf_x",
+    });
+
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("replaces an existing timer on repeated init (no leak)", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({ has_grant: false }),
+      text: async () => "",
+    });
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    initPersonaPromptCache({
+      accountId: "bot_repeat",
+      apiUrl: "http://api",
+      botToken: "bf_x",
+      onBehalfOf: "u_admin",
+    });
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+
+    // Re-init — should clear old timer and schedule a fresh one.
+    initPersonaPromptCache({
+      accountId: "bot_repeat",
+      apiUrl: "http://api",
+      botToken: "bf_x",
+      onBehalfOf: "u_admin",
+    });
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(2));
+
+    await vi.advanceTimersByTimeAsync(1000);
+    // Only one timer should now be active — exactly one extra call, not two.
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+
+    stopPersonaPromptCache("bot_repeat");
+  });
+});

--- a/openclaw-channel-octo/src/persona-prompt.test.ts
+++ b/openclaw-channel-octo/src/persona-prompt.test.ts
@@ -289,3 +289,117 @@ describe("initPersonaPromptCache (timer behavior)", () => {
     stopPersonaPromptCache("bot_repeat");
   });
 });
+
+describe("generation guard (abort in-flight fetches)", () => {
+  beforeEach(() => {
+    setPersonaPromptRefreshIntervalMs(60_000);
+  });
+
+  it("drops a stale in-flight fetch when stopPersonaPromptCache runs first", async () => {
+    // Hold the fetch open until we trigger its resolution.
+    let resolveFetch!: (v: unknown) => void;
+    const pending = new Promise((res) => {
+      resolveFetch = res;
+    });
+    global.fetch = vi.fn().mockImplementation(() => pending) as unknown as typeof fetch;
+
+    const account = {
+      accountId: "bot_race",
+      apiUrl: "http://api",
+      botToken: "bf_x",
+      onBehalfOf: "u_admin",
+    };
+
+    const inflight = refreshPersonaPromptCache(account);
+
+    // Simulate "account stopped while fetch is in flight"
+    stopPersonaPromptCache("bot_race");
+
+    // Now let the original fetch resolve with a non-empty grant.
+    resolveFetch({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({
+        has_grant: true,
+        grantor_uid: "u_admin",
+        grantor_name: "Admin",
+        persona_prompt: "stale",
+        active: true,
+      }),
+      text: async () => "",
+    });
+
+    await inflight;
+
+    // The stale fetch must NOT resurrect the cleared cache.
+    expect(getPersonaPromptForSession("bot_race")).toBeUndefined();
+  });
+
+  it("drops a stale in-flight fetch when initPersonaPromptCache runs first (reconfigure)", async () => {
+    // First fetch hangs forever (until we resolve it).
+    let resolveFirst!: (v: unknown) => void;
+    const firstPending = new Promise((res) => {
+      resolveFirst = res;
+    });
+    // Second fetch resolves immediately with a fresh grant.
+    const secondResponse = {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({
+        has_grant: true,
+        grantor_uid: "u_admin",
+        grantor_name: "Admin",
+        persona_prompt: "fresh",
+        active: true,
+      }),
+      text: async () => "",
+    };
+
+    const fetchSpy = vi
+      .fn()
+      .mockImplementationOnce(() => firstPending)
+      .mockResolvedValue(secondResponse);
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    const account = {
+      accountId: "bot_reconf",
+      apiUrl: "http://api",
+      botToken: "bf_x",
+      onBehalfOf: "u_admin",
+    };
+
+    // Kick off the first in-flight fetch via the explicit refresh API
+    // (initPersonaPromptCache's timer would otherwise complicate the test).
+    const stale = refreshPersonaPromptCache(account);
+
+    // Simulate reconfigure: bump generation, immediate fetch with new grant.
+    initPersonaPromptCache(account);
+    // Wait for the fresh fetch to populate the cache.
+    await vi.waitFor(() => {
+      expect(getPersonaPromptForSession("bot_reconf")).toContain("fresh");
+    });
+
+    // Now the original fetch resolves with a different (stale) grant.
+    resolveFirst({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({
+        has_grant: true,
+        grantor_uid: "u_admin",
+        grantor_name: "Admin",
+        persona_prompt: "stale",
+        active: true,
+      }),
+      text: async () => "",
+    });
+    await stale;
+
+    // Fresh entry must survive — stale fetch was superseded.
+    expect(getPersonaPromptForSession("bot_reconf")).toContain("fresh");
+
+    stopPersonaPromptCache("bot_reconf");
+  });
+});

--- a/openclaw-channel-octo/src/persona-prompt.test.ts
+++ b/openclaw-channel-octo/src/persona-prompt.test.ts
@@ -3,8 +3,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   composePersonaHint,
   getPersonaPromptForSession,
+  getRegisteredPersonaAccountIds,
   initPersonaPromptCache,
   refreshPersonaPromptCache,
+  resolvePersonaHintForSession,
   setPersonaPromptRefreshIntervalMs,
   stopPersonaPromptCache,
   _resetPersonaPromptCacheForTests,
@@ -401,5 +403,209 @@ describe("generation guard (abort in-flight fetches)", () => {
     expect(getPersonaPromptForSession("bot_reconf")).toContain("fresh");
 
     stopPersonaPromptCache("bot_reconf");
+  });
+});
+
+describe("getRegisteredPersonaAccountIds", () => {
+  it("returns the accountIds of accounts that called initPersonaPromptCache", async () => {
+    // Initial fetch is fire-and-forget; stub fetch so it can't reach the network.
+    mockFetchOnce({ has_grant: false });
+    initPersonaPromptCache({
+      accountId: "persona_a",
+      apiUrl: "http://api.example/",
+      botToken: "bf_a",
+      onBehalfOf: "u_admin",
+    });
+    mockFetchOnce({ has_grant: false });
+    initPersonaPromptCache({
+      accountId: "persona_b",
+      apiUrl: "http://api.example/",
+      botToken: "bf_b",
+      onBehalfOf: "u_admin",
+    });
+
+    expect(getRegisteredPersonaAccountIds().sort()).toEqual(["persona_a", "persona_b"]);
+
+    stopPersonaPromptCache("persona_a");
+    expect(getRegisteredPersonaAccountIds()).toEqual(["persona_b"]);
+  });
+
+  it("skips non-persona accounts (no onBehalfOf)", () => {
+    initPersonaPromptCache({
+      accountId: "regular_bot",
+      apiUrl: "http://api.example/",
+      botToken: "bf_x",
+      // onBehalfOf intentionally undefined
+    });
+    expect(getRegisteredPersonaAccountIds()).toEqual([]);
+  });
+});
+
+describe("resolvePersonaHintForSession — multi-account isolation (PR#69 R3)", () => {
+  async function seedPersonaCache(accountId: string, personaPrompt: string) {
+    mockFetchOnce({
+      has_grant: true,
+      grantor_uid: "u_admin",
+      grantor_name: `Admin-${accountId}`,
+      persona_prompt: personaPrompt,
+      active: true,
+    });
+    await refreshPersonaPromptCache({
+      accountId,
+      apiUrl: "http://api.example/",
+      botToken: `bf_${accountId}`,
+      onBehalfOf: "u_admin",
+    });
+  }
+
+  /**
+   * Build a fake sessionAccountMap closure over a plain Map so the test
+   * mirrors the real call site in index.ts (`sessionAccountMap.has(
+   * buildSessionAccountKey(accountId, sessionKey))`) without importing
+   * from inbound.ts (which would drag the channel runtime into this
+   * isolated test).
+   */
+  function makeHasAccountSession(entries: Array<[string, string]>) {
+    const set = new Set(entries.map(([acct, sk]) => `${acct}:${sk}`));
+    return (accountId: string, sessionKey: string) => set.has(`${accountId}:${sessionKey}`);
+  }
+
+  it("returns the hint when exactly one persona account is bound to the session", async () => {
+    mockFetchOnce({ has_grant: false }); // suppress init's fire-and-forget fetch
+    initPersonaPromptCache({
+      accountId: "persona_only",
+      apiUrl: "http://api.example/",
+      botToken: "bf_only",
+      onBehalfOf: "u_admin",
+    });
+    await seedPersonaCache("persona_only", "be helpful");
+
+    const sessionKey = "agent:default:octo:group:abc";
+    const hint = resolvePersonaHintForSession({
+      sessionKey,
+      hasAccountSession: makeHasAccountSession([["persona_only", sessionKey]]),
+    });
+    expect(hint).toContain("be helpful");
+
+    stopPersonaPromptCache("persona_only");
+  });
+
+  it("returns undefined when zero persona accounts match the session", async () => {
+    mockFetchOnce({ has_grant: false });
+    initPersonaPromptCache({
+      accountId: "persona_alpha",
+      apiUrl: "http://api.example/",
+      botToken: "bf_alpha",
+      onBehalfOf: "u_admin",
+    });
+    await seedPersonaCache("persona_alpha", "alpha prompt");
+
+    const hint = resolvePersonaHintForSession({
+      sessionKey: "agent:default:octo:group:other",
+      // Empty map — persona_alpha never seen on this sessionKey.
+      hasAccountSession: makeHasAccountSession([]),
+    });
+    expect(hint).toBeUndefined();
+
+    stopPersonaPromptCache("persona_alpha");
+  });
+
+  it("returns undefined when two persona accounts share the same sessionKey (no cross-account leak)", async () => {
+    // 🔴 Core regression guard for PR#69 R3 (Jerry-Xin blocker):
+    // when two persona-clone accounts collide on a sessionKey we MUST
+    // refuse to inject either persona prompt rather than guessing,
+    // because the hook cannot tell which account the prompt build is for.
+    mockFetchOnce({ has_grant: false });
+    initPersonaPromptCache({
+      accountId: "persona_a",
+      apiUrl: "http://api.example/",
+      botToken: "bf_a",
+      onBehalfOf: "u_admin",
+    });
+    mockFetchOnce({ has_grant: false });
+    initPersonaPromptCache({
+      accountId: "persona_b",
+      apiUrl: "http://api.example/",
+      botToken: "bf_b",
+      onBehalfOf: "u_admin",
+    });
+    await seedPersonaCache("persona_a", "A-only prompt");
+    await seedPersonaCache("persona_b", "B-only prompt");
+
+    const sharedSessionKey = "agent:default:octo:group:shared";
+    const hint = resolvePersonaHintForSession({
+      sessionKey: sharedSessionKey,
+      hasAccountSession: makeHasAccountSession([
+        ["persona_a", sharedSessionKey],
+        ["persona_b", sharedSessionKey],
+      ]),
+    });
+
+    expect(hint).toBeUndefined();
+    // And the per-account caches themselves are untouched — each persona
+    // still has its own prompt, the resolver just refused to disambiguate.
+    expect(getPersonaPromptForSession("persona_a")).toContain("A-only");
+    expect(getPersonaPromptForSession("persona_b")).toContain("B-only");
+
+    stopPersonaPromptCache("persona_a");
+    stopPersonaPromptCache("persona_b");
+  });
+
+  it("ignores non-persona accounts that share a sessionKey with a persona account", async () => {
+    // Regular bot (no onBehalfOf) bound to the same sessionKey must NOT
+    // prevent the persona account's prompt from being resolved — only
+    // entries from registered persona accounts count toward disambiguation.
+    mockFetchOnce({ has_grant: false });
+    initPersonaPromptCache({
+      accountId: "persona_solo",
+      apiUrl: "http://api.example/",
+      botToken: "bf_solo",
+      onBehalfOf: "u_admin",
+    });
+    await seedPersonaCache("persona_solo", "solo prompt");
+
+    const sharedSessionKey = "agent:default:octo:group:mixed";
+    const hint = resolvePersonaHintForSession({
+      sessionKey: sharedSessionKey,
+      // sessionAccountMap contains both a persona and a regular bot, but
+      // only `persona_solo` is a registered persona account so only its
+      // membership is consulted.
+      hasAccountSession: makeHasAccountSession([
+        ["persona_solo", sharedSessionKey],
+        ["regular_bot", sharedSessionKey],
+      ]),
+    });
+    expect(hint).toContain("solo prompt");
+
+    stopPersonaPromptCache("persona_solo");
+  });
+
+  it("returns undefined for empty sessionKey", () => {
+    const hint = resolvePersonaHintForSession({
+      sessionKey: "",
+      hasAccountSession: () => true,
+    });
+    expect(hint).toBeUndefined();
+  });
+
+  it("returns undefined when the matching persona account has no cached hint yet (cold start)", async () => {
+    mockFetchOnce({ has_grant: false });
+    initPersonaPromptCache({
+      accountId: "persona_cold",
+      apiUrl: "http://api.example/",
+      botToken: "bf_cold",
+      onBehalfOf: "u_admin",
+    });
+    // Deliberately do NOT seed a hint — _cache.get returns undefined.
+
+    const sessionKey = "agent:default:octo:dm:user1";
+    const hint = resolvePersonaHintForSession({
+      sessionKey,
+      hasAccountSession: makeHasAccountSession([["persona_cold", sessionKey]]),
+    });
+    // Single match, but no hint cached → undefined (fail-safe).
+    expect(hint).toBeUndefined();
+
+    stopPersonaPromptCache("persona_cold");
   });
 });

--- a/openclaw-channel-octo/src/persona-prompt.test.ts
+++ b/openclaw-channel-octo/src/persona-prompt.test.ts
@@ -406,6 +406,109 @@ describe("generation guard (abort in-flight fetches)", () => {
   });
 });
 
+describe("cache lifecycle on reconfigure (PR#69 R4 Jerry-Xin)", () => {
+  // Blocking 1: persona → regular bot must not leave a stale hint behind.
+  it("clears the cached hint when the account is reconfigured to drop onBehalfOf", async () => {
+    // 1. Seed the cache as a persona-clone.
+    mockFetchOnce({
+      has_grant: true,
+      grantor_uid: "u_admin",
+      grantor_name: "Admin",
+      persona_prompt: "old persona",
+      active: true,
+    });
+    const personaAccount = {
+      accountId: "bot_switch",
+      apiUrl: "http://api",
+      botToken: "bf_x",
+      onBehalfOf: "u_admin",
+    };
+    await refreshPersonaPromptCache(personaAccount);
+    expect(getPersonaPromptForSession("bot_switch")).toContain("old persona");
+
+    // Also start the refresh loop (mirrors the real channel-start path).
+    mockFetchOnce({ has_grant: false });
+    initPersonaPromptCache(personaAccount);
+    expect(getRegisteredPersonaAccountIds()).toContain("bot_switch");
+
+    // 2. Reconfigure: same accountId, but onBehalfOf cleared (now a plain bot).
+    initPersonaPromptCache({
+      accountId: "bot_switch",
+      apiUrl: "http://api",
+      botToken: "bf_x",
+      // onBehalfOf intentionally omitted
+    });
+
+    // 3. The old persona hint must be gone — before this fix, the early
+    //    return left _cache untouched and the before_prompt_build hook
+    //    would keep injecting "old persona" into the now-regular bot.
+    expect(getPersonaPromptForSession("bot_switch")).toBeUndefined();
+    // And the timer must be torn down so we don't keep polling either.
+    expect(getRegisteredPersonaAccountIds()).not.toContain("bot_switch");
+  });
+
+  // Blocking 2: re-init with a different grantor must not serve the old
+  // grantor's hint during the new fetch's in-flight window.
+  it("returns undefined during the refetch window when re-init switches grantor", async () => {
+    // Seed cache with grantor A's hint.
+    mockFetchOnce({
+      has_grant: true,
+      grantor_uid: "u_alice",
+      grantor_name: "Alice",
+      persona_prompt: "alice voice",
+      active: true,
+    });
+    await refreshPersonaPromptCache({
+      accountId: "bot_regrant",
+      apiUrl: "http://api",
+      botToken: "bf_x",
+      onBehalfOf: "u_alice",
+    });
+    expect(getPersonaPromptForSession("bot_regrant")).toContain("alice voice");
+
+    // Re-init with grantor B, but hold the new fetch open so we can
+    // observe the in-flight window.
+    let resolveNew!: (v: unknown) => void;
+    const pending = new Promise((res) => {
+      resolveNew = res;
+    });
+    global.fetch = vi.fn().mockImplementation(() => pending) as unknown as typeof fetch;
+
+    initPersonaPromptCache({
+      accountId: "bot_regrant",
+      apiUrl: "http://api",
+      botToken: "bf_x",
+      onBehalfOf: "u_bob",
+    });
+
+    // Before this fix, _cache.get("bot_regrant") still returned Alice's
+    // hint during the gap. Now it must be cleared eagerly so the hook
+    // fails safe (no persona injection) until the new fetch completes.
+    expect(getPersonaPromptForSession("bot_regrant")).toBeUndefined();
+
+    // Resolve with grantor B's grant — cache should now reflect B.
+    resolveNew({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({
+        has_grant: true,
+        grantor_uid: "u_bob",
+        grantor_name: "Bob",
+        persona_prompt: "bob voice",
+        active: true,
+      }),
+      text: async () => "",
+    });
+    await vi.waitFor(() => {
+      expect(getPersonaPromptForSession("bot_regrant")).toContain("bob voice");
+    });
+    expect(getPersonaPromptForSession("bot_regrant")).not.toContain("alice voice");
+
+    stopPersonaPromptCache("bot_regrant");
+  });
+});
+
 describe("getRegisteredPersonaAccountIds", () => {
   it("returns the accountIds of accounts that called initPersonaPromptCache", async () => {
     // Initial fetch is fire-and-forget; stub fetch so it can't reach the network.

--- a/openclaw-channel-octo/src/persona-prompt.ts
+++ b/openclaw-channel-octo/src/persona-prompt.ts
@@ -195,7 +195,16 @@ export function initPersonaPromptCache(
   account: PersonaAccountInput,
   log?: ChannelLogSink,
 ): void {
-  if (!account.onBehalfOf) return;
+  if (!account.onBehalfOf) {
+    // PR#69 R4 (Jerry-Xin) Blocking 1: when an account is reconfigured
+    // from persona-clone (`onBehalfOf` set) to a regular bot (`onBehalfOf`
+    // cleared), a bare early return would leave the previous timer and
+    // cached hint in place, so the before_prompt_build hook would keep
+    // injecting the old grantor's persona prompt into a now-plain bot.
+    // Tear down any prior state for this accountId before bailing out.
+    stopPersonaPromptCache(account.accountId);
+    return;
+  }
 
   // Drop any pre-existing timer for this account so repeated calls
   // (hot reload, account reconfigure) don't leak intervals.
@@ -206,6 +215,19 @@ export function initPersonaPromptCache(
   // is still in flight will see a generation mismatch when it resolves
   // and bail out before mutating _cache.
   _bumpGeneration(account.accountId);
+
+  // PR#69 R4 (Jerry-Xin) Blocking 2: on reconfigure (e.g. grantor
+  // switched from A to B), the previous grantor's hint is still sitting
+  // in _cache. The new fetch we kick off below is async — until it
+  // resolves, getPersonaPromptForSession would keep serving the OLD
+  // grantor's prompt. Clear the cache eagerly so the hook fails safe
+  // (returns undefined → no persona injection) during the refetch
+  // window, rather than leaking stale identity into the new context.
+  _cache.delete(account.accountId);
+  // Allow the next successful fetch for this account to re-emit the
+  // one-shot "loaded" / "not active" info log, so operators can see the
+  // post-reconfigure state in logs.
+  _firstFetchLogged.delete(account.accountId);
 
   // Fire-and-forget initial fetch. We deliberately don't await
   // because account start should not block on persona init.

--- a/openclaw-channel-octo/src/persona-prompt.ts
+++ b/openclaw-channel-octo/src/persona-prompt.ts
@@ -252,6 +252,54 @@ export function getPersonaPromptForSession(
   return _cache.get(accountId)?.hint;
 }
 
+/**
+ * Return the accountIds that have an active persona refresh loop registered
+ * via `initPersonaPromptCache`. This is the set of accounts the
+ * `before_prompt_build` hook should consider when resolving persona identity
+ * for a given sessionKey.
+ *
+ * Returning only persona-clone accounts (those with `account.config.onBehalfOf`
+ * set, since `initPersonaPromptCache` is a no-op for non-persona accounts)
+ * keeps the hook's resolution cheap and avoids accidentally matching regular
+ * bots that happen to share a sessionKey with a persona clone.
+ */
+export function getRegisteredPersonaAccountIds(): string[] {
+  return Array.from(_timers.keys());
+}
+
+/**
+ * Resolve the persona hint for a sessionKey using a caller-supplied
+ * `(accountId, sessionKey) → boolean` membership check.
+ *
+ * The hook caller passes a closure over `sessionAccountMap` (composite-keyed
+ * by `${accountId}:${sessionKey}`, see inbound.ts). We iterate every
+ * registered persona account and ask "have you been seen on this
+ * sessionKey?". If exactly one persona account matches we return its cached
+ * hint; on 0 or >1 matches we return undefined (fail safe — better to drop
+ * the persona injection than to attach the wrong account's identity to the
+ * prompt). This is the multi-account isolation fix called out in PR#69 R3
+ * (Jerry-Xin).
+ *
+ * Extracted as a pure helper so the resolution logic is unit-testable
+ * without standing up the full plugin hook surface.
+ */
+export function resolvePersonaHintForSession(params: {
+  sessionKey: string;
+  hasAccountSession: (accountId: string, sessionKey: string) => boolean;
+}): string | undefined {
+  const { sessionKey, hasAccountSession } = params;
+  if (!sessionKey) return undefined;
+  const matches: string[] = [];
+  for (const accountId of _timers.keys()) {
+    if (hasAccountSession(accountId, sessionKey)) {
+      matches.push(accountId);
+      if (matches.length > 1) return undefined; // ambiguous — fail safe
+    }
+  }
+  if (matches.length !== 1) return undefined;
+  return _cache.get(matches[0])?.hint;
+}
+
 /** Test helper — fully reset module state between cases. */
 export function _resetPersonaPromptCacheForTests(): void {
   for (const timer of _timers.values()) clearInterval(timer);

--- a/openclaw-channel-octo/src/persona-prompt.ts
+++ b/openclaw-channel-octo/src/persona-prompt.ts
@@ -1,0 +1,215 @@
+/**
+ * persona_prompt cache + composer for the before_prompt_build hook
+ * (GH octo-adapters#68).
+ *
+ * Persona clones (bot accounts with `account.config.onBehalfOf` set)
+ * are granted a free-form `persona_prompt` by their grantor. That
+ * prompt must reach the bot's LLM system prompt so the bot replies
+ * in the grantor's voice.
+ *
+ * Historically this travelled via OBO v2 fan-out as `obo_system_hint`
+ * → `GroupSystemPrompt` (see inbound.ts), which works only when
+ * messages are routed through the OBO v2 envelope. Direct group /
+ * DM messages addressed to the persona-clone bot skip that envelope,
+ * so the persona_prompt was effectively dropped on those paths.
+ *
+ * This module owns the active-pull path:
+ *   - on account start, fetch GET /v1/bot/obo-grant once
+ *   - refresh every `refreshIntervalMs` (default 60s)
+ *   - cache by accountId, surfaced via `getPersonaPromptForSession`
+ *
+ * The before_prompt_build hook in index.ts reads the cache on every
+ * prompt build and prepends the composed hint to the system prompt.
+ *
+ * The legacy `obo_system_hint → GroupSystemPrompt` path in inbound.ts
+ * is intentionally preserved as a fallback (per issue #68 禁改清单).
+ */
+
+import type { ChannelLogSink } from "openclaw/plugin-sdk/channel-contract";
+import { getBotOboGrant, type BotOboGrant } from "./api-fetch.js";
+
+const DEFAULT_REFRESH_INTERVAL_MS = 60_000;
+
+let _refreshIntervalMs = DEFAULT_REFRESH_INTERVAL_MS;
+
+interface PersonaCacheEntry {
+  /** Composed hint ready to be prepended to the LLM system prompt. */
+  hint: string | undefined;
+  fetchedAt: number;
+}
+
+/**
+ * Minimal shape this module needs from an account. Kept structural
+ * (not coupled to ResolvedDmworkAccount) so tests can construct a
+ * stub without dragging in the full config-schema graph.
+ */
+export interface PersonaAccountInput {
+  accountId: string;
+  apiUrl: string;
+  botToken: string;
+  /** Grantor uid — when undefined, persona logic is a no-op. */
+  onBehalfOf?: string;
+}
+
+const _cache = new Map<string, PersonaCacheEntry>();
+const _timers = new Map<string, NodeJS.Timeout>();
+/** Track which accounts have already logged their first successful fetch. */
+const _firstFetchLogged = new Set<string>();
+
+/**
+ * Override the refresh interval (ms). Intended for tests; production
+ * uses the default 60s cadence.
+ */
+export function setPersonaPromptRefreshIntervalMs(ms: number): void {
+  if (ms > 0) _refreshIntervalMs = ms;
+}
+
+/**
+ * Compose the system-prompt hint from a grant payload. Returns
+ * undefined when the grant has no usable persona content.
+ *
+ * Format mirrors octo-server's buildFanoutCopyReq (obo_fanout.go) —
+ * the OBO v2 fan-out path uses the same shape, so a single LLM
+ * prompt template covers both routes.
+ *
+ * NOTE: buildFanoutCopyReq's prefix includes the message origin
+ * (group name / sender name). That context is not available at
+ * prompt-build time (the hook fires per session, not per inbound
+ * message), so we omit it here and ship the channel-agnostic
+ * variant the issue spec defines:
+ *
+ *   你正在以「<grantor>」的分身身份运作。请以 <grantor> 的身份回复。
+ *
+ *   <persona_prompt>
+ */
+export function composePersonaHint(grant: BotOboGrant): string | undefined {
+  if (!grant.has_grant) return undefined;
+  // Treat paused/inactive grants as no-prompt — the server may still
+  // return the row, but the persona should not influence the LLM.
+  if (grant.active === false) return undefined;
+  const prompt = (grant.persona_prompt ?? "").trim();
+  if (!prompt) return undefined;
+  const grantorName = (grant.grantor_name ?? "").trim() || grant.grantor_uid;
+  if (!grantorName) return undefined;
+  return (
+    `你正在以「${grantorName}」的分身身份运作。请以 ${grantorName} 的身份回复。` +
+    `\n\n${prompt}`
+  );
+}
+
+/**
+ * Fetch the latest grant once and update the cache. Failures are
+ * swallowed (logged) so a transient server hiccup never blocks
+ * message processing — the next tick will retry.
+ */
+export async function refreshPersonaPromptCache(
+  account: PersonaAccountInput,
+  log?: ChannelLogSink,
+): Promise<void> {
+  if (!account.onBehalfOf) return;
+  let grant: BotOboGrant | null;
+  try {
+    grant = await getBotOboGrant({
+      apiUrl: account.apiUrl,
+      botToken: account.botToken,
+    });
+  } catch (err) {
+    log?.warn?.(
+      `octo: persona_prompt fetch failed for ${account.accountId}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return;
+  }
+
+  const hint = grant ? composePersonaHint(grant) : undefined;
+  const prev = _cache.get(account.accountId);
+  _cache.set(account.accountId, { hint, fetchedAt: Date.now() });
+
+  if (!_firstFetchLogged.has(account.accountId)) {
+    _firstFetchLogged.add(account.accountId);
+    if (hint) {
+      log?.info?.(
+        `octo: persona_prompt loaded for ${account.accountId} (grantor=${account.onBehalfOf}, ${hint.length} chars)`,
+      );
+    } else {
+      log?.info?.(
+        `octo: persona_prompt not active for ${account.accountId} (grantor=${account.onBehalfOf}); cache will retry every ${_refreshIntervalMs}ms`,
+      );
+    }
+    return;
+  }
+  if (prev?.hint !== hint) {
+    log?.info?.(
+      `octo: persona_prompt refreshed for ${account.accountId} (changed=${prev?.hint !== hint}, hasHint=${Boolean(hint)})`,
+    );
+  }
+}
+
+/**
+ * Start the per-account refresh loop. Idempotent — calling twice
+ * for the same accountId resets the timer.
+ *
+ * No-op when `account.onBehalfOf` is undefined (regular non-persona
+ * bot) so the channel start path can call this unconditionally
+ * without an outer guard.
+ */
+export function initPersonaPromptCache(
+  account: PersonaAccountInput,
+  log?: ChannelLogSink,
+): void {
+  if (!account.onBehalfOf) return;
+
+  // Drop any pre-existing timer for this account so repeated calls
+  // (hot reload, account reconfigure) don't leak intervals.
+  const existing = _timers.get(account.accountId);
+  if (existing) clearInterval(existing);
+
+  // Fire-and-forget initial fetch. We deliberately don't await
+  // because account start should not block on persona init.
+  void refreshPersonaPromptCache(account, log);
+
+  const timer = setInterval(() => {
+    void refreshPersonaPromptCache(account, log);
+  }, _refreshIntervalMs);
+  // Refresh timer alone must not keep the Node process alive.
+  timer.unref?.();
+  _timers.set(account.accountId, timer);
+}
+
+/**
+ * Stop the refresh loop and clear cached state for an account.
+ * Called when the account is shut down or reconfigured.
+ */
+export function stopPersonaPromptCache(accountId: string): void {
+  const timer = _timers.get(accountId);
+  if (timer) clearInterval(timer);
+  _timers.delete(accountId);
+  _cache.delete(accountId);
+  _firstFetchLogged.delete(accountId);
+}
+
+/**
+ * Read the composed persona hint for an account. Returns undefined
+ * when:
+ *   - the account is not a persona clone,
+ *   - the initial fetch hasn't completed yet,
+ *   - the grant is empty / paused / has no persona_prompt,
+ *   - the fetch is failing (last successful hint is still served).
+ *
+ * Callers (currently the before_prompt_build hook in index.ts) can
+ * push the return value directly into the prompt sections array
+ * when truthy.
+ */
+export function getPersonaPromptForSession(
+  accountId: string,
+): string | undefined {
+  return _cache.get(accountId)?.hint;
+}
+
+/** Test helper — fully reset module state between cases. */
+export function _resetPersonaPromptCacheForTests(): void {
+  for (const timer of _timers.values()) clearInterval(timer);
+  _timers.clear();
+  _cache.clear();
+  _firstFetchLogged.clear();
+  _refreshIntervalMs = DEFAULT_REFRESH_INTERVAL_MS;
+}

--- a/openclaw-channel-octo/src/persona-prompt.ts
+++ b/openclaw-channel-octo/src/persona-prompt.ts
@@ -55,6 +55,27 @@ const _cache = new Map<string, PersonaCacheEntry>();
 const _timers = new Map<string, NodeJS.Timeout>();
 /** Track which accounts have already logged their first successful fetch. */
 const _firstFetchLogged = new Set<string>();
+/**
+ * Per-account generation counter. Bumped on every init/stop so that any
+ * in-flight refresh fetch can detect that it has been superseded and bail
+ * out before writing stale data into _cache.
+ *
+ * Without this guard, an account stop/reconfigure that races with an
+ * in-flight `getBotOboGrant` call would let the old fetch resolve later
+ * and overwrite the cleared cache (or replace the next account's fresh
+ * hint). See PR#69 review.
+ */
+const _generation = new Map<string, number>();
+
+function _bumpGeneration(accountId: string): number {
+  const next = (_generation.get(accountId) ?? 0) + 1;
+  _generation.set(accountId, next);
+  return next;
+}
+
+function _currentGeneration(accountId: string): number {
+  return _generation.get(accountId) ?? 0;
+}
 
 /**
  * Override the refresh interval (ms). Intended for tests; production
@@ -101,12 +122,22 @@ export function composePersonaHint(grant: BotOboGrant): string | undefined {
  * Fetch the latest grant once and update the cache. Failures are
  * swallowed (logged) so a transient server hiccup never blocks
  * message processing — the next tick will retry.
+ *
+ * Each call captures the current generation token for the account.
+ * If `stopPersonaPromptCache` or `initPersonaPromptCache` runs while
+ * the fetch is in flight (bumping the generation), the post-fetch
+ * branches bail out instead of writing the now-stale grant into the
+ * cache. This prevents stop → in-flight resolve → cache resurrected
+ * races, and also covers reconfigure (old account token still fetches,
+ * resolves late, would otherwise overwrite the freshly-initialised
+ * cache entry with stale data).
  */
 export async function refreshPersonaPromptCache(
   account: PersonaAccountInput,
   log?: ChannelLogSink,
 ): Promise<void> {
   if (!account.onBehalfOf) return;
+  const myGeneration = _currentGeneration(account.accountId);
   let grant: BotOboGrant | null;
   try {
     grant = await getBotOboGrant({
@@ -114,11 +145,19 @@ export async function refreshPersonaPromptCache(
       botToken: account.botToken,
     });
   } catch (err) {
+    // Even logging on a superseded fetch is noise — but skipping it
+    // could mask real failures. Keep the warn but suppress cache writes.
+    if (_currentGeneration(account.accountId) !== myGeneration) return;
     log?.warn?.(
       `octo: persona_prompt fetch failed for ${account.accountId}: ${err instanceof Error ? err.message : String(err)}`,
     );
     return;
   }
+
+  // Drop this result if the account was stopped or reconfigured while
+  // the fetch was outstanding. Without this check, a stale grant could
+  // overwrite the cleared cache or the next init's fresh entry.
+  if (_currentGeneration(account.accountId) !== myGeneration) return;
 
   const hint = grant ? composePersonaHint(grant) : undefined;
   const prev = _cache.get(account.accountId);
@@ -163,6 +202,11 @@ export function initPersonaPromptCache(
   const existing = _timers.get(account.accountId);
   if (existing) clearInterval(existing);
 
+  // Bump generation so any fetch from a previous init/start-cycle that
+  // is still in flight will see a generation mismatch when it resolves
+  // and bail out before mutating _cache.
+  _bumpGeneration(account.accountId);
+
   // Fire-and-forget initial fetch. We deliberately don't await
   // because account start should not block on persona init.
   void refreshPersonaPromptCache(account, log);
@@ -180,6 +224,9 @@ export function initPersonaPromptCache(
  * Called when the account is shut down or reconfigured.
  */
 export function stopPersonaPromptCache(accountId: string): void {
+  // Bump generation BEFORE clearing state so any fetch that resolves
+  // after this point sees the mismatch and skips its cache write.
+  _bumpGeneration(accountId);
   const timer = _timers.get(accountId);
   if (timer) clearInterval(timer);
   _timers.delete(accountId);
@@ -211,5 +258,6 @@ export function _resetPersonaPromptCacheForTests(): void {
   _timers.clear();
   _cache.clear();
   _firstFetchLogged.clear();
+  _generation.clear();
   _refreshIntervalMs = DEFAULT_REFRESH_INTERVAL_MS;
 }


### PR DESCRIPTION
## Summary

Persona-clone bots (`account.config.onBehalfOf` set) currently rely on the OBO v2 fan-out copy to deliver `persona_prompt` as `obo_system_hint` → `GroupSystemPrompt`. That path only fires when messages travel through the fan-out envelope, so direct group / DM messages addressed to the persona-clone bot silently drop the `persona_prompt`.

This PR adds a second, complementary path that mirrors how `GROUP.md` is injected: an active-pull cache hydrated from `GET /v1/bot/obo-grant` and prepended to the system prompt via the existing `before_prompt_build` hook.

## Changes

- **`src/persona-prompt.ts`** (new) — per-account cache. Polls `GET /v1/bot/obo-grant` once at account start and refreshes every 60s. No-op when `onBehalfOf` is undefined. Network failures are logged and the last good cache is served so message processing never blocks.
- **`src/api-fetch.ts`** — `getBotOboGrant()` helper for the new endpoint (octo-server YUJ-1762). 404 / `has_grant=false` / inactive grants all collapse to "no hint".
- **`index.ts` `before_prompt_build` hook** — after GROUP.md (section 1) and member/history context (section 2), pushes the composed persona hint as section 3 when the cache has a value.
- **`src/channel.ts`** — wires `initPersonaPromptCache()` into the account start path and `stopPersonaPromptCache()` into the cleanup path.

## Hint format

Mirrors `buildFanoutCopyReq` in `octo-server/modules/bot_api/obo_fanout.go` so the OBO v2 path and this hook path produce structurally identical system prompts:

```
你正在以「<grantor_name>」的分身身份运作。请以 <grantor_name> 的身份回复。

<persona_prompt>
```

Channel-specific context (group name / sender name) is omitted because the hook fires per session, not per message — adding it would require coupling to inbound state and would not be available on the very first message of a session. The OBO v2 fan-out path retains the richer per-message hint.

## Backward compatibility

The legacy `inbound.ts obo_system_hint → GroupSystemPrompt` path is **preserved unchanged** as a fallback (per issue #68 禁改清单). When both paths fire (OBO v2 fan-out into a persona clone), the LLM sees two slightly redundant system messages — duplicate priming is harmless and is what the existing fan-out clients already produce.

## Dependencies

Depends on octo-server `GET /v1/bot/obo-grant` (YUJ-1762, in progress). Until that ships, persona clones running this build will keep logging `persona_prompt fetch failed (404)` every 60s and gracefully fall back to the legacy `GroupSystemPrompt` path. The 404 path is exercised in unit tests so the rollout is non-breaking even when paired with an older server.

## Tests

- 15 new unit tests in `src/persona-prompt.test.ts` covering: hint composition (5 cases), cache population from 200, has_grant=false clearing the cache, 404 handling, no-op when `onBehalfOf` is undefined, 5xx error swallowing + cache retention, Authorization header shape, periodic refresh timer, and timer replacement on repeated init.
- All 840 existing tests still pass.
- `tsc --noEmit` clean.

## Manual integration verification (post-merge, requires YUJ-1762)

1. **Group chat**: bot in a group with grantor → @grantor → bot reply matches `persona_prompt` style.
2. **DM**: `u_bob` → admin → bot reply matches `persona_prompt` style.
3. **Live edit**: change `persona_prompt` via the grantor UI → wait ≤60s → next reply uses the new prompt without process restart.

Closes #68