### PR TITLE
refactor(dmwork/inbound): drop mentionAll/ignoreMentionAll, gate on mention.ais

### DIFF
--- a/openclaw-channel-dmwork/openclaw.plugin.json
+++ b/openclaw-channel-dmwork/openclaw.plugin.json
@@ -26,7 +26,6 @@
           "pollIntervalMs": { "type": "number", "minimum": 500 },
           "heartbeatIntervalMs": { "type": "number", "minimum": 5000 },
           "requireMention": { "type": "boolean" },
-          "ignoreMentionAll": { "type": "boolean" },
           "botUid": { "type": "string" },
           "historyLimit": { "type": "number", "minimum": 1, "maximum": 100 },
           "historyPromptTemplate": { "type": "string" },
@@ -44,7 +43,6 @@
                 "pollIntervalMs": { "type": "number", "minimum": 500 },
                 "heartbeatIntervalMs": { "type": "number", "minimum": 5000 },
                 "requireMention": { "type": "boolean" },
-                "ignoreMentionAll": { "type": "boolean" },
                 "botUid": { "type": "string" },
                 "historyLimit": { "type": "number", "minimum": 1, "maximum": 100 },
                 "historyPromptTemplate": { "type": "string" }

--- a/openclaw-channel-dmwork/skills/dmwork-bot-api/SKILL.md
+++ b/openclaw-channel-dmwork/skills/dmwork-bot-api/SKILL.md
@@ -788,7 +788,7 @@ This lets you understand context when someone asks about a specific message.
 
 **To reply to every message:** set requireMention to false in your dmwork channel config (channels.dmwork.requireMention = false). This costs more tokens but lets the AI decide when to reply.
 
-**To ignore @all/@所有人:** set ignoreMentionAll to true (channels.dmwork.accounts.xxx.ignoreMentionAll = true). This only applies when requireMention is true — @all will not trigger a bot reply, but direct @bot still will. When requireMention is false, ignoreMentionAll has no effect since the bot replies to all messages anyway.
+**Mention triggers (when requireMention is true):** the bot replies when the incoming message has `mention.uids` containing the bot's uid, or `mention.ais === true|1` (the API's "@AIs" flag, which targets all AI bots in the group). Plain `@all`/`@所有人` (i.e. `mention.all`) does NOT trigger a bot reply on its own — only `@AIs` or a direct `@bot` does. When requireMention is false, the bot replies to all messages regardless of mention.
 
 ### Rule 2: Don't respond to other bots
 

--- a/openclaw-channel-dmwork/src/accounts.ts
+++ b/openclaw-channel-dmwork/src/accounts.ts
@@ -19,7 +19,6 @@ export type ResolvedDmworkAccount = {
     pollIntervalMs: number;
     heartbeatIntervalMs: number;
     requireMention?: boolean;
-    ignoreMentionAll?: boolean;
     historyLimit?: number;  // 群聊历史消息条数限制
     historyPromptTemplate?: string;  // Template for group history context injection
   };
