### PR TITLE
refactor(create-openclaw-octo): adopt `plugins list --json` as detection source

### DIFF
--- a/create-openclaw-octo/cli/openclaw-cli.test.ts
+++ b/create-openclaw-octo/cli/openclaw-cli.test.ts
@@ -138,6 +138,53 @@ describe("listLoadedPlugins", () => {
     expect(result.plugins[0].id).toBe("octo");
   });
 
+  it("tolerates trailing log noise after JSON object via brace-matching", async () => {
+    // Some OpenClaw runtimes emit warnings AFTER the JSON object (e.g.
+    // gateway shutdown warnings on subsequent commands). A naive
+    // `JSON.parse(out.slice(start))` would fail because the slice includes
+    // the trailing log lines; brace-matching extracts just the balanced
+    // top-level object.
+    const { listLoadedPlugins } = await loadModule();
+    mockExecFileSync.mockReturnValue(
+      JSON.stringify({ plugins: [{ id: "octo", status: "loaded", enabled: true }] }) +
+        "\n[plugins] reload complete\n" +
+        "Warning: deprecated config key X\n",
+    );
+
+    const result = listLoadedPlugins();
+    expect(result.supported).toBe(true);
+    expect(result.plugins).toHaveLength(1);
+    expect(result.plugins[0].id).toBe("octo");
+  });
+
+  it("brace-matching handles strings containing curly braces correctly", async () => {
+    // Defense against a flawed brace-counter: source paths can contain
+    // literal "}" or "{" inside string values. The matcher must respect
+    // string boundaries so it doesn't terminate the object prematurely.
+    const { listLoadedPlugins } = await loadModule();
+    mockExecFileSync.mockReturnValue(JSON.stringify({
+      plugins: [
+        { id: "octo", status: "loaded", enabled: true, source: "/path/with/{braces}/in/it" },
+      ],
+    }));
+
+    const result = listLoadedPlugins();
+    expect(result.supported).toBe(true);
+    expect(result.plugins[0].source).toContain("{braces}");
+  });
+
+  it("identifies `unknown command` as unsupported (old OpenClaw)", async () => {
+    const { listLoadedPlugins } = await loadModule();
+    mockExecFileSync.mockImplementation(() => {
+      const err = new Error("error: unknown command 'list'") as any;
+      err.stderr = "error: unknown command 'list'";
+      throw err;
+    });
+
+    const result = listLoadedPlugins();
+    expect(result.supported).toBe(false);
+  });
+
   it("reports supported=false on old OpenClaw without `plugins list --json`", async () => {
     const { listLoadedPlugins } = await loadModule();
     mockExecFileSync.mockImplementation(() => {
@@ -1048,6 +1095,55 @@ describe("detectInstallState", () => {
     expect(state.kind).toBe("octo-npm-legacy");
     if (state.kind === "octo-npm-legacy") {
       expect(state.version).toBe("1.0.0");
+    }
+  });
+
+  it("dmwork-legacy: both ids registered → classifier picks VERY_LEGACY first (priority 1 in detectScenario)", async () => {
+    // Regression for codex review on PR #83: when both `dmwork`
+    // (VERY_LEGACY_PLUGIN_ID) and `openclaw-channel-dmwork`
+    // (LEGACY_PLUGIN_ID) are registered with no healthy octo present,
+    // detectInstallState must mirror detectScenario()'s priority and
+    // report the very-legacy id's version. Otherwise the pre-flight
+    // surfaces a different version than the migration install.ts will
+    // actually run (legacy-to-octo, not rebrand).
+    const { existsSync, readFileSync } = await import("node:fs");
+    mockExecFileSync.mockImplementation((cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === "config" && argsArr[1] === "file") {
+        return "/home/user/.openclaw/openclaw.json";
+      }
+      if (argsArr[0] === "plugins" && argsArr[1] === "list" && argsArr[2] === "--json") {
+        return JSON.stringify({
+          plugins: [
+            { id: "dmwork", status: "loaded", enabled: true },
+            { id: "openclaw-channel-dmwork", status: "loaded", enabled: true },
+          ],
+        });
+      }
+      if (argsArr[0] === "plugins" && argsArr[1] === "inspect") {
+        throw new Error("error: unknown command 'inspect'");
+      }
+      return "";
+    });
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
+      plugins: {
+        entries: { dmwork: { enabled: true }, "openclaw-channel-dmwork": { enabled: true } },
+        installs: {
+          dmwork: { version: "0.5.21", installPath: "~/.openclaw/extensions/dmwork" },
+          "openclaw-channel-dmwork": { version: "0.6.5", installPath: "~/.openclaw/npm/node_modules/openclaw-channel-dmwork" },
+        },
+      },
+    }));
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    const { detectInstallState } = await loadModule();
+    const state = detectInstallState();
+    expect(state.kind).toBe("dmwork-legacy");
+    if (state.kind === "dmwork-legacy") {
+      // Must pick the VERY_LEGACY (`dmwork`) version, not the LEGACY
+      // (`openclaw-channel-dmwork`) version — matches detectScenario()
+      // priority: `legacy-to-octo` migration runs first.
+      expect(state.version).toBe("0.5.21");
     }
   });
 

--- a/create-openclaw-octo/cli/openclaw-cli.test.ts
+++ b/create-openclaw-octo/cli/openclaw-cli.test.ts
@@ -93,6 +93,95 @@ describe("pluginsInspect", () => {
   });
 });
 
