### PR TITLE
feat(create-openclaw-octo): force-upgrade legacy installs (2/2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,6 @@ jobs:
           filters: |
             code:
               - 'create-openclaw-octo/**'
-              - 'package.json'
-              - 'pnpm-lock.yaml'
-              - '*.config.*'
               - '.github/workflows/**'
 
   build:

--- a/create-openclaw-octo/README.md
+++ b/create-openclaw-octo/README.md
@@ -8,6 +8,8 @@ CLI tools for the [OpenClaw Octo channel plugin](https://github.com/Mininglamp-O
 
 > **Renamed from `openclaw-channel-octo`** (npm).
 > The old npm package name has been replaced by `create-openclaw-octo`. The legacy npm name will print a redirect notice; please use `npx -y create-openclaw-octo ...` going forward.
+>
+> If you previously installed the old name globally (`npm i -g openclaw-channel-octo`), the `openclaw-channel-octo` shim binary on your `$PATH` will not be updated by the rename. Remove it with `npm uninstall -g openclaw-channel-octo` and switch to the `npx -y create-openclaw-octo ...` workflow above. (No global install of the new name is needed; `npx` always fetches the latest.)
 
 Repository: https://github.com/Mininglamp-OSS/octo-adapters
 

--- a/create-openclaw-octo/cli/account-writes-octo.test.ts
+++ b/create-openclaw-octo/cli/account-writes-octo.test.ts
@@ -13,14 +13,14 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // Mocks must be declared before importing the modules under test.
 // ---------------------------------------------------------------------------
 
-// Stub utils.js so ensureOpenClawCompat doesn't try to spawn `openclaw`.
+// Stub utils.js so enforceHealthyClawHubInstall doesn't try to spawn `openclaw`.
 // Re-export the real CHANNEL_ID/PLUGIN_ID/etc. via importOriginal so the
 // module under test sees the canonical helper behaviour for paths/objects.
 vi.mock("./utils.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./utils.js")>();
   return {
     ...actual,
-    ensureOpenClawCompat: vi.fn(),
+    enforceHealthyClawHubInstall: vi.fn(),
   };
 });
 

--- a/create-openclaw-octo/cli/bind.ts
+++ b/create-openclaw-octo/cli/bind.ts
@@ -5,7 +5,6 @@
  */
 
 import {
-  isHealthyInstall,
   readConfigFromFile,
   writeConfigAtomic,
 } from "./openclaw-cli.js";
@@ -13,7 +12,7 @@ import {
   CHANNEL_ID,
   RECOMMENDED_DM_SCOPE,
   ensureChannelConfigObject,
-  ensureOpenClawCompat,
+  enforceHealthyClawHubInstall,
   validateAccountId,
 } from "./utils.js";
 