@@ -86,7 +85,6 @@ export function resolveDmworkAccount(params: {
       pollIntervalMs,
       heartbeatIntervalMs,
       requireMention: accountConfig.requireMention ?? channel.requireMention,
-      ignoreMentionAll: accountConfig.ignoreMentionAll ?? channel.ignoreMentionAll,
       historyLimit: accountConfig.historyLimit ?? channel.historyLimit ?? 20,
       historyPromptTemplate: accountConfig.historyPromptTemplate ?? channel.historyPromptTemplate,
     },

--- a/openclaw-channel-dmwork/src/config-schema.ts
+++ b/openclaw-channel-dmwork/src/config-schema.ts
@@ -10,7 +10,6 @@ export interface DmworkAccountConfig {
   pollIntervalMs?: number;
   heartbeatIntervalMs?: number;
   requireMention?: boolean;
-  ignoreMentionAll?: boolean;
   botUid?: string;
   historyLimit?: number;  // 群聊历史消息条数限制（默认20）
   historyPromptTemplate?: string;  // Template for group history context injection
@@ -26,7 +25,6 @@ export interface DmworkConfig {
   pollIntervalMs?: number;
   heartbeatIntervalMs?: number;
   requireMention?: boolean;
-  ignoreMentionAll?: boolean;
   botUid?: string;
   historyLimit?: number;  // 群聊历史消息条数限制（默认20）
   historyPromptTemplate?: string;  // Template for group history context injection
@@ -51,7 +49,6 @@ export const DmworkConfigJsonSchema = {
       pollIntervalMs: { type: "number", minimum: 500 },
       heartbeatIntervalMs: { type: "number", minimum: 5000 },
       requireMention: { type: "boolean" },
-      ignoreMentionAll: { type: "boolean" },
       botUid: { type: "string" },
       historyLimit: { type: "number", minimum: 1, maximum: 100 },
       historyPromptTemplate: { type: "string" },
@@ -69,7 +66,6 @@ export const DmworkConfigJsonSchema = {
             pollIntervalMs: { type: "number", minimum: 500 },
             heartbeatIntervalMs: { type: "number", minimum: 5000 },
             requireMention: { type: "boolean" },
-            ignoreMentionAll: { type: "boolean" },
             botUid: { type: "string" },
             historyLimit: { type: "number", minimum: 1, maximum: 100 },
             historyPromptTemplate: { type: "string" },

--- a/openclaw-channel-dmwork/src/inbound.test.ts
+++ b/openclaw-channel-dmwork/src/inbound.test.ts
@@ -22,53 +22,78 @@ import { extractMentionUids } from "./mention-utils.js";
 import { existsSync, unlinkSync, readFileSync } from "node:fs";
 
 /**
- * Tests for mention.all detection logic.
+ * Tests for the mention-trigger logic used in inbound.ts.
  *
- * The API can return mention.all as either:
- * - boolean `true` (newer API versions)
- * - number `1` (older API versions / WuKongIM native format)
+ * The dmwork backend signals "this message should ping the AI bot" via two
+ * payload fields:
+ * - `mention.uids[]`: explicit list of mentioned UIDs (bot replies if its own
+ *   uid is included).
+ * - `mention.ais`: "@AIs" flag, meaning the message targets every AI bot in
+ *   the group. May arrive as boolean `true` (newer API) or numeric `1`
+ *   (older API / WuKongIM native format) — both must be honored.
  *
- * Both should be treated as "mention all".
+ * Plain `@all` / `@所有人` (`mention.all`) is intentionally NOT a trigger:
+ * humans broadcasting to the room shouldn't wake every bot.
  */
-describe("mention.all detection", () => {
-  // Helper to simulate the detection logic from inbound.ts
-  function isMentionAll(mention?: MentionPayload): boolean {
-    const mentionAllRaw = mention?.all;
-    return mentionAllRaw === true || mentionAllRaw === 1;
+describe("mention trigger logic (mentionAis + uids)", () => {
+  // Helper that mirrors the isMentioned computation from inbound.ts
+  function isMentioned(mention: MentionPayload | undefined, botUid: string): boolean {
+    const mentionUids = extractMentionUids(mention);
+    const mentionAisRaw = mention?.ais;
+    const mentionAis: boolean = mentionAisRaw === true || mentionAisRaw === 1;
+    return mentionAis || mentionUids.includes(botUid);
   }
 
-  it("should detect mention.all when all is boolean true", () => {
-    const mention: MentionPayload = { all: true };
-    expect(isMentionAll(mention)).toBe(true);
-  });
+  const BOT_UID = "bot_123";
 
-  it("should detect mention.all when all is numeric 1", () => {
+  it("should NOT trigger when only mention.all is set ({all: 1})", () => {
     const mention: MentionPayload = { all: 1 };
-    expect(isMentionAll(mention)).toBe(true);
+    expect(isMentioned(mention, BOT_UID)).toBe(false);
   });
 
-  it("should NOT detect mention.all when all is false", () => {
-    const mention: MentionPayload = { all: false as unknown as boolean | number };
-    expect(isMentionAll(mention)).toBe(false);
+  it("should NOT trigger when only mention.all is set ({all: true})", () => {
+    const mention: MentionPayload = { all: true };
+    expect(isMentioned(mention, BOT_UID)).toBe(false);
   });
 
-  it("should NOT detect mention.all when all is 0", () => {
-    const mention: MentionPayload = { all: 0 };
-    expect(isMentionAll(mention)).toBe(false);
+  it("should trigger when mention.ais is numeric 1", () => {
+    const mention: MentionPayload = { ais: 1 };
+    expect(isMentioned(mention, BOT_UID)).toBe(true);
   });
 
-  it("should NOT detect mention.all when all is undefined", () => {
-    const mention: MentionPayload = { uids: ["user1"] };
-    expect(isMentionAll(mention)).toBe(false);
+  it("should trigger when mention.ais is boolean true", () => {
+    const mention: MentionPayload = { ais: true };
+    expect(isMentioned(mention, BOT_UID)).toBe(true);
   });
 
-  it("should NOT detect mention.all when mention is undefined", () => {
-    expect(isMentionAll(undefined)).toBe(false);
+  it("should trigger via mention.ais even when mention.all is also set", () => {
+    const mention: MentionPayload = { ais: 1, all: 1 };
+    expect(isMentioned(mention, BOT_UID)).toBe(true);
   });
 
-  it("should NOT detect mention.all when all is a different number", () => {
-    const mention: MentionPayload = { all: 2 };
-    expect(isMentionAll(mention)).toBe(false);
+  it("should trigger when mention.uids contains the bot uid", () => {
+    const mention: MentionPayload = { uids: [BOT_UID] };
+    expect(isMentioned(mention, BOT_UID)).toBe(true);
+  });
+
+  it("should NOT trigger for an unrelated 'humans' field", () => {
+    const mention = { humans: 1 } as unknown as MentionPayload;
+    expect(isMentioned(mention, BOT_UID)).toBe(false);
+  });
+
+  it("should NOT trigger for an empty mention payload", () => {
+    expect(isMentioned({}, BOT_UID)).toBe(false);
+  });
+
+  it("should NOT trigger when mention is undefined", () => {
+    expect(isMentioned(undefined, BOT_UID)).toBe(false);
+  });
+
+  it("should NOT trigger when mention.ais is false / 0 and uids omit the bot", () => {
+    expect(isMentioned({ ais: false as unknown as boolean | number }, BOT_UID)).toBe(false);
+    expect(isMentioned({ ais: 0 }, BOT_UID)).toBe(false);
+    expect(isMentioned({ ais: 2 }, BOT_UID)).toBe(false);
+    expect(isMentioned({ uids: ["someone_else"] }, BOT_UID)).toBe(false);
   });
 });
 

--- a/openclaw-channel-dmwork/src/inbound.ts
+++ b/openclaw-channel-dmwork/src/inbound.ts
@@ -1181,9 +1181,9 @@ export async function handleInboundMessage(params: {
   let isExplicitBotMention = false;
   if (isGroup) {
     const mentionUids = extractMentionUids(message.payload?.mention);
-    const mentionAllRaw = message.payload?.mention?.all;
-    const mentionAll: boolean = mentionAllRaw === true || mentionAllRaw === 1;
-    isMentioned = (!account.config.ignoreMentionAll && mentionAll) || mentionUids.includes(botUid);
+    const mentionAisRaw = message.payload?.mention?.ais;
+    const mentionAis: boolean = mentionAisRaw === true || mentionAisRaw === 1;
+    isMentioned = mentionAis || mentionUids.includes(botUid);
     isExplicitBotMention = mentionUids.includes(botUid);
 
     // Defensive fallback: if payload.mention is missing/empty but the message

--- a/openclaw-channel-dmwork/src/types.ts
+++ b/openclaw-channel-dmwork/src/types.ts
@@ -64,6 +64,7 @@ export interface MentionPayload {
   uids?: string[];
   entities?: MentionEntity[];
   all?: boolean | number; // true or 1 = @all (API returns either depending on version)
+  ais?: boolean | number; // true or 1 = @ais (mentions all AI bots in the group)
 }
 
 export interface ReplyPayload {


### PR DESCRIPTION
Fixes Mininglamp-OSS/octo-adapters#70

## What

Switch the dmwork inbound mention-trigger from the legacy `@all`
broadcast (with an `ignoreMentionAll` opt-out) to the backend's new
`mention.ais` ("@AIs") flag. The new rule, applied in groups when
`requireMention` is on:

```ts
const mentionUids = extractMentionUids(message.payload?.mention);
const mentionAisRaw = message.payload?.mention?.ais;
const mentionAis: boolean = mentionAisRaw === true || mentionAisRaw === 1;
isMentioned = mentionAis || mentionUids.includes(botUid);
```

Plain `@all` no longer wakes a bot; only an explicit `@bot` mention or
the `@AIs` flag does.

## Why

`@all` is a human broadcast — having every bot in the room reply to it
spams the channel. The dmwork API now exposes a separate `mention.ais`
flag for "ping every AI bot," which is the right abstraction. With that
in place, `ignoreMentionAll` (a workaround for the old behavior) is dead
config and is removed.

## Files

- `openclaw-channel-dmwork/src/inbound.ts` — rewrite the mention block
  (~L1183-1186). `isExplicitBotMention` and the defensive `@botName`
  text fallback are preserved.
- `openclaw-channel-dmwork/src/types.ts` — add
  `MentionPayload.ais?: boolean | number` (mirrors the existing
  `all` typing for backend compatibility).
- `openclaw-channel-dmwork/src/config-schema.ts`,
  `src/accounts.ts`, `openclaw.plugin.json` — drop the
  `ignoreMentionAll` config flag from the TS interfaces, the JSON
  Schema, and the resolved-account shape.
- `openclaw-channel-dmwork/src/inbound.test.ts` — replace the
  `mention.all detection` suite with a `mention trigger logic` suite
  covering: `{all:1}` ❌, `{all:true}` ❌, `{ais:1}` ✅, `{ais:true}` ✅,
  `{ais:1, all:1}` ✅, `{uids:[botUid]}` ✅, `{humans:1}` ❌,
  `{}` / undefined ❌, plus `ais:false/0/2` ❌.
- `openclaw-channel-dmwork/skills/dmwork-bot-api/SKILL.md` — update
  the operator-facing note to describe the new `@AIs` trigger.

## Out of scope

- `openclaw-channel-octo` — to be migrated separately.
- Outbound / send path (`sendMessage`'s `mentionAll`, `actions.ts`,
  `channel.ts`) — unchanged.
- `mention-utils.ts` — unchanged.

## Validation

```
cd openclaw-channel-dmwork
npm run type-check   # clean
npm test             # 22 files, 698 tests, all green
```

review-tier: low-risk