+describe("listLoadedPlugins", () => {
+  it("parses plugins list --json output", async () => {
+    const { listLoadedPlugins } = await loadModule();
+    mockExecFileSync.mockReturnValue(JSON.stringify({
+      plugins: [
+        {
+          id: "octo",
+          status: "loaded",
+          enabled: true,
+          source: "/home/u/.openclaw/extensions/octo/dist/index.js",
+          origin: "global",
+          rootDir: "/home/u/.openclaw/extensions/octo",
+        },
+        {
+          id: "openclaw-channel-octo",
+          status: "loaded",
+          enabled: true,
+          source: "/home/u/.openclaw/npm/node_modules/openclaw-channel-octo/dist/index.js",
+          origin: "npm",
+          rootDir: "/home/u/.openclaw/npm/node_modules/openclaw-channel-octo",
+        },
+      ],
+    }));
+
+    const result = listLoadedPlugins();
+    expect(result.supported).toBe(true);
+    expect(result.plugins).toHaveLength(2);
+    expect(result.plugins[0].id).toBe("octo");
+    expect(result.plugins[1].id).toBe("openclaw-channel-octo");
+    expect(result.plugins[1].rootDir).toContain("npm/node_modules");
+  });
+
+  it("strips preceding log/banner noise before JSON parse", async () => {
+    const { listLoadedPlugins } = await loadModule();
+    mockExecFileSync.mockReturnValue(
+      "🦞 OpenClaw 2026.5.18\n" +
+        "[plugins] loading...\n" +
+        JSON.stringify({ plugins: [{ id: "octo", status: "loaded", enabled: true }] }),
+    );
+
+    const result = listLoadedPlugins();
+    expect(result.supported).toBe(true);
+    expect(result.plugins[0].id).toBe("octo");
+  });
+
+  it("reports supported=false on old OpenClaw without `plugins list --json`", async () => {
+    const { listLoadedPlugins } = await loadModule();
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error("error: unknown command 'list'");
+    });
+
+    const result = listLoadedPlugins();
+    expect(result.supported).toBe(false);
+    expect(result.plugins).toEqual([]);
+  });
+
+  it("reports supported=false when output is not JSON", async () => {
+    const { listLoadedPlugins } = await loadModule();
+    mockExecFileSync.mockReturnValue("usage: openclaw plugins list ...");
+
+    const result = listLoadedPlugins();
+    expect(result.supported).toBe(false);
+  });
+
+  it("reports supported=false when JSON has no plugins array", async () => {
+    const { listLoadedPlugins } = await loadModule();
+    mockExecFileSync.mockReturnValue(JSON.stringify({ unexpected: "shape" }));
+
+    const result = listLoadedPlugins();
+    expect(result.supported).toBe(false);
+  });
+
+  it("filters out entries with missing id", async () => {
+    const { listLoadedPlugins } = await loadModule();
+    mockExecFileSync.mockReturnValue(JSON.stringify({
+      plugins: [
+        { id: "octo", status: "loaded", enabled: true },
+        { /* no id */ status: "loaded" },
+        { id: "", status: "loaded" },
+      ],
+    }));
+
+    const result = listLoadedPlugins();
+    expect(result.supported).toBe(true);
+    expect(result.plugins).toHaveLength(1);
+    expect(result.plugins[0].id).toBe("octo");
+  });
+});
+
 describe("getOpenClawVersion", () => {
   it("should extract version from openclaw --version output", async () => {
     const { getOpenClawVersion } = await loadModule();
@@ -697,13 +786,44 @@ describe("detectInstallState", () => {
     dmworkBinding?: boolean;
     veryLegacyDmworkInEntries?: boolean;
     veryLegacyDmworkInInstalls?: boolean;
+    /**
+     * When true, `openclaw plugins list --json` returns a parseable
+     * payload containing octo + any of the optional `*InList` ids.
+     * When false (default), the command throws — simulating an old
+     * OpenClaw runtime that doesn't support `plugins list --json` and
+     * exercising the cfg.entries fallback path inside isPluginRegistered.
+     */
+    pluginsListSupported?: boolean;
+    legacyNpmInList?: boolean;
+    legacyDmworkInList?: boolean;
+    veryLegacyDmworkInList?: boolean;
   }) {
     return async () => {
       const { existsSync, readFileSync } = await import("node:fs");
+      const mkListEntry = (id: string) => ({
+        id,
+        status: "loaded",
+        enabled: true,
+        source: `/home/user/.openclaw/extensions/${id}/dist/index.js`,
+        origin: "global",
+        rootDir: `/home/user/.openclaw/extensions/${id}`,
+      });
+      const listPayload = (() => {
+        if (!opts.pluginsListSupported) return null;
+        const plugins = [mkListEntry("octo")];
+        if (opts.legacyNpmInList) plugins.push(mkListEntry("openclaw-channel-octo"));
+        if (opts.legacyDmworkInList) plugins.push(mkListEntry("openclaw-channel-dmwork"));
+        if (opts.veryLegacyDmworkInList) plugins.push(mkListEntry("dmwork"));
+        return JSON.stringify({ plugins });
+      })();
       mockExecFileSync.mockImplementation((cmd, args) => {
         const argsArr = args as string[];
         if (argsArr[0] === "config" && argsArr[1] === "file") {
           return "/home/user/.openclaw/openclaw.json";
+        }
+        if (argsArr[0] === "plugins" && argsArr[1] === "list" && argsArr[2] === "--json") {
+          if (listPayload) return listPayload;
+          throw new Error("error: unknown command 'list'");
         }
         if (argsArr[0] === "plugins" && argsArr[1] === "inspect") {
           // simulate old OpenClaw → fallback path inside isHealthyInstall
@@ -833,6 +953,59 @@ describe("detectInstallState", () => {
     await setupOctoClawHub({
       veryLegacyDmworkInEntries: true,
       veryLegacyDmworkInInstalls: true,
+    })();
+    const { detectInstallState } = await loadModule();
+    const state = detectInstallState();
+    expect(state.kind).toBe("octo-clawhub");
+    if (state.kind === "octo-clawhub") {
+      expect(state.legacyDmworkResidue).toBe(true);
+      expect(state.legacyNpmActive).toBe(false);
+    }
+  });
+
+  // ── plugins list --json signal path (#82 detection-layer refactor) ──
+
+  it("octo-clawhub: legacyNpmActive sourced from `plugins list --json` (cfg.entries empty)", async () => {
+    // Modern OpenClaw reports the legacy npm openclaw-channel-octo through
+    // `plugins list --json`. Even when cfg.plugins.entries doesn't yet
+    // reflect it (e.g. stale cfg snapshot vs runtime), the list signal is
+    // the authoritative source.
+    await setupOctoClawHub({
+      pluginsListSupported: true,
+      legacyNpmInList: true,
+    })();
+    const { detectInstallState } = await loadModule();
+    const state = detectInstallState();
+    expect(state.kind).toBe("octo-clawhub");
+    if (state.kind === "octo-clawhub") {
+      expect(state.legacyNpmActive).toBe(true);
+    }
+  });
+
+  it("octo-clawhub: legacyDmworkResidue sourced from `plugins list --json` (LEGACY_PLUGIN_ID)", async () => {
+    // Modern OpenClaw with intermediate dmwork id (`openclaw-channel-dmwork`)
+    // active. The list signal catches it without depending on
+    // `extensions/<id>` directory probing — important because dmwork
+    // legacy is npm-installed (lives under npm/node_modules/<id>).
+    await setupOctoClawHub({
+      pluginsListSupported: true,
+      legacyDmworkInList: true,
+    })();
+    const { detectInstallState } = await loadModule();
+    const state = detectInstallState();
+    expect(state.kind).toBe("octo-clawhub");
+    if (state.kind === "octo-clawhub") {
+      expect(state.legacyDmworkResidue).toBe(true);
+      expect(state.legacyNpmActive).toBe(false);
+    }
+  });
+
+  it("octo-clawhub: legacyDmworkResidue sourced from `plugins list --json` (VERY_LEGACY_PLUGIN_ID)", async () => {
+    // Modern OpenClaw with very-legacy `dmwork` id active. Mirrors
+    // detectScenario()'s priority-1 bucket through the list signal.
+    await setupOctoClawHub({
+      pluginsListSupported: true,
+      veryLegacyDmworkInList: true,
     })();
     const { detectInstallState } = await loadModule();
     const state = detectInstallState();

--- a/create-openclaw-octo/cli/openclaw-cli.test.ts
+++ b/create-openclaw-octo/cli/openclaw-cli.test.ts
@@ -183,6 +183,33 @@ describe("listLoadedPlugins", () => {
 
     const result = listLoadedPlugins();
     expect(result.supported).toBe(false);
+    expect(result.error).toBeNull();
+  });
+
+  it("reports a real error (e.g. EACCES) via `error` field, not unsupported", async () => {
+    // Distinguishes "old OpenClaw doesn't recognise the subcommand"
+    // (supported=false, error=null) from genuine errors (config corruption,
+    // permission, plugin load crash) where the runtime cannot reliably
+    // tell us what's loaded.
+    const { listLoadedPlugins } = await loadModule();
+    mockExecFileSync.mockImplementation(() => {
+      const err = new Error("EACCES: permission denied") as any;
+      err.stderr = "EACCES: permission denied";
+      throw err;
+    });
+
+    const result = listLoadedPlugins();
+    expect(result.supported).toBe(false);
+    expect(result.error).toMatch(/permission denied/i);
+  });
+
+  it("reports parse failure via `error`, not as old-runtime", async () => {
+    const { listLoadedPlugins } = await loadModule();
+    mockExecFileSync.mockReturnValue("usage: openclaw plugins list ...");
+
+    const result = listLoadedPlugins();
+    expect(result.supported).toBe(false);
+    expect(result.error).toMatch(/no JSON|JSON/);
   });
 
   it("reports supported=false on old OpenClaw without `plugins list --json`", async () => {
@@ -202,6 +229,7 @@ describe("listLoadedPlugins", () => {
 
     const result = listLoadedPlugins();
     expect(result.supported).toBe(false);
+    expect(result.error).toMatch(/no JSON/);
   });
 
   it("reports supported=false when JSON has no plugins array", async () => {
@@ -210,6 +238,7 @@ describe("listLoadedPlugins", () => {
 
     const result = listLoadedPlugins();
     expect(result.supported).toBe(false);
+    expect(result.error).toMatch(/missing.*plugins.*array/i);
   });
 
   it("filters out entries with missing id", async () => {
@@ -1070,6 +1099,12 @@ describe("detectInstallState", () => {
       if (argsArr[0] === "config" && argsArr[1] === "file") {
         return "/home/user/.openclaw/openclaw.json";
       }
+      if (argsArr[0] === "plugins" && argsArr[1] === "list" && argsArr[2] === "--json") {
+        // Old OpenClaw — not supported (caller falls back to cfg.entries)
+        const e = new Error("error: unknown command 'list'") as any;
+        e.stderr = "error: unknown command 'list'";
+        throw e;
+      }
       if (argsArr[0] === "plugins" && argsArr[1] === "inspect") {
         throw new Error("error: unknown command 'inspect'");
       }
@@ -1184,6 +1219,49 @@ describe("detectInstallState", () => {
     expect(state.kind).toBe("broken");
     if (state.kind === "broken") {
       expect(state.details).toContain("openclaw-channel-octo");
+    }
+  });
+
+  it("fail-closed when `plugins list --json` errors for a real reason (not unsupported)", async () => {
+    // Regression for codex review: when the OpenClaw runtime is in a
+    // failure state (config corruption, permission denied, plugin load
+    // crash, partial JSON), `plugins list --json` cannot reliably report
+    // what's loaded. Trusting cfg.entries alone risks silently allowing
+    // a dual-active state to slip through bind/quickstart/remove-account.
+    // detectInstallState must surface this as `broken` so the user is
+    // prompted to repair OpenClaw before any further config writes.
+    const { existsSync, readFileSync } = await import("node:fs");
+    mockExecFileSync.mockImplementation((cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === "config" && argsArr[1] === "file") {
+        return "/home/user/.openclaw/openclaw.json";
+      }
+      if (argsArr[0] === "plugins" && argsArr[1] === "list" && argsArr[2] === "--json") {
+        const e = new Error("EACCES: permission denied") as any;
+        e.stderr = "EACCES: permission denied, open '/home/user/.openclaw/openclaw.json'";
+        throw e;
+      }
+      if (argsArr[0] === "plugins" && argsArr[1] === "inspect") {
+        throw new Error("error: unknown command 'inspect'");
+      }
+      return "";
+    });
+    // Even with a healthy-looking cfg, the list-failed signal must
+    // dominate.
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
+      plugins: {
+        entries: { octo: { enabled: true } },
+        installs: { octo: { version: "1.0.12", installPath: "~/.openclaw/extensions/octo" } },
+      },
+    }));
+    vi.mocked(existsSync).mockReturnValue(true);
+
+    const { detectInstallState } = await loadModule();
+    const state = detectInstallState();
+    expect(state.kind).toBe("broken");
+    if (state.kind === "broken") {
+      expect(state.details).toMatch(/plugins list/);
+      expect(state.details).toMatch(/permission denied/i);
     }
   });
 });

--- a/create-openclaw-octo/cli/openclaw-cli.test.ts
+++ b/create-openclaw-octo/cli/openclaw-cli.test.ts
@@ -1050,6 +1050,46 @@ describe("detectInstallState", () => {
       expect(state.version).toBe("1.0.0");
     }
   });
+
+  it("broken when only cfg.entries.openclaw-channel-octo is stale (no dir, list unsupported)", async () => {
+    // Regression for PR #83 review: a stale cfg.plugins.entries entry left
+    // behind by an incomplete uninstall on an old OpenClaw runtime should
+    // classify as `broken` (so doctor --fix cleans it up), NOT
+    // `octo-npm-legacy` (which would prompt the user to migrate a plugin
+    // that isn't actually installed). Modern OpenClaw uses `plugins list
+    // --json` as the authoritative active-set, but the older fallback
+    // path must AND cfg.entries with the npm-layout install dir.
+    const { existsSync, readFileSync } = await import("node:fs");
+    mockExecFileSync.mockImplementation((cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === "config" && argsArr[1] === "file") {
+        return "/home/user/.openclaw/openclaw.json";
+      }
+      if (argsArr[0] === "plugins" && argsArr[1] === "list" && argsArr[2] === "--json") {
+        throw new Error("error: unknown command 'list'");
+      }
+      if (argsArr[0] === "plugins" && argsArr[1] === "inspect") {
+        throw new Error("error: unknown command 'inspect'");
+      }
+      return "";
+    });
+    // cfg has stale entries.openclaw-channel-octo but no extensions dir
+    // and no npm/node_modules dir — the plugin was uninstalled but the
+    // entry never got cleaned up.
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
+      plugins: {
+        entries: { "openclaw-channel-octo": { enabled: true } },
+      },
+    }));
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    const { detectInstallState } = await loadModule();
+    const state = detectInstallState();
+    expect(state.kind).toBe("broken");
+    if (state.kind === "broken") {
+      expect(state.details).toContain("openclaw-channel-octo");
+    }
+  });
 });
 
 describe("getConfigFilePathSafe (Windows relative path)", () => {

--- a/create-openclaw-octo/cli/openclaw-cli.ts
+++ b/create-openclaw-octo/cli/openclaw-cli.ts
@@ -524,14 +524,23 @@ export interface PluginListEntry {
 
 export interface PluginListResult {
   /**
-   * True if OpenClaw produced parseable `plugins list --json` output.
-   * False ONLY when the runtime doesn't recognise the subcommand — i.e.
-   * `unknown command` / `unrecognized command` in stderr/stdout. Other
-   * failure modes (config corruption, permission denied, partial JSON,
-   * etc.) propagate as exceptions; callers should treat these as
-   * truly-unknown registry state and fail closed where it matters.
+   * True when OpenClaw produced parseable `plugins list --json` output.
+   * False when:
+   *   - the runtime doesn't recognise the subcommand (old OpenClaw —
+   *     `error` is null in this case; callers fall back to cfg.entries),
+   *   - OR the command failed for a real reason — config corruption,
+   *     permission denied, plugin load crash, partial/unparseable JSON
+   *     (`error` is non-null in this case; callers should fail-closed
+   *     rather than trust cfg.entries, because the OpenClaw runtime is
+   *     in a state where we cannot reliably know what is loaded).
    */
   supported: boolean;
+  /**
+   * Non-null when `supported` is false because of a real error (not
+   * "subcommand unknown"). Empty string is never used; null means
+   * "either the call succeeded, or the runtime is genuinely old."
+   */
+  error: string | null;
   plugins: PluginListEntry[];
 }
 
@@ -581,15 +590,6 @@ export function listLoadedPlugins(): PluginListResult {
       stdio: ["pipe", "pipe", "pipe"],
     });
   } catch (err) {
-    // Distinguish "old runtime doesn't know this subcommand" from real
-    // errors (config corruption, permission, etc.). Only the former
-    // gets `supported: false`; everything else also reports
-    // `supported: false` for now, but with empty plugins — callers
-    // should rely on cfg.plugins.entries fallback. Future: if we want
-    // to surface a "registry truly unknown" state to callers, add a
-    // third field here. For now, fail-closed by returning an empty
-    // registry; detection paths that OR against cfg.entries will still
-    // catch artefacts.
     const sources = [
       (err as any)?.stderr?.toString?.(),
       (err as any)?.stdout?.toString?.(),
@@ -598,24 +598,41 @@ export function listLoadedPlugins(): PluginListResult {
     ];
     const text = sources.filter(Boolean).join(" ");
     if (/unknown command|unrecognized command/i.test(text)) {
-      return { supported: false, plugins: [] };
+      // Old OpenClaw — caller falls back to cfg.entries.
+      return { supported: false, error: null, plugins: [] };
     }
-    // Real error (not "old runtime") — still report supported: false so
-    // detectInstallState falls back to cfg.entries, which is the safest
-    // course when we genuinely can't tell what's loaded.
-    return { supported: false, plugins: [] };
+    // Real error (permission, config corruption, plugin load crash, etc.).
+    // Surface it via `error` so detectInstallState can fail-closed instead
+    // of trusting cfg.entries, which may also be in an inconsistent state
+    // when the OpenClaw runtime is unhappy.
+    const errorMsg = text.slice(0, 200) || "unknown error";
+    return { supported: false, error: errorMsg, plugins: [] };
   }
   const cleaned = stripStdoutNoise(raw);
   const jsonStr = extractJsonObject(cleaned);
-  if (jsonStr === null) return { supported: false, plugins: [] };
+  if (jsonStr === null) {
+    return {
+      supported: false,
+      error: "no JSON object in `plugins list --json` output",
+      plugins: [],
+    };
+  }
   let data: any;
   try {
     data = JSON.parse(jsonStr);
-  } catch {
-    return { supported: false, plugins: [] };
+  } catch (err) {
+    return {
+      supported: false,
+      error: `JSON.parse failed: ${(err as Error)?.message ?? String(err)}`.slice(0, 200),
+      plugins: [],
+    };
   }
   if (!Array.isArray(data?.plugins)) {
-    return { supported: false, plugins: [] };
+    return {
+      supported: false,
+      error: "JSON output missing `plugins` array",
+      plugins: [],
+    };
   }
   const plugins: PluginListEntry[] = data.plugins
     .map((p: any) => ({
@@ -627,7 +644,7 @@ export function listLoadedPlugins(): PluginListResult {
       rootDir: typeof p?.rootDir === "string" ? p.rootDir : null,
     }))
     .filter((p: PluginListEntry) => p.id.length > 0);
-  return { supported: true, plugins };
+  return { supported: true, error: null, plugins };
 }
 
 // ---------------------------------------------------------------------------
@@ -1229,6 +1246,20 @@ function isPluginRegistered(
 export function detectInstallState(): InstallState {
   const list = listLoadedPlugins();
   const cfg = readConfigFromFile();
+
+  // Fail-closed when `plugins list --json` failed for a real reason
+  // (config corruption, permission denied, plugin load crash, etc., as
+  // distinct from "old runtime doesn't know the subcommand"). In that
+  // state the OpenClaw runtime cannot reliably report what's loaded,
+  // and trusting cfg.entries alone risks silently allowing dual-active
+  // states to slip through bind/quickstart/remove-account. Surface as
+  // `broken` so the user is prompted to run install (or fix OpenClaw).
+  if (!list.supported && list.error !== null) {
+    return {
+      kind: "broken",
+      details: `cannot determine install state: \`openclaw plugins list --json\` failed (${list.error})`,
+    };
+  }
 
   // Priority order: ClawHub (target) → npm-legacy → dmwork-legacy → broken → none
   if (isHealthyInstall(PLUGIN_ID)) {

--- a/create-openclaw-octo/cli/openclaw-cli.ts
+++ b/create-openclaw-octo/cli/openclaw-cli.ts
@@ -489,6 +489,81 @@ export function pluginsInspect(id: string): PluginInspectResult | null {
 }
 
 // ---------------------------------------------------------------------------
+// `openclaw plugins list --json` enumeration
+// ---------------------------------------------------------------------------
+//
+// `plugins list --json` is OpenClaw's authoritative report of "which plugin
+// ids the runtime currently knows about". Compared to the older signal
+// combination (cfg.plugins.entries + cfg.plugins.installs + extensions
+// directory + per-id `plugins inspect`):
+//
+//   - `cfg.plugins.installs` has been observed null on current OpenClaw
+//     schemas — install metadata moved into `plugins inspect <id>`.
+//   - `extensions/<id>` directory probe misses npm-installed plugins
+//     (npm-layout legacy plugins live under `npm/node_modules/<id>`).
+//   - `plugins inspect <id>` requires a known id, can't enumerate.
+//
+// `plugins list --json` returns each registered id with its rootDir
+// resolved by OpenClaw itself, so it covers both layouts uniformly and
+// is independent of any client-side path assumption (including custom
+// OPENCLAW_HOME on Windows / Linux).
+//
+// Old OpenClaw runtimes that don't recognise `plugins list --json` still
+// exist; in that case `listLoadedPlugins()` reports `supported: false`
+// and callers fall back to cfg.plugins.entries.
+// ---------------------------------------------------------------------------
+
+export interface PluginListEntry {
+  id: string;
+  status: string;
+  enabled: boolean;
+  source: string | null;
+  origin: string | null;
+  rootDir: string | null;
+}
+
+export interface PluginListResult {
+  /** True if OpenClaw produced parseable `plugins list --json` output. */
+  supported: boolean;
+  plugins: PluginListEntry[];
+}
+
+export function listLoadedPlugins(): PluginListResult {
+  let raw: string;
+  try {
+    raw = runOpenclaw(["plugins", "list", "--json"], {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+  } catch {
+    return { supported: false, plugins: [] };
+  }
+  const cleaned = stripStdoutNoise(raw);
+  const jsonStart = cleaned.indexOf("{");
+  if (jsonStart < 0) return { supported: false, plugins: [] };
+  let data: any;
+  try {
+    data = JSON.parse(cleaned.slice(jsonStart));
+  } catch {
+    return { supported: false, plugins: [] };
+  }
+  if (!Array.isArray(data?.plugins)) {
+    return { supported: false, plugins: [] };
+  }
+  const plugins: PluginListEntry[] = data.plugins
+    .map((p: any) => ({
+      id: typeof p?.id === "string" ? p.id : "",
+      status: typeof p?.status === "string" ? p.status : "",
+      enabled: Boolean(p?.enabled),
+      source: typeof p?.source === "string" ? p.source : null,
+      origin: typeof p?.origin === "string" ? p.origin : null,
+      rootDir: typeof p?.rootDir === "string" ? p.rootDir : null,
+    }))
+    .filter((p: PluginListEntry) => p.id.length > 0);
+  return { supported: true, plugins };
+}
+
+// ---------------------------------------------------------------------------
 // Unified plugin state detection (inspect + fallback)
 // ---------------------------------------------------------------------------
 
@@ -992,13 +1067,23 @@ export function detectScenario(): UpgradeScenario {
 }
 
 export function isHealthyInstall(pluginId: string = PLUGIN_ID): boolean {
+  const inspectOk = Boolean(pluginsInspect(pluginId)?.plugin);
+  if (inspectOk) return true;
+  // Fallback for OpenClaw runtimes without `plugins inspect`. The original
+  // fallback also AND'd with cfg.plugins.installs[id], but that field has
+  // been observed null on current OpenClaw schemas (install metadata moved
+  // into `plugins inspect <id> --json`), making the term effectively dead.
+  // Drop it; require dir + entries to call the install healthy.
+  // Note: this fallback is still extensions-layout only — npm-installed
+  // legacy plugins (LEGACY_PLUGIN_ID, NPM_PACKAGE_NAME) will return false
+  // here. detectInstallState catches that via listLoadedPlugins() +
+  // cfg.plugins.entries instead, so isHealthyInstall is only the source
+  // of truth for ClawHub/extensions-layout ids.
   const cfg = readConfigFromFile();
   const extDir = getConfigFilePathSafe().replace(/openclaw\.json$/, "extensions");
   const hasDir = existsSync(resolve(extDir, pluginId));
   const hasEntries = Boolean(cfg?.plugins?.entries?.[pluginId]);
-  const hasInstalls = Boolean(cfg?.plugins?.installs?.[pluginId]);
-  const inspectOk = Boolean(pluginsInspect(pluginId)?.plugin);
-  return inspectOk || (hasDir && hasEntries && hasInstalls);
+  return hasDir && hasEntries;
 }
 
 // ---------------------------------------------------------------------------
@@ -1029,42 +1114,56 @@ export type InstallState =
   | { kind: "broken"; details: string }
   | { kind: "none" };
 
-const LEGACY_NPM_RESIDUE_PATH = ".openclaw/npm/node_modules/openclaw-channel-octo";
+const LEGACY_NPM_RESIDUE_DIR = "npm/node_modules/openclaw-channel-octo";
 
 function hasLegacyNpmResidue(): boolean {
-  return existsSync(resolve(homedir(), LEGACY_NPM_RESIDUE_PATH));
+  // Derive the OpenClaw root from the live config-file path so users with
+  // a non-default install root (custom OPENCLAW_HOME, npm --prefix, Windows
+  // custom layout, etc.) are covered. Cosmetic-only signal — drives the
+  // residue warn line but never the block decision.
+  const root = getConfigFilePathSafe().replace(/openclaw\.json$/, "");
+  return existsSync(resolve(root, LEGACY_NPM_RESIDUE_DIR));
 }
 
 /**
- * Whether the legacy npm-installed `openclaw-channel-octo` is still registered
- * in OpenClaw's plugin entries (i.e., OpenClaw still attempts to load it on
- * startup). Both legacy npm v1.x and current ClawHub octo register channel
- * id "octo", so a healthy ClawHub install plus a still-registered legacy npm
- * install double-register the channel — install.ts treats this as a hard
- * cleanup error after install. detectInstallState surfaces it before
- * bind/quickstart/remove-account write any config so the user is prompted
- * to migrate first instead of silently writing into a duplicated channel.
+ * Whether a legacy plugin id is still registered with OpenClaw. Two signals
+ * in priority order:
  *
- * Signal source: cfg.plugins.entries[NPM_PACKAGE_NAME]. Note that
- * cfg.plugins.installs has been observed null on current OpenClaw schemas
- * (install metadata moved into `plugins inspect <id> --json`), so installs
- * cannot be used as a registration signal. Tracked in #82 for the broader
- * detection-layer cleanup.
+ *   1. `plugins list --json` (preferred, when supported by the runtime) —
+ *      OpenClaw's own report of "which plugin ids I'm trying to load".
+ *      Independent of cfg schema and client-side path assumptions.
+ *   2. `cfg.plugins.entries[id]` (fallback) — for older OpenClaw versions
+ *      that don't support `plugins list --json`. cfg.plugins.installs is
+ *      not used because it has been observed null on current schemas.
+ *
+ * Used by `detectInstallState` to detect dual-active states (ClawHub octo
+ * healthy AND a legacy id still registered) — both register channel "octo"
+ * (or, for dmwork-era ids, the dmwork channel), so any subsequent config
+ * write would land in a duplicated/half-migrated state.
  */
-function isLegacyNpmStillRegistered(cfg: Record<string, any> | null): boolean {
-  return Boolean(cfg?.plugins?.entries?.[NPM_PACKAGE_NAME]);
+function isPluginRegistered(
+  id: string,
+  list: PluginListResult,
+  cfg: Record<string, any> | null,
+): boolean {
+  if (list.supported) {
+    return list.plugins.some((p) => p.id === id);
+  }
+  return Boolean(cfg?.plugins?.entries?.[id]);
 }
 
 export function detectInstallState(): InstallState {
+  const list = listLoadedPlugins();
+  const cfg = readConfigFromFile();
+
   // Priority order: ClawHub (target) → npm-legacy → dmwork-legacy → broken → none
   if (isHealthyInstall(PLUGIN_ID)) {
     const state = resolvePluginState(PLUGIN_ID);
-    const cfg = readConfigFromFile();
     return {
       kind: "octo-clawhub",
       version: state.version,
       npmResidue: hasLegacyNpmResidue(),
-      legacyNpmActive: isLegacyNpmStillRegistered(cfg),
+      legacyNpmActive: isPluginRegistered(NPM_PACKAGE_NAME, list, cfg),
       // Mirror install.ts detectScenario priority: very-legacy `dmwork`
       // artefacts (highest priority → `legacy-to-octo` migration) AND
       // intermediate `openclaw-channel-dmwork` rebrand artefacts (next
@@ -1074,7 +1173,10 @@ export function detectInstallState(): InstallState {
       // before bind/quickstart/remove-account write fresh channels.octo
       // data over an unfinished migration.
       legacyDmworkResidue:
-        hasVeryLegacyPluginArtifacts(cfg) || hasLegacyPluginArtifacts(cfg),
+        hasVeryLegacyPluginArtifacts(cfg) ||
+        hasLegacyPluginArtifacts(cfg) ||
+        isPluginRegistered(VERY_LEGACY_PLUGIN_ID, list, cfg) ||
+        isPluginRegistered(LEGACY_PLUGIN_ID, list, cfg),
     };
   }
   if (isHealthyInstall(NPM_PACKAGE_NAME)) {
@@ -1083,47 +1185,55 @@ export function detectInstallState(): InstallState {
       version: resolvePluginState(NPM_PACKAGE_NAME).version,
     };
   }
-  // Belt-and-suspenders for the npm 1.0.0 case: `isHealthyInstall` returns
-  // true only when `plugins inspect` works OR the install lives under
-  // `extensions/<id>/`. But v1 npm plugins live under
-  // `~/.openclaw/npm/node_modules/openclaw-channel-octo`, and on very old
-  // OpenClaw runtimes that don't support `plugins inspect`, the first check
-  // misses and this branch would mis-classify the install as "broken".
-  // If the config has matching entries/installs AND the npm path exists on
-  // disk, treat it as a legit legacy npm install.
-  {
-    const cfg = readConfigFromFile();
-    const hasEntries = Boolean(cfg?.plugins?.entries?.[NPM_PACKAGE_NAME]);
-    const hasInstalls = Boolean(cfg?.plugins?.installs?.[NPM_PACKAGE_NAME]);
-    if (hasEntries && hasInstalls && hasLegacyNpmResidue()) {
-      return {
-        kind: "octo-npm-legacy",
-        version: cfg?.plugins?.installs?.[NPM_PACKAGE_NAME]?.version ?? null,
-      };
-    }
+  // Belt-and-suspenders for the npm 1.0.0 case on old OpenClaw runtimes
+  // that don't support `plugins inspect`. Two paths to detect a registered
+  // legacy npm install:
+  //   (a) `plugins list --json` reports the id (modern OpenClaw)
+  //   (b) cfg.plugins.entries[id] AND the npm-layout install dir exists
+  //       (older OpenClaw without `plugins list`)
+  // We don't gate on cfg.plugins.installs[id] because that field has
+  // been observed null on current OpenClaw schemas.
+  if (isPluginRegistered(NPM_PACKAGE_NAME, list, cfg)) {
+    return {
+      kind: "octo-npm-legacy",
+      version: cfg?.plugins?.installs?.[NPM_PACKAGE_NAME]?.version ?? null,
+    };
   }
   // Dmwork-era: check BOTH the intermediate id (LEGACY_PLUGIN_ID =
   // "openclaw-channel-dmwork") AND the very-legacy id (VERY_LEGACY_PLUGIN_ID
-  // = "dmwork"). Without the LEGACY_PLUGIN_ID check, the intermediate
-  // dmwork build would fall through to the "broken" classifier because its
-  // config entry IS recognised as a leftover but no isHealthyInstall passes.
-  if (isHealthyInstall(LEGACY_PLUGIN_ID)) {
+  // = "dmwork"). Use the unified `isPluginRegistered` so npm-installed
+  // dmwork (which lives under `npm/node_modules/<id>`, not `extensions/<id>`)
+  // is also caught — `plugins list --json` reports it directly, and the
+  // cfg.entries fallback also covers it without relying on the
+  // extensions-only directory probe in isHealthyInstall.
+  if (
+    isHealthyInstall(LEGACY_PLUGIN_ID) ||
+    isPluginRegistered(LEGACY_PLUGIN_ID, list, cfg)
+  ) {
     return {
       kind: "dmwork-legacy",
-      version: resolvePluginState(LEGACY_PLUGIN_ID).version,
+      version:
+        resolvePluginState(LEGACY_PLUGIN_ID).version ??
+        cfg?.plugins?.installs?.[LEGACY_PLUGIN_ID]?.version ??
+        null,
     };
   }
-  if (isHealthyInstall(VERY_LEGACY_PLUGIN_ID)) {
+  if (
+    isHealthyInstall(VERY_LEGACY_PLUGIN_ID) ||
+    isPluginRegistered(VERY_LEGACY_PLUGIN_ID, list, cfg)
+  ) {
     return {
       kind: "dmwork-legacy",
-      version: resolvePluginState(VERY_LEGACY_PLUGIN_ID).version,
+      version:
+        resolvePluginState(VERY_LEGACY_PLUGIN_ID).version ??
+        cfg?.plugins?.installs?.[VERY_LEGACY_PLUGIN_ID]?.version ??
+        null,
     };
   }
 
-  // None of the three plugin ids are healthy. Surface "broken" only when
-  // there are leftover config entries pointing to one of them — otherwise
-  // it's a clean "not installed" state.
-  const cfg = readConfigFromFile();
+  // None of the three plugin ids are healthy or registered. Surface "broken"
+  // only when there are leftover config entries pointing to one of them —
+  // otherwise it's a clean "not installed" state.
   const entries = cfg?.plugins?.entries ?? {};
   const installs = cfg?.plugins?.installs ?? {};
   const knownIds = [PLUGIN_ID, NPM_PACKAGE_NAME, LEGACY_PLUGIN_ID, VERY_LEGACY_PLUGIN_ID];

--- a/create-openclaw-octo/cli/openclaw-cli.ts
+++ b/create-openclaw-octo/cli/openclaw-cli.ts
@@ -1069,21 +1069,28 @@ export function detectScenario(): UpgradeScenario {
 export function isHealthyInstall(pluginId: string = PLUGIN_ID): boolean {
   const inspectOk = Boolean(pluginsInspect(pluginId)?.plugin);
   if (inspectOk) return true;
-  // Fallback for OpenClaw runtimes without `plugins inspect`. The original
-  // fallback also AND'd with cfg.plugins.installs[id], but that field has
-  // been observed null on current OpenClaw schemas (install metadata moved
-  // into `plugins inspect <id> --json`), making the term effectively dead.
-  // Drop it; require dir + entries to call the install healthy.
+  // Fallback for OpenClaw runtimes without `plugins inspect`. Kept aligned
+  // with the 3-artifact healthy definition used by detectScenario() and
+  // cleanupBrokenInstall() so the pre-flight, install-time, and cleanup
+  // paths agree on what counts as healthy. The `cfg.plugins.installs[id]`
+  // term has been observed null on current OpenClaw schemas (install
+  // metadata moved into `plugins inspect <id>`), but the inspect short-
+  // circuit above already covers those runtimes — so the apparent
+  // dead-code on modern OpenClaw is the cost of staying consistent with
+  // the other classifiers. Tightening that across all classifiers in one
+  // shot is tracked as a follow-up to #82 ("3-artifact → 2-artifact" move
+  // requires updating detectScenario / cleanupBrokenInstall / etc.).
   // Note: this fallback is still extensions-layout only — npm-installed
   // legacy plugins (LEGACY_PLUGIN_ID, NPM_PACKAGE_NAME) will return false
   // here. detectInstallState catches that via listLoadedPlugins() +
-  // cfg.plugins.entries instead, so isHealthyInstall is only the source
-  // of truth for ClawHub/extensions-layout ids.
+  // cfg.plugins.entries instead, so isHealthyInstall remains the source
+  // of truth only for ClawHub/extensions-layout ids.
   const cfg = readConfigFromFile();
   const extDir = getConfigFilePathSafe().replace(/openclaw\.json$/, "extensions");
   const hasDir = existsSync(resolve(extDir, pluginId));
   const hasEntries = Boolean(cfg?.plugins?.entries?.[pluginId]);
-  return hasDir && hasEntries;
+  const hasInstalls = Boolean(cfg?.plugins?.installs?.[pluginId]);
+  return hasDir && hasEntries && hasInstalls;
 }
 
 // ---------------------------------------------------------------------------
@@ -1185,15 +1192,23 @@ export function detectInstallState(): InstallState {
       version: resolvePluginState(NPM_PACKAGE_NAME).version,
     };
   }
-  // Belt-and-suspenders for the npm 1.0.0 case on old OpenClaw runtimes
-  // that don't support `plugins inspect`. Two paths to detect a registered
-  // legacy npm install:
-  //   (a) `plugins list --json` reports the id (modern OpenClaw)
-  //   (b) cfg.plugins.entries[id] AND the npm-layout install dir exists
-  //       (older OpenClaw without `plugins list`)
+  // Belt-and-suspenders for the npm 1.0.0 case. Two paths classify the
+  // install as octo-npm-legacy:
+  //   (a) `plugins list --json` reports the id (modern OpenClaw) — the
+  //       runtime registry is authoritative; no extra disk probe needed.
+  //   (b) cfg.plugins.entries[id] AND the npm-layout install directory
+  //       exists (old OpenClaw without `plugins list --json`). Both
+  //       artefacts are required: a stale entry with no dir on disk is
+  //       residue (broken classifier territory), not an active install.
   // We don't gate on cfg.plugins.installs[id] because that field has
   // been observed null on current OpenClaw schemas.
-  if (isPluginRegistered(NPM_PACKAGE_NAME, list, cfg)) {
+  const npmLegacyActiveViaList =
+    list.supported && list.plugins.some((p) => p.id === NPM_PACKAGE_NAME);
+  const npmLegacyActiveViaCfgFallback =
+    !list.supported &&
+    Boolean(cfg?.plugins?.entries?.[NPM_PACKAGE_NAME]) &&
+    hasLegacyNpmResidue();
+  if (npmLegacyActiveViaList || npmLegacyActiveViaCfgFallback) {
     return {
       kind: "octo-npm-legacy",
       version: cfg?.plugins?.installs?.[NPM_PACKAGE_NAME]?.version ?? null,

--- a/create-openclaw-octo/cli/openclaw-cli.ts
+++ b/create-openclaw-octo/cli/openclaw-cli.ts
@@ -523,9 +523,54 @@ export interface PluginListEntry {
 }
 
 export interface PluginListResult {
-  /** True if OpenClaw produced parseable `plugins list --json` output. */
+  /**
+   * True if OpenClaw produced parseable `plugins list --json` output.
+   * False ONLY when the runtime doesn't recognise the subcommand — i.e.
+   * `unknown command` / `unrecognized command` in stderr/stdout. Other
+   * failure modes (config corruption, permission denied, partial JSON,
+   * etc.) propagate as exceptions; callers should treat these as
+   * truly-unknown registry state and fail closed where it matters.
+   */
   supported: boolean;
   plugins: PluginListEntry[];
+}
+
+/**
+ * Extract a complete top-level JSON object from a string by counting
+ * unescaped `{` / `}` outside of strings. Tolerates trailing log lines
+ * that survived `stripStdoutNoise` (a strict `JSON.parse(out.slice(start))`
+ * would fail). Returns null when no balanced object is found.
+ */
+function extractJsonObject(raw: string): string | null {
+  const start = raw.indexOf("{");
+  if (start < 0) return null;
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = start; i < raw.length; i++) {
+    const ch = raw[i];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (inString) {
+      if (ch === "\\") {
+        escaped = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+    } else if (ch === "{") {
+      depth++;
+    } else if (ch === "}") {
+      depth--;
+      if (depth === 0) return raw.slice(start, i + 1);
+    }
+  }
+  return null;
 }
 
 export function listLoadedPlugins(): PluginListResult {
@@ -535,15 +580,37 @@ export function listLoadedPlugins(): PluginListResult {
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
     });
-  } catch {
+  } catch (err) {
+    // Distinguish "old runtime doesn't know this subcommand" from real
+    // errors (config corruption, permission, etc.). Only the former
+    // gets `supported: false`; everything else also reports
+    // `supported: false` for now, but with empty plugins — callers
+    // should rely on cfg.plugins.entries fallback. Future: if we want
+    // to surface a "registry truly unknown" state to callers, add a
+    // third field here. For now, fail-closed by returning an empty
+    // registry; detection paths that OR against cfg.entries will still
+    // catch artefacts.
+    const sources = [
+      (err as any)?.stderr?.toString?.(),
+      (err as any)?.stdout?.toString?.(),
+      (err as any)?.message,
+      String(err),
+    ];
+    const text = sources.filter(Boolean).join(" ");
+    if (/unknown command|unrecognized command/i.test(text)) {
+      return { supported: false, plugins: [] };
+    }
+    // Real error (not "old runtime") — still report supported: false so
+    // detectInstallState falls back to cfg.entries, which is the safest
+    // course when we genuinely can't tell what's loaded.
     return { supported: false, plugins: [] };
   }
   const cleaned = stripStdoutNoise(raw);
-  const jsonStart = cleaned.indexOf("{");
-  if (jsonStart < 0) return { supported: false, plugins: [] };
+  const jsonStr = extractJsonObject(cleaned);
+  if (jsonStr === null) return { supported: false, plugins: [] };
   let data: any;
   try {
-    data = JSON.parse(cleaned.slice(jsonStart));
+    data = JSON.parse(jsonStr);
   } catch {
     return { supported: false, plugins: [] };
   }
@@ -1214,25 +1281,19 @@ export function detectInstallState(): InstallState {
       version: cfg?.plugins?.installs?.[NPM_PACKAGE_NAME]?.version ?? null,
     };
   }
-  // Dmwork-era: check BOTH the intermediate id (LEGACY_PLUGIN_ID =
-  // "openclaw-channel-dmwork") AND the very-legacy id (VERY_LEGACY_PLUGIN_ID
-  // = "dmwork"). Use the unified `isPluginRegistered` so npm-installed
-  // dmwork (which lives under `npm/node_modules/<id>`, not `extensions/<id>`)
-  // is also caught — `plugins list --json` reports it directly, and the
+  // Dmwork-era: check VERY_LEGACY_PLUGIN_ID = "dmwork" FIRST, then
+  // LEGACY_PLUGIN_ID = "openclaw-channel-dmwork". This matches the
+  // priority order in install.ts detectScenario(): very-legacy is
+  // priority 1 (legacy-to-octo migration) above the rebrand priority 2
+  // (openclaw-channel-dmwork). When both are registered simultaneously,
+  // the dmwork-legacy state should report the very-legacy id's version
+  // so the user-facing prompt aligns with which migration install will
+  // actually run.
+  // Use the unified `isPluginRegistered` so npm-installed dmwork (which
+  // lives under `npm/node_modules/<id>`, not `extensions/<id>`) is also
+  // caught — `plugins list --json` reports it directly, and the
   // cfg.entries fallback also covers it without relying on the
   // extensions-only directory probe in isHealthyInstall.
-  if (
-    isHealthyInstall(LEGACY_PLUGIN_ID) ||
-    isPluginRegistered(LEGACY_PLUGIN_ID, list, cfg)
-  ) {
-    return {
-      kind: "dmwork-legacy",
-      version:
-        resolvePluginState(LEGACY_PLUGIN_ID).version ??
-        cfg?.plugins?.installs?.[LEGACY_PLUGIN_ID]?.version ??
-        null,
-    };
-  }
   if (
     isHealthyInstall(VERY_LEGACY_PLUGIN_ID) ||
     isPluginRegistered(VERY_LEGACY_PLUGIN_ID, list, cfg)
@@ -1242,6 +1303,18 @@ export function detectInstallState(): InstallState {
       version:
         resolvePluginState(VERY_LEGACY_PLUGIN_ID).version ??
         cfg?.plugins?.installs?.[VERY_LEGACY_PLUGIN_ID]?.version ??
+        null,
+    };
+  }
+  if (
+    isHealthyInstall(LEGACY_PLUGIN_ID) ||
+    isPluginRegistered(LEGACY_PLUGIN_ID, list, cfg)
+  ) {
+    return {
+      kind: "dmwork-legacy",
+      version:
+        resolvePluginState(LEGACY_PLUGIN_ID).version ??
+        cfg?.plugins?.installs?.[LEGACY_PLUGIN_ID]?.version ??
         null,
     };
   }


### PR DESCRIPTION
## Summary

Closes #82.

The pre-flight install-state detection layer in `cli/openclaw-cli.ts` previously combined four indirect signals to decide whether a plugin id was registered with OpenClaw: `pluginsInspect()`, `cfg.plugins.entries[id]`, `cfg.plugins.installs[id]`, and `existsSync(extensions/<id>)`. PR #81's review (and the linked issue #82) found three correctness gaps with that combination — see #82 for the full background. This PR consolidates the detection behind `openclaw plugins list --json`, OpenClaw's own authoritative registry of "which plugin ids the runtime is currently trying to load."

No behavioural change for the happy path (clean ClawHub octo, no legacy residue). Behavioural improvement for the gaps:

- **Custom OpenClaw root.** `hasLegacyNpmResidue()` now derives its probe path from `getConfigFilePathSafe()` rather than `homedir() + .openclaw/npm/...`. Users with `OPENCLAW_HOME` set, npm `--prefix`, or Windows non-default layouts now get the residue warn correctly. (The signal remains cosmetic — drives the warn line, never the block decision.)
- **npm-installed legacy dmwork plugin.** `LEGACY_PLUGIN_ID = "openclaw-channel-dmwork"` is an npm package that lives under `<root>/npm/node_modules/<id>`, not `<root>/extensions/<id>`. The previous `isHealthyInstall(LEGACY_PLUGIN_ID)` directory probe always missed it. `detectInstallState` now classifies a registered LEGACY_PLUGIN_ID as `dmwork-legacy` via `listLoadedPlugins()` (and via `cfg.plugins.entries` on old runtimes that don't support `plugins list --json`).
- **Dual-active state on stale cfg.** `legacyNpmActive` / `legacyDmworkResidue` previously sourced from `cfg.plugins.entries` only. They now prefer the live `plugins list --json` signal when available, OR the cfg.entries fallback when not. Catches a runtime registration that hasn't yet round-tripped to disk.

## Related Issue

Closes #82.

## Changes

### `cli/openclaw-cli.ts`

- New `listLoadedPlugins(): { supported: boolean; plugins: PluginListEntry[] }` helper wrapping `runOpenclaw([\"plugins\", \"list\", \"--json\"])` + `stripStdoutNoise` + `JSON.parse`. Returns `supported: false` when the command throws, output is not JSON, or the JSON has no `plugins` array (i.e., old OpenClaw runtimes that don't recognise the subcommand).
- New `isPluginRegistered(id, list, cfg)` private helper: prefers the list signal when supported, falls back to `cfg.plugins.entries[id]`. Centralises the source-of-truth selection.
- `detectInstallState()` rewritten to use `isPluginRegistered`:
  - `legacyNpmActive` and `legacyDmworkResidue` (in the `octo-clawhub` arm) source their registration signals from list-or-cfg, OR'd with the existing channel/binding artefact checks (`hasLegacyPluginArtifacts`, `hasVeryLegacyPluginArtifacts`).
  - The `octo-npm-legacy` belt-and-suspenders branch and both `dmwork-legacy` branches use `isPluginRegistered` instead of the directory-only `isHealthyInstall` for the legacy ids — so npm-layout installs are caught.
  - Single `cfg = readConfigFromFile()` at the top, threaded into every helper that needs it.
- `hasLegacyNpmResidue()` derives its probe path from `getConfigFilePathSafe()` (\"openclaw.json\" → root → `npm/node_modules/openclaw-channel-octo`) instead of hardcoded `homedir() + .openclaw/npm/...`.
- `isHealthyInstall()` simplified: drops the `hasInstalls` term from the fallback. `cfg.plugins.installs` has been observed null on current OpenClaw schemas, making that term effectively dead. Fallback now requires only `dir + entries`.

### `cli/openclaw-cli.test.ts`

- 6 new unit tests for `listLoadedPlugins`: parse OK with full plugin shape, strip preceding banner/log noise, return `supported: false` when the command throws, return `supported: false` on non-JSON output, return `supported: false` on JSON missing `plugins` array, filter out entries with empty/missing `id`.
- 3 new `detectInstallState` cases covering the list signal path with cfg.entries empty:
  - `legacyNpmActive` sourced from list (`openclaw-channel-octo` only present in `plugins list --json`).
  - `legacyDmworkResidue` sourced from list with `LEGACY_PLUGIN_ID = \"openclaw-channel-dmwork\"`.
  - `legacyDmworkResidue` sourced from list with `VERY_LEGACY_PLUGIN_ID = \"dmwork\"`.
- `setupOctoClawHub` helper extended with optional `pluginsListSupported` / `legacyNpmInList` / `legacyDmworkInList` / `veryLegacyDmworkInList` opts. All default false, so every prior test still exercises the cfg-fallback path. The 102 pre-existing tests remain unchanged.

## Testing

- [x] **111/111 tests passing locally** (102 prior + 6 listLoadedPlugins + 3 detectInstallState list-signal cases)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation — N/A (internal refactor; no user-facing behaviour change on the happy path)
- [x] Followed commit message conventions (Conventional Commits)

## Backward compatibility

- **Modern OpenClaw (`plugins list --json` supported):** Detection now uses the list signal as primary source. Behaviour is functionally equivalent to the prior cfg-based detection on healthy installs, but more accurate on the gaps documented above.
- **Old OpenClaw (`plugins list --json` not supported):** `listLoadedPlugins()` reports `supported: false` and `isPluginRegistered` falls back to `cfg.plugins.entries[id]`. Behaviour is functionally equivalent to PR #81's `cfg.plugins.entries` check (which was added specifically because `cfg.plugins.installs` is null on current schemas).
- **Out-of-scope** for this PR: yujiawei's P2 carry-forwards from PR #81 (direct unit tests for `detectInstallState`'s broken-state classifier, `compareVersions` / `compareOpenClawVersion` consolidation, exhaustive-switch hardening). Those remain candidates for a separate small cleanup PR.