@@ -25,14 +24,8 @@ export interface BindOptions {
 }
 
 export async function runBind(opts: BindOptions): Promise<void> {
-  ensureOpenClawCompat();
-
-  // 1. Pre-flight: plugin must be healthy
-  if (!isHealthyInstall()) {
-    console.error("Octo plugin is not installed or in an unhealthy state.");
-    console.error("Please run first: npx -y create-openclaw-octo install");
-    process.exit(1);
-  }
+  // 1. Pre-flight: enforce healthy ClawHub octo + recent OpenClaw (exits on legacy/missing/broken)
+  enforceHealthyClawHubInstall();
 
   // 2. Validate params
   if (!opts.botToken.startsWith("bf_")) {

--- a/create-openclaw-octo/cli/index.ts
+++ b/create-openclaw-octo/cli/index.ts
@@ -14,7 +14,7 @@ import {
 } from "./doctor.js";
 import { runUninstall } from "./uninstall.js";
 import { runRemoveAccount } from "./remove-account.js";
-import { ensureOpenClawCompat, NPM_PACKAGE_NAME, PLUGIN_ID, renderInstallStatusBanner } from "./utils.js";
+import { ensureOpenClawCompat, PLUGIN_ID, renderInstallStatusBanner } from "./utils.js";
 import { getOpenClawVersionStrict, resolvePluginState } from "./openclaw-cli.js";
 import { PLUGIN_VERSION } from "./version.js";
 
@@ -57,7 +57,6 @@ program
     console.log(`${b}openclaw:${r} ${g}${openclawVersion}${r}`);
     console.log(`${b}installed plugin id:${r} ${g}${PLUGIN_ID}${r} (ClawHub)`);
     console.log(`${b}installed plugin version:${r} ${g}${installedVersion}${r}`);
-    console.log(`${b}npm package:${r} ${g}${NPM_PACKAGE_NAME}${r}`);
     console.log();
     console.log(`${b}Environment:${r}`);
     console.log(`${b}OS:${r} ${g}${process.platform} ${process.arch}${r}`);

--- a/create-openclaw-octo/cli/index.ts
+++ b/create-openclaw-octo/cli/index.ts
@@ -14,7 +14,7 @@ import {
 } from "./doctor.js";
 import { runUninstall } from "./uninstall.js";
 import { runRemoveAccount } from "./remove-account.js";
-import { ensureOpenClawCompat, NPM_PACKAGE_NAME, PLUGIN_ID } from "./utils.js";
+import { ensureOpenClawCompat, NPM_PACKAGE_NAME, PLUGIN_ID, renderInstallStatusBanner } from "./utils.js";
 import { getOpenClawVersionStrict, resolvePluginState } from "./openclaw-cli.js";
 import { PLUGIN_VERSION } from "./version.js";
 
@@ -141,7 +141,6 @@ program
   .option("--fix", "Attempt to automatically fix issues", false)
   .option("--json", "Output JSON", false)
   .action(async (opts) => {
-    ensureOpenClawCompat();
     const result = await runDoctorChecks({
       reader: cliConfigReader,
       accountId: opts.accountId,
@@ -150,6 +149,13 @@ program
     if (opts.json) {
       console.log(JSON.stringify(result, null, 2));
     } else {
+      // Render upgrade-status banner first (only when there's actually an
+      // issue to surface — null on the healthy path).
+      const banner = renderInstallStatusBanner();
+      if (banner) {
+        console.error(banner);
+        console.error("");
+      }
       console.log(formatDoctorResult(result));
     }
   });

--- a/create-openclaw-octo/cli/openclaw-cli.test.ts
+++ b/create-openclaw-octo/cli/openclaw-cli.test.ts
@@ -554,6 +554,132 @@ describe("resolvePluginState", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// compareOpenClawVersion — pure function, no mocks needed
+//
+// IMPORTANT: This block (and detectOpenClawState below) MUST stay before the
+// `getConfigFilePathSafe` block. That block uses `vi.doMock("node:child_process",
+// ...)` with a LOCAL mock fn, which permanently re-binds the module mock so the
+// global `mockExecFileSync` reference (set at the top of this file) no longer
+// reaches the openclaw-cli.js module instance after that. Tests below
+// `getConfigFilePathSafe` can't reliably control execFileSync via that ref.
+// ---------------------------------------------------------------------------
+
+describe("compareOpenClawVersion", () => {
+  it("returns 0 for equal versions", async () => {
+    const { compareOpenClawVersion } = await loadModule();
+    expect(compareOpenClawVersion("2026.4.15", "2026.4.15")).toBe(0);
+  });
+
+  it("returns -1 when a < b in patch", async () => {
+    const { compareOpenClawVersion } = await loadModule();
+    expect(compareOpenClawVersion("2026.4.14", "2026.4.15")).toBe(-1);
+  });
+
+  it("returns 1 when a > b in patch", async () => {
+    const { compareOpenClawVersion } = await loadModule();
+    expect(compareOpenClawVersion("2026.4.16", "2026.4.15")).toBe(1);
+  });
+
+  it("returns 1 when a > b in minor (major equal)", async () => {
+    const { compareOpenClawVersion } = await loadModule();
+    expect(compareOpenClawVersion("2026.5.0", "2026.4.99")).toBe(1);
+  });
+
+  it("returns 1 when a > b in major", async () => {
+    const { compareOpenClawVersion } = await loadModule();
+    expect(compareOpenClawVersion("2027.0.0", "2026.99.99")).toBe(1);
+  });
+
+  it("regression: double-digit minor is integer-compared, not lex-compared", async () => {
+    // Lexical compare would say "10" < "9". Integer compare says "10" > "9".
+    const { compareOpenClawVersion } = await loadModule();
+    expect(compareOpenClawVersion("2026.10.0", "2026.9.0")).toBe(1);
+    expect(compareOpenClawVersion("2026.9.0", "2026.10.0")).toBe(-1);
+  });
+
+  it("regression: double-digit patch is integer-compared, not lex-compared", async () => {
+    const { compareOpenClawVersion } = await loadModule();
+    expect(compareOpenClawVersion("2026.5.18", "2026.5.2")).toBe(1);
+    expect(compareOpenClawVersion("2026.5.2", "2026.5.18")).toBe(-1);
+  });
+
+  it("treats missing segments as 0", async () => {
+    const { compareOpenClawVersion } = await loadModule();
+    expect(compareOpenClawVersion("2026.5", "2026.5.0")).toBe(0);
+    expect(compareOpenClawVersion("2026", "2026.0.0")).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectOpenClawState — three tiers: block / warn / ok
+// ---------------------------------------------------------------------------
+
+describe("detectOpenClawState", () => {
+  it("block when openclaw is not on PATH (ENOENT)", async () => {
+    const { detectOpenClawState } = await loadModule();
+    mockExecFileSync.mockImplementation(() => {
+      const err = new Error("spawn openclaw ENOENT") as any;
+      err.code = "ENOENT";
+      throw err;
+    });
+    const state = detectOpenClawState();
+    expect(state.kind).toBe("block");
+    if (state.kind === "block") {
+      expect(state.version).toBeNull();
+      expect(state.reason).toMatch(/not installed|not on PATH/i);
+    }
+  });
+
+  it("block when version < OPENCLAW_PEER_MIN (2026.4.15)", async () => {
+    const { detectOpenClawState } = await loadModule();
+    mockExecFileSync.mockImplementation(() => "OpenClaw 2026.3.10 (abc1234)\n" as any);
+    const state = detectOpenClawState();
+    expect(state.kind).toBe("block");
+    if (state.kind === "block") {
+      expect(state.version).toBe("2026.3.10");
+      expect(state.reason).toContain("2026.3.10");
+      expect(state.reason).toContain("2026.4.15");
+    }
+  });
+
+  it("warn when peer-min <= version < recommended (2026.5.18)", async () => {
+    const { detectOpenClawState } = await loadModule();
+    mockExecFileSync.mockImplementation(() => "OpenClaw 2026.4.20 (abc1234)\n" as any);
+    const state = detectOpenClawState();
+    expect(state.kind).toBe("warn");
+    if (state.kind === "warn") {
+      expect(state.version).toBe("2026.4.20");
+      expect(state.reason).toContain("2026.4.20");
+      expect(state.reason).toContain("2026.5.18");
+    }
+  });
+
+  it("warn at exact peer-min (boundary)", async () => {
+    const { detectOpenClawState } = await loadModule();
+    mockExecFileSync.mockImplementation(() => "OpenClaw 2026.4.15 (abc1234)\n" as any);
+    const state = detectOpenClawState();
+    expect(state.kind).toBe("warn");
+  });
+
+  it("ok at exact recommended (boundary)", async () => {
+    const { detectOpenClawState } = await loadModule();
+    mockExecFileSync.mockImplementation(() => "OpenClaw 2026.5.18 (abc1234)\n" as any);
+    const state = detectOpenClawState();
+    expect(state.kind).toBe("ok");
+    if (state.kind === "ok") {
+      expect(state.version).toBe("2026.5.18");
+    }
+  });
+
+  it("ok when version > recommended", async () => {
+    const { detectOpenClawState } = await loadModule();
+    mockExecFileSync.mockImplementation(() => "OpenClaw 2027.1.0 (abc1234)\n" as any);
+    const state = detectOpenClawState();
+    expect(state.kind).toBe("ok");
+  });
+});
+
 describe("getConfigFilePathSafe (Windows relative path)", () => {
   it("should resolve Windows relative path .\\.\\.openclaw\\openclaw.json to homedir", async () => {
     vi.resetModules();

--- a/create-openclaw-octo/cli/openclaw-cli.test.ts
+++ b/create-openclaw-octo/cli/openclaw-cli.test.ts
@@ -693,6 +693,8 @@ describe("detectInstallState", () => {
     legacyNpmInEntries?: boolean;
     legacyNpmInInstalls?: boolean;
     npmDirResidue?: boolean;
+    dmworkChannel?: boolean;
+    dmworkBinding?: boolean;
   }) {
     return async () => {
       const { existsSync, readFileSync } = await import("node:fs");
@@ -722,6 +724,12 @@ describe("detectInstallState", () => {
           installPath: "~/.openclaw/npm/node_modules/openclaw-channel-octo",
         };
       }
+      if (opts.dmworkChannel) {
+        cfg.channels = { dmwork: { accounts: { "u1": {} } } };
+      }
+      if (opts.dmworkBinding) {
+        cfg.bindings = [{ match: { channel: "dmwork" }, accountId: "u1", agent: "main" }];
+      }
       vi.mocked(readFileSync).mockReturnValue(JSON.stringify(cfg));
       vi.mocked(existsSync).mockImplementation((p: unknown) => {
         const path = String(p);
@@ -741,6 +749,7 @@ describe("detectInstallState", () => {
     expect(state.kind).toBe("octo-clawhub");
     if (state.kind === "octo-clawhub") {
       expect(state.legacyNpmActive).toBe(false);
+      expect(state.legacyDmworkResidue).toBe(false);
       expect(state.npmResidue).toBe(false);
       expect(state.version).toBe("1.0.12");
     }
@@ -779,6 +788,27 @@ describe("detectInstallState", () => {
     if (state.kind === "octo-clawhub") {
       expect(state.legacyNpmActive).toBe(true);
       expect(state.npmResidue).toBe(true);
+    }
+  });
+
+  it("octo-clawhub with dmwork channel residue — legacyDmworkResidue=true (BLOCK)", async () => {
+    await setupOctoClawHub({ dmworkChannel: true })();
+    const { detectInstallState } = await loadModule();
+    const state = detectInstallState();
+    expect(state.kind).toBe("octo-clawhub");
+    if (state.kind === "octo-clawhub") {
+      expect(state.legacyDmworkResidue).toBe(true);
+      expect(state.legacyNpmActive).toBe(false);
+    }
+  });
+
+  it("octo-clawhub with dmwork binding residue — legacyDmworkResidue=true (BLOCK)", async () => {
+    await setupOctoClawHub({ dmworkBinding: true })();
+    const { detectInstallState } = await loadModule();
+    const state = detectInstallState();
+    expect(state.kind).toBe("octo-clawhub");
+    if (state.kind === "octo-clawhub") {
+      expect(state.legacyDmworkResidue).toBe(true);
     }
   });
 

--- a/create-openclaw-octo/cli/openclaw-cli.test.ts
+++ b/create-openclaw-octo/cli/openclaw-cli.test.ts
@@ -680,6 +680,144 @@ describe("detectOpenClawState", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// detectInstallState — also kept BEFORE the `getConfigFilePathSafe` block for
+// the same `vi.doMock` re-binding reason called out at line 560.
+// ---------------------------------------------------------------------------
+
+describe("detectInstallState", () => {
+  // Helper: ClawHub octo present in cfg + extensions dir, with optional
+  // `legacyNpm` toggle to add cfg.plugins.entries["openclaw-channel-octo"]
+  // (the dual-active signal).
+  function setupOctoClawHub(opts: {
+    legacyNpmInEntries?: boolean;
+    legacyNpmInInstalls?: boolean;
+    npmDirResidue?: boolean;
+  }) {
+    return async () => {
+      const { existsSync, readFileSync } = await import("node:fs");
+      mockExecFileSync.mockImplementation((cmd, args) => {
+        const argsArr = args as string[];
+        if (argsArr[0] === "config" && argsArr[1] === "file") {
+          return "/home/user/.openclaw/openclaw.json";
+        }
+        if (argsArr[0] === "plugins" && argsArr[1] === "inspect") {
+          // simulate old OpenClaw → fallback path inside isHealthyInstall
+          throw new Error("error: unknown command 'inspect'");
+        }
+        return "";
+      });
+      const cfg: any = {
+        plugins: {
+          entries: { octo: { enabled: true } },
+          installs: { octo: { version: "1.0.12", installPath: "~/.openclaw/extensions/octo" } },
+        },
+      };
+      if (opts.legacyNpmInEntries) {
+        cfg.plugins.entries["openclaw-channel-octo"] = { enabled: true };
+      }
+      if (opts.legacyNpmInInstalls) {
+        cfg.plugins.installs["openclaw-channel-octo"] = {
+          version: "1.0.0",
+          installPath: "~/.openclaw/npm/node_modules/openclaw-channel-octo",
+        };
+      }
+      vi.mocked(readFileSync).mockReturnValue(JSON.stringify(cfg));
+      vi.mocked(existsSync).mockImplementation((p: unknown) => {
+        const path = String(p);
+        if (path.endsWith("/extensions/octo")) return true;
+        if (path.endsWith(".openclaw/npm/node_modules/openclaw-channel-octo")) {
+          return Boolean(opts.npmDirResidue);
+        }
+        return false;
+      });
+    };
+  }
+
+  it("octo-clawhub healthy and clean (no residue, no legacy active)", async () => {
+    await setupOctoClawHub({})();
+    const { detectInstallState } = await loadModule();
+    const state = detectInstallState();
+    expect(state.kind).toBe("octo-clawhub");
+    if (state.kind === "octo-clawhub") {
+      expect(state.legacyNpmActive).toBe(false);
+      expect(state.npmResidue).toBe(false);
+      expect(state.version).toBe("1.0.12");
+    }
+  });
+
+  it("octo-clawhub with directory residue only — npmResidue=true, legacyNpmActive=false", async () => {
+    await setupOctoClawHub({ npmDirResidue: true })();
+    const { detectInstallState } = await loadModule();
+    const state = detectInstallState();
+    expect(state.kind).toBe("octo-clawhub");
+    if (state.kind === "octo-clawhub") {
+      expect(state.npmResidue).toBe(true);
+      expect(state.legacyNpmActive).toBe(false);
+    }
+  });
+
+  it("octo-clawhub with legacy npm still registered in cfg.entries — legacyNpmActive=true (BLOCK)", async () => {
+    await setupOctoClawHub({ legacyNpmInEntries: true, legacyNpmInInstalls: true })();
+    const { detectInstallState } = await loadModule();
+    const state = detectInstallState();
+    expect(state.kind).toBe("octo-clawhub");
+    if (state.kind === "octo-clawhub") {
+      expect(state.legacyNpmActive).toBe(true);
+    }
+  });
+
+  it("octo-clawhub: legacyNpmActive takes precedence regardless of dir residue", async () => {
+    await setupOctoClawHub({
+      legacyNpmInEntries: true,
+      legacyNpmInInstalls: true,
+      npmDirResidue: true,
+    })();
+    const { detectInstallState } = await loadModule();
+    const state = detectInstallState();
+    expect(state.kind).toBe("octo-clawhub");
+    if (state.kind === "octo-clawhub") {
+      expect(state.legacyNpmActive).toBe(true);
+      expect(state.npmResidue).toBe(true);
+    }
+  });
+
+  it("octo-npm-legacy when ClawHub octo absent and NPM_PACKAGE_NAME healthy", async () => {
+    const { existsSync, readFileSync } = await import("node:fs");
+    mockExecFileSync.mockImplementation((cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === "config" && argsArr[1] === "file") {
+        return "/home/user/.openclaw/openclaw.json";
+      }
+      if (argsArr[0] === "plugins" && argsArr[1] === "inspect") {
+        throw new Error("error: unknown command 'inspect'");
+      }
+      return "";
+    });
+    // No `octo` entry; only legacy npm is present
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
+      plugins: {
+        entries: { "openclaw-channel-octo": { enabled: true } },
+        installs: {
+          "openclaw-channel-octo": {
+            version: "1.0.0",
+            installPath: "~/.openclaw/extensions/openclaw-channel-octo",
+          },
+        },
+      },
+    }));
+    vi.mocked(existsSync).mockImplementation((p: unknown) =>
+      String(p).endsWith("/extensions/openclaw-channel-octo"),
+    );
+    const { detectInstallState } = await loadModule();
+    const state = detectInstallState();
+    expect(state.kind).toBe("octo-npm-legacy");
+    if (state.kind === "octo-npm-legacy") {
+      expect(state.version).toBe("1.0.0");
+    }
+  });
+});
+
 describe("getConfigFilePathSafe (Windows relative path)", () => {
   it("should resolve Windows relative path .\\.\\.openclaw\\openclaw.json to homedir", async () => {
     vi.resetModules();

--- a/create-openclaw-octo/cli/openclaw-cli.test.ts
+++ b/create-openclaw-octo/cli/openclaw-cli.test.ts
@@ -695,6 +695,8 @@ describe("detectInstallState", () => {
     npmDirResidue?: boolean;
     dmworkChannel?: boolean;
     dmworkBinding?: boolean;
+    veryLegacyDmworkInEntries?: boolean;
+    veryLegacyDmworkInInstalls?: boolean;
   }) {
     return async () => {
       const { existsSync, readFileSync } = await import("node:fs");
@@ -729,6 +731,15 @@ describe("detectInstallState", () => {
       }
       if (opts.dmworkBinding) {
         cfg.bindings = [{ match: { channel: "dmwork" }, accountId: "u1", agent: "main" }];
+      }
+      if (opts.veryLegacyDmworkInEntries) {
+        cfg.plugins.entries["dmwork"] = { enabled: true };
+      }
+      if (opts.veryLegacyDmworkInInstalls) {
+        cfg.plugins.installs["dmwork"] = {
+          version: "0.5.21",
+          installPath: "~/.openclaw/extensions/dmwork",
+        };
       }
       vi.mocked(readFileSync).mockReturnValue(JSON.stringify(cfg));
       vi.mocked(existsSync).mockImplementation((p: unknown) => {
@@ -809,6 +820,26 @@ describe("detectInstallState", () => {
     expect(state.kind).toBe("octo-clawhub");
     if (state.kind === "octo-clawhub") {
       expect(state.legacyDmworkResidue).toBe(true);
+    }
+  });
+
+  it("octo-clawhub with very-legacy `dmwork` plugin entries — legacyDmworkResidue=true (BLOCK)", async () => {
+    // Regression for the `hasVeryLegacyPluginArtifacts` precedence —
+    // detectScenario() in install.ts treats `dmwork` (very-legacy id) as
+    // priority 1 (legacy-to-octo migration) above `openclaw-channel-dmwork`
+    // (intermediate id) at priority 2 (rebrand). The pre-flight must
+    // surface BOTH ids so a stale `dmwork` entry without channels.dmwork
+    // or bindings still blocks bind/quickstart/remove-account.
+    await setupOctoClawHub({
+      veryLegacyDmworkInEntries: true,
+      veryLegacyDmworkInInstalls: true,
+    })();
+    const { detectInstallState } = await loadModule();
+    const state = detectInstallState();
+    expect(state.kind).toBe("octo-clawhub");
+    if (state.kind === "octo-clawhub") {
+      expect(state.legacyDmworkResidue).toBe(true);
+      expect(state.legacyNpmActive).toBe(false);
     }
   });
 

--- a/create-openclaw-octo/cli/openclaw-cli.ts
+++ b/create-openclaw-octo/cli/openclaw-cli.ts
@@ -1017,7 +1017,12 @@ export function isHealthyInstall(pluginId: string = PLUGIN_ID): boolean {
  * state we surface as a warn but don't block on).
  */
 export type InstallState =
-  | { kind: "octo-clawhub"; version: string | null; npmResidue: boolean }
+  | {
+      kind: "octo-clawhub";
+      version: string | null;
+      npmResidue: boolean;
+      legacyNpmActive: boolean;
+    }
   | { kind: "octo-npm-legacy"; version: string | null }
   | { kind: "dmwork-legacy"; version: string | null }
   | { kind: "broken"; details: string }
@@ -1029,6 +1034,27 @@ function hasLegacyNpmResidue(): boolean {
   return existsSync(resolve(homedir(), LEGACY_NPM_RESIDUE_PATH));
 }
 
+/**
+ * Whether the legacy npm-installed `openclaw-channel-octo` is still registered
+ * in OpenClaw's plugin entries (i.e., OpenClaw still attempts to load it on
+ * startup). Both legacy npm v1.x and current ClawHub octo register channel
+ * id "octo", so a healthy ClawHub install plus a still-registered legacy npm
+ * install double-register the channel — install.ts treats this as a hard
+ * cleanup error after install. detectInstallState surfaces it before
+ * bind/quickstart/remove-account write any config so the user is prompted
+ * to migrate first instead of silently writing into a duplicated channel.
+ *
+ * Signal source: cfg.plugins.entries[NPM_PACKAGE_NAME]. Note that
+ * cfg.plugins.installs has been observed null on current OpenClaw schemas
+ * (install metadata moved into `plugins inspect <id> --json`), so installs
+ * cannot be used as a registration signal. Tracked in #82 for the broader
+ * detection-layer cleanup.
+ */
+function isLegacyNpmStillRegistered(): boolean {
+  const cfg = readConfigFromFile();
+  return Boolean(cfg?.plugins?.entries?.[NPM_PACKAGE_NAME]);
+}
+
 export function detectInstallState(): InstallState {
   // Priority order: ClawHub (target) → npm-legacy → dmwork-legacy → broken → none
   if (isHealthyInstall(PLUGIN_ID)) {
@@ -1037,6 +1063,7 @@ export function detectInstallState(): InstallState {
       kind: "octo-clawhub",
       version: state.version,
       npmResidue: hasLegacyNpmResidue(),
+      legacyNpmActive: isLegacyNpmStillRegistered(),
     };
   }
   if (isHealthyInstall(NPM_PACKAGE_NAME)) {

--- a/create-openclaw-octo/cli/openclaw-cli.ts
+++ b/create-openclaw-octo/cli/openclaw-cli.ts
@@ -1065,13 +1065,16 @@ export function detectInstallState(): InstallState {
       version: state.version,
       npmResidue: hasLegacyNpmResidue(),
       legacyNpmActive: isLegacyNpmStillRegistered(cfg),
-      // Mirror install.ts detectScenario priority: dmwork artifacts (plugin
-      // dir/entries/installs/allow + channels.dmwork + bindings(channel=dmwork))
-      // require a `rebrand` migration even when octo is otherwise healthy.
-      // Block the pre-flight in this state so the user is prompted to run
-      // install before bind/quickstart/remove-account write fresh
-      // channels.octo data over an unfinished dmwork→octo migration.
-      legacyDmworkResidue: hasLegacyPluginArtifacts(cfg),
+      // Mirror install.ts detectScenario priority: very-legacy `dmwork`
+      // artefacts (highest priority → `legacy-to-octo` migration) AND
+      // intermediate `openclaw-channel-dmwork` rebrand artefacts (next
+      // priority → `rebrand` migration) both require install to finish
+      // the migration even when octo is otherwise healthy. Block the
+      // pre-flight in either state so the user is prompted to run install
+      // before bind/quickstart/remove-account write fresh channels.octo
+      // data over an unfinished migration.
+      legacyDmworkResidue:
+        hasVeryLegacyPluginArtifacts(cfg) || hasLegacyPluginArtifacts(cfg),
     };
   }
   if (isHealthyInstall(NPM_PACKAGE_NAME)) {

--- a/create-openclaw-octo/cli/openclaw-cli.ts
+++ b/create-openclaw-octo/cli/openclaw-cli.ts
@@ -1001,6 +1001,178 @@ export function isHealthyInstall(pluginId: string = PLUGIN_ID): boolean {
   return inspectOk || (hasDir && hasEntries && hasInstalls);
 }
 
+// ---------------------------------------------------------------------------
+// Plan A: install state + OpenClaw state detection (PR3)
+// ---------------------------------------------------------------------------
+
+/**
+ * Aggregated install state across the three known plugin ids:
+ *   - PLUGIN_ID            ("octo")              — current ClawHub install
+ *   - NPM_PACKAGE_NAME     ("openclaw-channel-octo") — legacy npm 1.0.0 install
+ *   - VERY_LEGACY_PLUGIN_ID ("dmwork")           — legacy dmwork 0.6.x install
+ *
+ * `octo-clawhub` additionally carries `npmResidue` indicating whether the
+ * deprecated `~/.openclaw/npm/node_modules/openclaw-channel-octo` directory
+ * is still present alongside a healthy ClawHub install (a partial-cleanup
+ * state we surface as a warn but don't block on).
+ */
+export type InstallState =
+  | { kind: "octo-clawhub"; version: string | null; npmResidue: boolean }
+  | { kind: "octo-npm-legacy"; version: string | null }
+  | { kind: "dmwork-legacy"; version: string | null }
+  | { kind: "broken"; details: string }
+  | { kind: "none" };
+
+const LEGACY_NPM_RESIDUE_PATH = ".openclaw/npm/node_modules/openclaw-channel-octo";
+
+function hasLegacyNpmResidue(): boolean {
+  return existsSync(resolve(homedir(), LEGACY_NPM_RESIDUE_PATH));
+}
+
+export function detectInstallState(): InstallState {
+  // Priority order: ClawHub (target) → npm-legacy → dmwork-legacy → broken → none
+  if (isHealthyInstall(PLUGIN_ID)) {
+    const state = resolvePluginState(PLUGIN_ID);
+    return {
+      kind: "octo-clawhub",
+      version: state.version,
+      npmResidue: hasLegacyNpmResidue(),
+    };
+  }
+  if (isHealthyInstall(NPM_PACKAGE_NAME)) {
+    return {
+      kind: "octo-npm-legacy",
+      version: resolvePluginState(NPM_PACKAGE_NAME).version,
+    };
+  }
+  // Belt-and-suspenders for the npm 1.0.0 case: `isHealthyInstall` returns
+  // true only when `plugins inspect` works OR the install lives under
+  // `extensions/<id>/`. But v1 npm plugins live under
+  // `~/.openclaw/npm/node_modules/openclaw-channel-octo`, and on very old
+  // OpenClaw runtimes that don't support `plugins inspect`, the first check
+  // misses and this branch would mis-classify the install as "broken".
+  // If the config has matching entries/installs AND the npm path exists on
+  // disk, treat it as a legit legacy npm install.
+  {
+    const cfg = readConfigFromFile();
+    const hasEntries = Boolean(cfg?.plugins?.entries?.[NPM_PACKAGE_NAME]);
+    const hasInstalls = Boolean(cfg?.plugins?.installs?.[NPM_PACKAGE_NAME]);
+    if (hasEntries && hasInstalls && hasLegacyNpmResidue()) {
+      return {
+        kind: "octo-npm-legacy",
+        version: cfg?.plugins?.installs?.[NPM_PACKAGE_NAME]?.version ?? null,
+      };
+    }
+  }
+  // Dmwork-era: check BOTH the intermediate id (LEGACY_PLUGIN_ID =
+  // "openclaw-channel-dmwork") AND the very-legacy id (VERY_LEGACY_PLUGIN_ID
+  // = "dmwork"). Without the LEGACY_PLUGIN_ID check, the intermediate
+  // dmwork build would fall through to the "broken" classifier because its
+  // config entry IS recognised as a leftover but no isHealthyInstall passes.
+  if (isHealthyInstall(LEGACY_PLUGIN_ID)) {
+    return {
+      kind: "dmwork-legacy",
+      version: resolvePluginState(LEGACY_PLUGIN_ID).version,
+    };
+  }
+  if (isHealthyInstall(VERY_LEGACY_PLUGIN_ID)) {
+    return {
+      kind: "dmwork-legacy",
+      version: resolvePluginState(VERY_LEGACY_PLUGIN_ID).version,
+    };
+  }
+
+  // None of the three plugin ids are healthy. Surface "broken" only when
+  // there are leftover config entries pointing to one of them — otherwise
+  // it's a clean "not installed" state.
+  const cfg = readConfigFromFile();
+  const entries = cfg?.plugins?.entries ?? {};
+  const installs = cfg?.plugins?.installs ?? {};
+  const knownIds = [PLUGIN_ID, NPM_PACKAGE_NAME, LEGACY_PLUGIN_ID, VERY_LEGACY_PLUGIN_ID];
+  const leftovers = knownIds.filter((id) => entries[id] || installs[id]);
+  if (leftovers.length > 0) {
+    return {
+      kind: "broken",
+      details: `config references ${leftovers.join(", ")} but install is unhealthy`,
+    };
+  }
+  return { kind: "none" };
+}
+
+/**
+ * OpenClaw runtime version state.
+ *
+ *   block — `openclaw` not on PATH OR version < OPENCLAW_PEER_MIN
+ *   warn  — version is below recommended (still works but missing fixes)
+ *   ok    — version meets the recommended floor
+ */
+export type OpenClawState =
+  | { kind: "ok"; version: string }
+  | { kind: "warn"; version: string; reason: string }
+  | { kind: "block"; version: string | null; reason: string };
+
+/**
+ * Lower bound from package.json peerDependency. Below this the plugin
+ * literally cannot register — block.
+ */
+export const OPENCLAW_PEER_MIN = "2026.4.15";
+
+/**
+ * Recommended floor — version we test against, includes runtime fixes for
+ * issue #56 race conditions etc. Below this we warn but allow.
+ */
+export const OPENCLAW_RECOMMENDED = "2026.5.18";
+
+/**
+ * Compare two YYYY.M.PATCH-style versions per integer-segment ordering.
+ *
+ * NOT semver-compatible by design: OpenClaw's version scheme is date-based
+ * (`2026.4.15` is year.month.patch, not major.minor.patch in the SemVer
+ * sense), and a SemVer parser would mis-order things like `2026.10.0` vs
+ * `2026.9.0` (where `10 > 9` numerically but SemVer compares chunks
+ * differently with prereleases). Plain integer-by-segment is correct here.
+ *
+ * Returns -1 / 0 / 1.
+ */
+export function compareOpenClawVersion(a: string, b: string): -1 | 0 | 1 {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const va = pa[i] ?? 0;
+    const vb = pb[i] ?? 0;
+    if (va < vb) return -1;
+    if (va > vb) return 1;
+  }
+  return 0;
+}
+
+export function detectOpenClawState(): OpenClawState {
+  const v = getOpenClawVersion();
+  if (!v) {
+    return {
+      kind: "block",
+      version: null,
+      reason: "OpenClaw is not installed or not on PATH",
+    };
+  }
+  if (compareOpenClawVersion(v, OPENCLAW_PEER_MIN) < 0) {
+    return {
+      kind: "block",
+      version: v,
+      reason: `OpenClaw ${v} is too old (need >= ${OPENCLAW_PEER_MIN})`,
+    };
+  }
+  if (compareOpenClawVersion(v, OPENCLAW_RECOMMENDED) < 0) {
+    return {
+      kind: "warn",
+      version: v,
+      reason: `OpenClaw ${v} is older than recommended ${OPENCLAW_RECOMMENDED}`,
+    };
+  }
+  return { kind: "ok", version: v };
+}
+
 /**
  * Ensure `plugins.allow` exists and contains `pluginId`.
  *

--- a/create-openclaw-octo/cli/openclaw-cli.ts
+++ b/create-openclaw-octo/cli/openclaw-cli.ts
@@ -1022,6 +1022,7 @@ export type InstallState =
       version: string | null;
       npmResidue: boolean;
       legacyNpmActive: boolean;
+      legacyDmworkResidue: boolean;
     }
   | { kind: "octo-npm-legacy"; version: string | null }
   | { kind: "dmwork-legacy"; version: string | null }
@@ -1050,8 +1051,7 @@ function hasLegacyNpmResidue(): boolean {
  * cannot be used as a registration signal. Tracked in #82 for the broader
  * detection-layer cleanup.
  */
-function isLegacyNpmStillRegistered(): boolean {
-  const cfg = readConfigFromFile();
+function isLegacyNpmStillRegistered(cfg: Record<string, any> | null): boolean {
   return Boolean(cfg?.plugins?.entries?.[NPM_PACKAGE_NAME]);
 }
 
@@ -1059,11 +1059,19 @@ export function detectInstallState(): InstallState {
   // Priority order: ClawHub (target) → npm-legacy → dmwork-legacy → broken → none
   if (isHealthyInstall(PLUGIN_ID)) {
     const state = resolvePluginState(PLUGIN_ID);
+    const cfg = readConfigFromFile();
     return {
       kind: "octo-clawhub",
       version: state.version,
       npmResidue: hasLegacyNpmResidue(),
-      legacyNpmActive: isLegacyNpmStillRegistered(),
+      legacyNpmActive: isLegacyNpmStillRegistered(cfg),
+      // Mirror install.ts detectScenario priority: dmwork artifacts (plugin
+      // dir/entries/installs/allow + channels.dmwork + bindings(channel=dmwork))
+      // require a `rebrand` migration even when octo is otherwise healthy.
+      // Block the pre-flight in this state so the user is prompted to run
+      // install before bind/quickstart/remove-account write fresh
+      // channels.octo data over an unfinished dmwork→octo migration.
+      legacyDmworkResidue: hasLegacyPluginArtifacts(cfg),
     };
   }
   if (isHealthyInstall(NPM_PACKAGE_NAME)) {

--- a/create-openclaw-octo/cli/quickstart.test.ts
+++ b/create-openclaw-octo/cli/quickstart.test.ts
@@ -2,19 +2,21 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // ── runQuickstart error output tests ─────────────────────────────
 
-// Mock dependencies before importing runQuickstart
+// Mock dependencies before importing runQuickstart.
+// Note: `isHealthyInstall` is unused by quickstart since the PR3 wire-in
+// (pre-flight now goes through `enforceHealthyClawHubInstall`), but
+// keeping the mock for the other openclaw-cli surface that quickstart
+// does use (`readConfigFromFile`, `writeConfigAtomic`, `runOpenclaw`).
 vi.mock("./openclaw-cli.js", () => ({
-  isHealthyInstall: vi.fn(() => true),
   readConfigFromFile: vi.fn(() => ({})),
   writeConfigAtomic: vi.fn(),
   runOpenclaw: vi.fn(),
 }));
 
 vi.mock("./utils.js", () => ({
-  PLUGIN_ID: "openclaw-channel-octo",
   CHANNEL_ID: "octo",
   RECOMMENDED_DM_SCOPE: "octo",
-  ensureOpenClawCompat: vi.fn(),
+  enforceHealthyClawHubInstall: vi.fn(),
   ensureChannelConfigObject: (cfg: any, channelId = "octo") => {
     cfg.channels ??= {};
     cfg.channels[channelId] ??= {};
@@ -39,16 +41,14 @@ async function loadAndRun(opts: { apiKey: string; apiUrl: string }) {
   vi.resetModules();
 
   vi.doMock("./openclaw-cli.js", () => ({
-    isHealthyInstall: vi.fn(() => true),
     readConfigFromFile: vi.fn(() => ({})),
     writeConfigAtomic: vi.fn(),
     runOpenclaw: vi.fn(() => mockRunOpenclaw()),
   }));
   vi.doMock("./utils.js", () => ({
-    PLUGIN_ID: "openclaw-channel-octo",
     CHANNEL_ID: "octo",
     RECOMMENDED_DM_SCOPE: "octo",
-    ensureOpenClawCompat: vi.fn(),
+    enforceHealthyClawHubInstall: vi.fn(),
     ensureChannelConfigObject: (cfg: any, channelId = "octo") => {
       cfg.channels ??= {};
       cfg.channels[channelId] ??= {};

--- a/create-openclaw-octo/cli/quickstart.ts
+++ b/create-openclaw-octo/cli/quickstart.ts
@@ -10,7 +10,6 @@
  */
 
 import {
-  isHealthyInstall,
   readConfigFromFile,
   writeConfigAtomic,
   runOpenclaw,
@@ -19,7 +18,7 @@ import {
   CHANNEL_ID,
   RECOMMENDED_DM_SCOPE,
   ensureChannelConfigObject,
-  ensureOpenClawCompat,
+  enforceHealthyClawHubInstall,
 } from "./utils.js";
 
 export interface QuickstartOptions {
@@ -42,14 +41,8 @@ interface CreatedBot {
 }
 
 export async function runQuickstart(opts: QuickstartOptions): Promise<void> {
-  ensureOpenClawCompat();
-
-  // 1. Pre-flight: plugin must be healthy
-  if (!isHealthyInstall()) {
-    console.error("Octo plugin is not installed or in an unhealthy state.");
-    console.error("Please run first: npx -y create-openclaw-octo install");
-    process.exit(1);
-  }
+  // 1. Pre-flight: enforce healthy ClawHub octo + recent OpenClaw (exits on legacy/missing/broken)
+  enforceHealthyClawHubInstall();
 
   // 2. Get all agents
   console.log("Fetching agent list...");

--- a/create-openclaw-octo/cli/remove-account.ts
+++ b/create-openclaw-octo/cli/remove-account.ts
@@ -17,7 +17,7 @@ import {
   PLUGIN_ID,
   channelConfigPath,
   confirm,
-  ensureOpenClawCompat,
+  enforceHealthyClawHubInstall,
   validateAccountId,
 } from "./utils.js";
 
@@ -29,7 +29,7 @@ export interface RemoveAccountOptions {
 export async function runRemoveAccount(
   opts: RemoveAccountOptions,
 ): Promise<void> {
-  ensureOpenClawCompat();
+  enforceHealthyClawHubInstall();
 
   if (!validateAccountId(opts.accountId)) {
     console.error(

--- a/create-openclaw-octo/cli/utils.ts
+++ b/create-openclaw-octo/cli/utils.ts
@@ -7,7 +7,7 @@
  */
 
 import { createInterface } from "node:readline";
-import { getOpenClawVersion, getOpenClawVersionStrict } from "./openclaw-cli.js";
+import { getOpenClawVersion, getOpenClawVersionStrict, detectInstallState, detectOpenClawState } from "./openclaw-cli.js";
 import {
   PLUGIN_ID, CHANNEL_ID,
   NPM_PACKAGE_NAME, CLAWHUB_INSTALL_SPEC,
@@ -164,4 +164,179 @@ export async function prompt(question: string): Promise<string> {
       resolve(answer.trim());
     });
   });
+}
+
+// ---------------------------------------------------------------------------
+// Upgrade notice (boxed)
+// ---------------------------------------------------------------------------
+
+/**
+ * Render a left-anchored "open-right" notice box for upgrade/error prompts.
+ * Intentionally minimal: no feature lists, no marketing — just (1) status,
+ * (2) one-line context, (3) the command, (4) optional follow-up.
+ *
+ * Always written to stderr. The caller decides whether to exit afterwards.
+ */
+export interface UpgradeNoticeOpts {
+  /** "block" prints ✗; "warn" prints ⚠. */
+  status: "block" | "warn";
+  /** Short one-line headline, e.g. "Outdated octo plugin detected: ... 1.0.0". */
+  title: string;
+  /** Optional one-line context above the command, e.g. "This version is no longer supported. Please upgrade:". */
+  body?: string;
+  /** The shell command the user should run to fix the situation. */
+  command: string;
+  /** Optional one-line message after the command, e.g. "Re-run your command after the upgrade completes.". */
+  followup?: string;
+}
+
+export function printUpgradeNotice(opts: UpgradeNoticeOpts): void {
+  const symbol = opts.status === "block" ? "✗" : "⚠";
+  const horizontal = "─".repeat(62);
+  const out = (s: string) => console.error(s);
+
+  out("");
+  out(`┌${horizontal}`);
+  out(`│ ${symbol} ${opts.title}`);
+  if (opts.body) {
+    out(`│`);
+    out(`│ ${opts.body}`);
+  }
+  out(`│`);
+  out(`│   ${opts.command}`);
+  if (opts.followup) {
+    out(`│`);
+    out(`│ ${opts.followup}`);
+  }
+  out(`└${horizontal}`);
+  out("");
+}
+
+// ---------------------------------------------------------------------------
+// Plan A: pre-flight enforce (shared by bind / quickstart / remove-account)
+// ---------------------------------------------------------------------------
+
+/**
+ * Block the caller unless we have a healthy ClawHub octo install AND a
+ * recent-enough OpenClaw runtime. Prints the appropriate upgrade notice
+ * to stderr and exits with code 1 otherwise.
+ *
+ * Returns normally when:
+ *   - ClawHub octo is healthy (may print a one-liner ⚠ if OpenClaw is
+ *     below recommended, or if a stale npm residue is detected — neither
+ *     blocks).
+ */
+export function enforceHealthyClawHubInstall(): void {
+  const openclaw = detectOpenClawState();
+
+  // OpenClaw too old or missing → hard block (plugin can't load at all)
+  if (openclaw.kind === "block") {
+    printUpgradeNotice({
+      status: "block",
+      title: openclaw.reason,
+      body: "Upgrade OpenClaw first:",
+      command: "npm i -g openclaw@latest",
+      followup: "Then re-run your command.",
+    });
+    process.exit(1);
+  }
+
+  const plugin = detectInstallState();
+  switch (plugin.kind) {
+    case "octo-clawhub":
+      if (openclaw.kind === "warn") {
+        console.warn(`⚠  ${openclaw.reason}.`);
+        console.warn("   Consider upgrading: npm i -g openclaw@latest\n");
+      }
+      if (plugin.npmResidue) {
+        console.warn("⚠  Legacy npm plugin residue detected at ~/.openclaw/npm/node_modules/openclaw-channel-octo.");
+        console.warn("   Clean up by re-running install: npx -y create-openclaw-octo install\n");
+      }
+      return;
+
+    case "octo-npm-legacy":
+      printUpgradeNotice({
+        status: "block",
+        title: `Outdated octo plugin detected: openclaw-channel-octo ${plugin.version ?? "1.0.x"}`,
+        body: "This version is no longer supported. Please upgrade:",
+        command: "npx -y create-openclaw-octo install",
+        followup: "Re-run your command after the upgrade completes.",
+      });
+      process.exit(1);
+
+    case "dmwork-legacy":
+      printUpgradeNotice({
+        status: "block",
+        title: `Outdated dmwork plugin detected${plugin.version ? ` (${plugin.version})` : ""}`,
+        body: "This version is no longer supported. Please upgrade:",
+        command: "npx -y create-openclaw-octo install",
+        followup: "Re-run your command after the upgrade completes.",
+      });
+      process.exit(1);
+
+    case "broken":
+      printUpgradeNotice({
+        status: "block",
+        title: "Octo plugin install is in a broken state",
+        body: plugin.details,
+        command: "npx -y create-openclaw-octo install --force",
+      });
+      process.exit(1);
+
+    case "none":
+      printUpgradeNotice({
+        status: "block",
+        title: "Octo plugin is not installed",
+        body: "Install it first:",
+        command: "npx -y create-openclaw-octo install",
+      });
+      process.exit(1);
+  }
+}
+
+/**
+ * Returns a compact one- or two-line-per-issue banner summarising plugin
+ * and OpenClaw state. Returns `null` when everything is healthy (no noise
+ * on the happy path). Used by `doctor` to show "you should upgrade" hints
+ * without blocking the diagnostic checks.
+ */
+export function renderInstallStatusBanner(): string | null {
+  const plugin = detectInstallState();
+  const openclaw = detectOpenClawState();
+  const lines: string[] = [];
+
+  if (openclaw.kind === "block") {
+    lines.push(`✗ ${openclaw.reason}`);
+    lines.push("  Upgrade: npm i -g openclaw@latest");
+  } else if (openclaw.kind === "warn") {
+    lines.push(`⚠ ${openclaw.reason}`);
+    lines.push("  Recommended: npm i -g openclaw@latest");
+  }
+
+  switch (plugin.kind) {
+    case "octo-clawhub":
+      if (plugin.npmResidue) {
+        lines.push("⚠ Legacy npm plugin residue at ~/.openclaw/npm/node_modules/openclaw-channel-octo");
+        lines.push("  Clean up: npx -y create-openclaw-octo install");
+      }
+      break;
+    case "octo-npm-legacy":
+      lines.push(`⚠ Outdated octo plugin: openclaw-channel-octo ${plugin.version ?? "1.0.x"}`);
+      lines.push("  Upgrade: npx -y create-openclaw-octo install");
+      break;
+    case "dmwork-legacy":
+      lines.push(`⚠ Outdated dmwork plugin${plugin.version ? ` (${plugin.version})` : ""}`);
+      lines.push("  Upgrade: npx -y create-openclaw-octo install");
+      break;
+    case "broken":
+      lines.push(`✗ Octo plugin install is broken: ${plugin.details}`);
+      lines.push("  Fix: npx -y create-openclaw-octo install --force");
+      break;
+    case "none":
+      lines.push("✗ Octo plugin is not installed");
+      lines.push("  Install: npx -y create-openclaw-octo install");
+      break;
+  }
+
+  return lines.length > 0 ? lines.join("\n") : null;
 }

--- a/create-openclaw-octo/cli/utils.ts
+++ b/create-openclaw-octo/cli/utils.ts
@@ -263,6 +263,20 @@ export function enforceHealthyClawHubInstall(): void {
         });
         process.exit(1);
       }
+      // dmwork → octo migration not finished. Mirrors install.ts detectScenario
+      // priority: dmwork plugin/channel/binding residue triggers `rebrand`
+      // even when octo is otherwise healthy. Block before bind/quickstart
+      // write fresh channels.octo data over the unfinished migration.
+      if (plugin.legacyDmworkResidue) {
+        printUpgradeNotice({
+          status: "block",
+          title: "Unfinished dmwork → octo migration detected",
+          body: "Legacy dmwork plugin or channel/binding residue is present alongside ClawHub octo. Run install to finish the migration:",
+          command: "npx -y create-openclaw-octo install",
+          followup: "Re-run your command after the migration completes.",
+        });
+        process.exit(1);
+      }
       if (plugin.npmResidue) {
         console.warn("⚠  Legacy npm plugin residue detected at ~/.openclaw/npm/node_modules/openclaw-channel-octo.");
         console.warn("   Clean up by re-running install: npx -y create-openclaw-octo install\n");
@@ -333,6 +347,9 @@ export function renderInstallStatusBanner(): string | null {
       if (plugin.legacyNpmActive) {
         lines.push("✗ Legacy npm openclaw-channel-octo still registered alongside ClawHub octo");
         lines.push("  Migrate: npx -y create-openclaw-octo install --force");
+      } else if (plugin.legacyDmworkResidue) {
+        lines.push("✗ Unfinished dmwork → octo migration (dmwork plugin/channel/binding residue)");
+        lines.push("  Run: npx -y create-openclaw-octo install");
       } else if (plugin.npmResidue) {
         lines.push("⚠ Legacy npm plugin residue at ~/.openclaw/npm/node_modules/openclaw-channel-octo");
         lines.push("  Clean up: npx -y create-openclaw-octo install");

--- a/create-openclaw-octo/cli/utils.ts
+++ b/create-openclaw-octo/cli/utils.ts
@@ -248,6 +248,21 @@ export function enforceHealthyClawHubInstall(): void {
         console.warn(`⚠  ${openclaw.reason}.`);
         console.warn("   Consider upgrading: npm i -g openclaw@latest\n");
       }
+      // Dual-active state: ClawHub octo healthy AND legacy npm
+      // openclaw-channel-octo still registered in cfg.plugins.entries. Both
+      // register channel id "octo", so any write under channels.octo here
+      // would land in a duplicated-channel state. Block and force the user
+      // to migrate first.
+      if (plugin.legacyNpmActive) {
+        printUpgradeNotice({
+          status: "block",
+          title: "Legacy npm openclaw-channel-octo is still registered alongside ClawHub octo",
+          body: "Both register channel \"octo\" — running this command would write into a duplicated-channel state. Migrate first:",
+          command: "npx -y create-openclaw-octo install --force",
+          followup: "Re-run your command after the migration completes.",
+        });
+        process.exit(1);
+      }
       if (plugin.npmResidue) {
         console.warn("⚠  Legacy npm plugin residue detected at ~/.openclaw/npm/node_modules/openclaw-channel-octo.");
         console.warn("   Clean up by re-running install: npx -y create-openclaw-octo install\n");
@@ -315,7 +330,10 @@ export function renderInstallStatusBanner(): string | null {
 
   switch (plugin.kind) {
     case "octo-clawhub":
-      if (plugin.npmResidue) {
+      if (plugin.legacyNpmActive) {
+        lines.push("✗ Legacy npm openclaw-channel-octo still registered alongside ClawHub octo");
+        lines.push("  Migrate: npx -y create-openclaw-octo install --force");
+      } else if (plugin.npmResidue) {
         lines.push("⚠ Legacy npm plugin residue at ~/.openclaw/npm/node_modules/openclaw-channel-octo");
         lines.push("  Clean up: npx -y create-openclaw-octo install");
       }


### PR DESCRIPTION
## Summary

Second of two PRs in the CLI rename + force-upgrade migration (PR1 = #76, merged).

This PR adds the **force-upgrade pre-flight** that detects legacy installs (old npm 1.x of `openclaw-channel-octo`, the very-old `dmwork` plugin id, npm-residue after migration, etc.) and either auto-migrates (in `install`) or surfaces a clear blocking notice (in `bind` / `quickstart` / `remove-account`).

It also folds in the two P2 nits from #76's post-merge review (no code changes, infra/docs only).

## Related Issue

N/A — internal migration tracked in the implementation plan doc.

## Changes

### Force-upgrade pre-flight (the substantive part)

- `cli/openclaw-cli.ts`:
  - `detectInstallState()` — 5-state classifier: `octo-clawhub` / `octo-npm-legacy` / `dmwork-legacy` / `broken` / `none`. Belt-and-suspenders npm fallback (cfg `entries` + `installs` + `hasLegacyNpmResidue()`) so we still detect 1.0.0-style installs on OpenClaw versions that don't support `plugins inspect`.
  - `compareOpenClawVersion()` — integer-tuple compare on dotted version strings (NOT semver — OpenClaw uses calendar-versioned `YYYY.M.D`).
  - `detectOpenClawState()` — 3-tier: `ok` / `warn` / `block`, gated on `OPENCLAW_PEER_MIN = "2026.4.15"` and `OPENCLAW_RECOMMENDED = "2026.5.18"`.
- `cli/utils.ts`:
  - `printUpgradeNotice(status, ...)` — open-right box format; `block` (✗) for hard stops, `warn` (⚠) for advisories.
  - `enforceHealthyClawHubInstall()` — shared pre-flight used by `bind` / `quickstart` / `remove-account`. Returns cleanly only when state is `octo-clawhub` and OpenClaw is `ok` / `warn`; otherwise prints upgrade notice and `process.exit(1)`.
  - `renderInstallStatusBanner()` — non-blocking variant for `doctor` (returns string, doesn't exit).
- `cli/bind.ts`, `cli/quickstart.ts`, `cli/remove-account.ts`:
  - Replace the old `isHealthyInstall(PLUGIN_ID) + ensureOpenClawCompat()` pair with a single `enforceHealthyClawHubInstall()` call. Single source of truth.
- `cli/index.ts`:
  - Remove the redundant `npm package: ...` line from `info` output (it was a constant — adds noise, no signal).
- Tests: 14 new cases for `compareOpenClawVersion` (8) + `detectOpenClawState` (6). Both placed BEFORE the `getConfigFilePathSafe` test block to avoid `vi.doMock` mock pollution. **94/94 passing locally.**

### Post-merge nit cleanup from #76

- `.github/workflows/ci.yml`: drop stale paths-filter patterns (`package.json`, `pnpm-lock.yaml`, `*.config.*`). No root `package.json` exists; repo uses npm not pnpm. Harmless but misleading.
- `create-openclaw-octo/README.md`: add explicit guidance for users who installed the old name globally (`npm i -g openclaw-channel-octo`) — the rename does not auto-clean their on-disk shim binary; recommend `npm uninstall -g openclaw-channel-octo` + `npx` workflow.

## Testing

- [x] Unit tests: `npm test` → **94/94 passing** (80 from PR1 + 14 new)
- [x] Type-check: `npx tsc --noEmit` → clean
- [x] Build: `npm run build` → succeeds
- [x] Manual scenario testing (per implementation plan, scenarios A/B/C/D):
  - **A** ClawHub octo healthy → `bind` proceeds normally
  - **B** ClawHub octo + npm residue → warn banner, proceed
  - **C** npm 1.0.0 only (`openclaw-channel-octo`) → block, prompt force-upgrade
  - **D** very-old `dmwork` plugin id → block, prompt force-upgrade

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes (14 new cases)
- [x] Updated documentation (README global-install warning)
- [x] Followed commit message conventions (Conventional Commits)

## Commit list

```
3049931  feat: add Plan A detection helpers + upgrade notice
6252ae4  feat: wire plan A pre-flight into bind/quickstart/remove-account
462b125  test: cover compareOpenClawVersion + detectOpenClawState
5aa84f0  docs: drop redundant 'npm package' line from info output
14f3d83  chore: address PR #76 P2 review nits
```

## Series tracker

- [x] PR 1/2 (#76): rename subdir, shed plugin source, inline cli/constants + cli/version, rename npm package, infra
- [ ] **PR 2/2 (this PR)**: force-upgrade pre-flight + tests + post-merge nit cleanup

After this lands, the next external-facing step is publishing `create-openclaw-octo@1.0.1` to npm `@latest` (separate atomic-release plan; not part of this PR).