### PR TITLE
fix(create-openclaw-octo): detection counts only active legacy residue

### DIFF
--- a/create-openclaw-octo/cli/openclaw-cli.test.ts
+++ b/create-openclaw-octo/cli/openclaw-cli.test.ts
@@ -847,6 +847,107 @@ describe("detectOpenClawState", () => {
 });
 
 // ---------------------------------------------------------------------------
+// hasLegacyPluginArtifacts / hasVeryLegacyPluginArtifacts — direct unit
+// coverage for the residue-detection helpers used by detectInstallState
+// (octo-clawhub.legacyDmworkResidue) and detectScenario (rebrand priority).
+//
+// These need to count only ACTIVE residue (cfg state OpenClaw will read
+// at startup) — not inert disk residue / orphaned allowlist entries that
+// have no behavioural effect.
+// ---------------------------------------------------------------------------
+
+describe("hasLegacyPluginArtifacts", () => {
+  it("entries.openclaw-channel-dmwork → true", async () => {
+    const { hasLegacyPluginArtifacts } = await loadModule();
+    expect(hasLegacyPluginArtifacts({
+      plugins: { entries: { "openclaw-channel-dmwork": { enabled: true } } },
+    })).toBe(true);
+  });
+
+  it("installs.openclaw-channel-dmwork → true", async () => {
+    const { hasLegacyPluginArtifacts } = await loadModule();
+    expect(hasLegacyPluginArtifacts({
+      plugins: { installs: { "openclaw-channel-dmwork": { version: "0.6.4" } } },
+    })).toBe(true);
+  });
+
+  it("channels.dmwork → true (data needs migration)", async () => {
+    const { hasLegacyPluginArtifacts } = await loadModule();
+    expect(hasLegacyPluginArtifacts({
+      channels: { dmwork: { accounts: { bot1: { botToken: "x" } } } },
+    })).toBe(true);
+  });
+
+  it("bindings(channel=dmwork) → true (routing needs migration)", async () => {
+    const { hasLegacyPluginArtifacts } = await loadModule();
+    expect(hasLegacyPluginArtifacts({
+      bindings: [{ match: { channel: "dmwork" }, accountId: "x", agent: "main" }],
+    })).toBe(true);
+  });
+
+  it("plugins.allow only (no entry/install/channel/binding) → false", async () => {
+    // Allowlist alone is dead-letter — without a matching entry OpenClaw
+    // doesn't load it. Not a critical residue.
+    const { hasLegacyPluginArtifacts } = await loadModule();
+    expect(hasLegacyPluginArtifacts({
+      plugins: { allow: ["openclaw-channel-dmwork"] },
+    })).toBe(false);
+  });
+
+  it("empty cfg with disk residue (mocked) → false (cosmetic only)", async () => {
+    // Real-world Mac/Win scenario after rebrand uninstall:
+    // ~/.openclaw/extensions/openclaw-channel-dmwork/ remains on disk
+    // but cfg has no entry/install/channel/binding for it. OpenClaw's
+    // disk-scan auto-adds a disabled entry (which never calls setup()).
+    // No channel registration, no migration needed → not critical residue.
+    const { hasLegacyPluginArtifacts } = await loadModule();
+    const { existsSync } = await import("node:fs");
+    vi.mocked(existsSync).mockReturnValue(true);  // disk dir exists
+    expect(hasLegacyPluginArtifacts({})).toBe(false);
+  });
+
+  it("null cfg → false", async () => {
+    const { hasLegacyPluginArtifacts } = await loadModule();
+    expect(hasLegacyPluginArtifacts(null)).toBe(false);
+  });
+});
+
+describe("hasVeryLegacyPluginArtifacts", () => {
+  it("entries.dmwork → true", async () => {
+    const { hasVeryLegacyPluginArtifacts } = await loadModule();
+    expect(hasVeryLegacyPluginArtifacts({
+      plugins: { entries: { dmwork: { enabled: true } } },
+    })).toBe(true);
+  });
+
+  it("installs.dmwork → true", async () => {
+    const { hasVeryLegacyPluginArtifacts } = await loadModule();
+    expect(hasVeryLegacyPluginArtifacts({
+      plugins: { installs: { dmwork: { version: "0.5.21" } } },
+    })).toBe(true);
+  });
+
+  it("plugins.allow only → false (dead-letter)", async () => {
+    const { hasVeryLegacyPluginArtifacts } = await loadModule();
+    expect(hasVeryLegacyPluginArtifacts({
+      plugins: { allow: ["dmwork"] },
+    })).toBe(false);
+  });
+
+  it("empty cfg with disk residue (mocked) → false (cosmetic only)", async () => {
+    const { hasVeryLegacyPluginArtifacts } = await loadModule();
+    const { existsSync } = await import("node:fs");
+    vi.mocked(existsSync).mockReturnValue(true);
+    expect(hasVeryLegacyPluginArtifacts({})).toBe(false);
+  });
+
+  it("null cfg → false", async () => {
+    const { hasVeryLegacyPluginArtifacts } = await loadModule();
+    expect(hasVeryLegacyPluginArtifacts(null)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // detectInstallState — also kept BEFORE the `getConfigFilePathSafe` block for
 // the same `vi.doMock` re-binding reason called out at line 560.
 // ---------------------------------------------------------------------------
@@ -874,13 +975,22 @@ describe("detectInstallState", () => {
     legacyNpmInList?: boolean;
     legacyDmworkInList?: boolean;
     veryLegacyDmworkInList?: boolean;
+    /**
+     * Disabled-only list entries — what OpenClaw produces when disk-scan
+     * auto-discovers a residual plugin file but cfg has no entry for it.
+     * Such entries do NOT have setup() called → cannot register a channel,
+     * so they should NOT count as "active" by isPluginRegistered.
+     */
+    legacyNpmInListDisabled?: boolean;
+    legacyDmworkInListDisabled?: boolean;
+    veryLegacyDmworkInListDisabled?: boolean;
   }) {
     return async () => {
       const { existsSync, readFileSync } = await import("node:fs");
-      const mkListEntry = (id: string) => ({
+      const mkListEntry = (id: string, enabled = true) => ({
         id,
-        status: "loaded",
-        enabled: true,
+        status: enabled ? "loaded" : "disabled",
+        enabled,
         source: `/home/user/.openclaw/extensions/${id}/dist/index.js`,
         origin: "global",
         rootDir: `/home/user/.openclaw/extensions/${id}`,
@@ -891,6 +1001,9 @@ describe("detectInstallState", () => {
         if (opts.legacyNpmInList) plugins.push(mkListEntry("openclaw-channel-octo"));
         if (opts.legacyDmworkInList) plugins.push(mkListEntry("openclaw-channel-dmwork"));
         if (opts.veryLegacyDmworkInList) plugins.push(mkListEntry("dmwork"));
+        if (opts.legacyNpmInListDisabled) plugins.push(mkListEntry("openclaw-channel-octo", false));
+        if (opts.legacyDmworkInListDisabled) plugins.push(mkListEntry("openclaw-channel-dmwork", false));
+        if (opts.veryLegacyDmworkInListDisabled) plugins.push(mkListEntry("dmwork", false));
         return JSON.stringify({ plugins });
       })();
       mockExecFileSync.mockImplementation((cmd, args) => {
@@ -1262,6 +1375,63 @@ describe("detectInstallState", () => {
     if (state.kind === "broken") {
       expect(state.details).toMatch(/plugins list/);
       expect(state.details).toMatch(/permission denied/i);
+    }
+  });
+
+  // ── disabled / disk-only residue should NOT be reported as critical ──
+  // Mac/Windows real-machine evidence: after install the OpenClaw runtime
+  // auto-discovers leftover plugin files via disk scan and lists them as
+  // disabled (no cfg entry). Such entries do NOT have setup() called, so
+  // they cannot register a channel — no duplicate channel risk. Doctor
+  // should not report ✗ Unfinished migration in this state.
+
+  it("octo-clawhub: legacy NPM_PACKAGE_NAME in plugins list as DISABLED → legacyNpmActive=false", async () => {
+    // Real-world scenario: user upgraded from npm 1.0.0 → ClawHub octo.
+    // OpenClaw's `plugins uninstall` left the npm/node_modules dir on disk;
+    // gateway restart auto-discovered the file and listed it as `disabled`.
+    // The cfg has no entry for it → setup() not called → channel "octo"
+    // not registered by the legacy plugin → no dual-active risk.
+    await setupOctoClawHub({
+      pluginsListSupported: true,
+      legacyNpmInListDisabled: true,
+    })();
+    const { detectInstallState } = await loadModule();
+    const state = detectInstallState();
+    expect(state.kind).toBe("octo-clawhub");
+    if (state.kind === "octo-clawhub") {
+      expect(state.legacyNpmActive).toBe(false);
+      expect(state.legacyDmworkResidue).toBe(false);
+    }
+  });
+
+  it("octo-clawhub: LEGACY_PLUGIN_ID in plugins list as DISABLED → legacyDmworkResidue=false", async () => {
+    // Real-world scenario observed on Mac after dmwork rebrand: residual
+    // `~/.openclaw/extensions/openclaw-channel-dmwork/` from an earlier
+    // stock install is auto-discovered after rebrand uninstall, listed
+    // as `disabled` because cfg has no entry. Harmless (won't load).
+    await setupOctoClawHub({
+      pluginsListSupported: true,
+      legacyDmworkInListDisabled: true,
+    })();
+    const { detectInstallState } = await loadModule();
+    const state = detectInstallState();
+    expect(state.kind).toBe("octo-clawhub");
+    if (state.kind === "octo-clawhub") {
+      expect(state.legacyDmworkResidue).toBe(false);
+      expect(state.legacyNpmActive).toBe(false);
+    }
+  });
+
+  it("octo-clawhub: VERY_LEGACY_PLUGIN_ID in plugins list as DISABLED → legacyDmworkResidue=false", async () => {
+    await setupOctoClawHub({
+      pluginsListSupported: true,
+      veryLegacyDmworkInListDisabled: true,
+    })();
+    const { detectInstallState } = await loadModule();
+    const state = detectInstallState();
+    expect(state.kind).toBe("octo-clawhub");
+    if (state.kind === "octo-clawhub") {
+      expect(state.legacyDmworkResidue).toBe(false);
     }
   });
 });

--- a/create-openclaw-octo/cli/openclaw-cli.ts
+++ b/create-openclaw-octo/cli/openclaw-cli.ts
@@ -1217,20 +1217,29 @@ function hasLegacyNpmResidue(): boolean {
 }
 
 /**
- * Whether a legacy plugin id is still registered with OpenClaw. Two signals
- * in priority order:
+ * Whether a legacy plugin id is still **actively registered** with OpenClaw
+ * — i.e. OpenClaw will load it on startup and call its setup() to
+ * register hooks / channels. Two signals in priority order:
  *
  *   1. `plugins list --json` (preferred, when supported by the runtime) —
  *      OpenClaw's own report of "which plugin ids I'm trying to load".
- *      Independent of cfg schema and client-side path assumptions.
+ *      We only count entries with `enabled === true`; entries that
+ *      OpenClaw lists as `disabled` (because the cfg has no entry but
+ *      disk-scan auto-discovered the files) DO NOT have setup() called
+ *      and therefore cannot register a channel id, so they cannot cause
+ *      duplicate channel registration with the new ClawHub octo plugin.
  *   2. `cfg.plugins.entries[id]` (fallback) — for older OpenClaw versions
  *      that don't support `plugins list --json`. cfg.plugins.installs is
  *      not used because it has been observed null on current schemas.
  *
  * Used by `detectInstallState` to detect dual-active states (ClawHub octo
- * healthy AND a legacy id still registered) — both register channel "octo"
- * (or, for dmwork-era ids, the dmwork channel), so any subsequent config
- * write would land in a duplicated/half-migrated state.
+ * healthy AND a legacy id still actively registered) — both would register
+ * channel "octo" (or, for dmwork-era ids, the dmwork channel), so any
+ * subsequent config write would land in a duplicated/half-migrated state.
+ *
+ * A disabled-only entry in `plugins list` (auto-discovered from disk
+ * residue without a corresponding cfg entry) is harmless and not flagged
+ * as registered.
  */
 function isPluginRegistered(
   id: string,
@@ -1238,7 +1247,7 @@ function isPluginRegistered(
   cfg: Record<string, any> | null,
 ): boolean {
   if (list.supported) {
-    return list.plugins.some((p) => p.id === id);
+    return list.plugins.some((p) => p.id === id && p.enabled);
   }
   return Boolean(cfg?.plugins?.entries?.[id]);
 }
@@ -1919,36 +1928,55 @@ export function cleanupStaleWorkspaceIfEmpty(channelId: string): void {
 // ---------------------------------------------------------------------------
 
 /**
- * True if the very-legacy plugin id "dmwork" has any presence —
- * extension dir, plugins.entries, plugins.installs, or plugins.allow.
+ * True if the very-legacy plugin id "dmwork" is still active — i.e.
+ * OpenClaw will load it on startup or it owns config data we need to
+ * migrate.
+ *
+ * Active signals:
+ *   - cfg.plugins.entries[id]    — OpenClaw's load registry
+ *   - cfg.plugins.installs[id]   — install metadata (older schemas)
+ *
+ * Inert signals (intentionally NOT checked):
+ *   - extensions/<id>/ directory — without a cfg entry OpenClaw won't
+ *     load it on startup; auto-discovered entries default to disabled
+ *     and never call setup() / channel.register(...). No duplicate
+ *     channel registration risk. Cosmetic disk residue.
+ *   - cfg.plugins.allow[id]      — pure allowlist entry without a
+ *     corresponding entry/install is dead-letter, never loaded.
  *
  * Predates `openclaw-channel-dmwork`. Detection takes priority over rebrand.
  */
 export function hasVeryLegacyPluginArtifacts(cfg: Record<string, any> | null): boolean {
-  const extDir = getConfigFilePathSafe().replace(/openclaw\.json$/, "extensions");
-  const hasDir = existsSync(resolve(extDir, VERY_LEGACY_PLUGIN_ID));
   const hasEntry = Boolean(cfg?.plugins?.entries?.[VERY_LEGACY_PLUGIN_ID]);
   const hasInstall = Boolean(cfg?.plugins?.installs?.[VERY_LEGACY_PLUGIN_ID]);
-  const inAllow = Array.isArray(cfg?.plugins?.allow) &&
-    cfg.plugins.allow.includes(VERY_LEGACY_PLUGIN_ID);
-  return hasDir || hasEntry || hasInstall || inAllow;
+  return hasEntry || hasInstall;
 }
 
 /**
- * True if the intermediate plugin id "openclaw-channel-dmwork" has any
- * presence — covers full installs as well as residual config-only state.
+ * True if the intermediate plugin id "openclaw-channel-dmwork" is still
+ * active — i.e. OpenClaw will load it, or there's data on the
+ * dmwork channel that needs migration to channel=octo.
+ *
+ * Active signals:
+ *   - cfg.plugins.entries[id]              — OpenClaw load registry
+ *   - cfg.plugins.installs[id]             — install metadata
+ *   - cfg.channels.dmwork                  — channel data (accounts, settings)
+ *   - cfg.bindings[*].match.channel=dmwork — routing rules pointing at it
+ *
+ * Inert signals (intentionally NOT checked):
+ *   - extensions/<id>/ directory — without a cfg entry OpenClaw won't
+ *     auto-enable it; auto-discovered entries default to disabled and
+ *     never call setup() / channel.register("dmwork", ...). No
+ *     duplicate channel registration risk. Cosmetic disk residue.
+ *   - cfg.plugins.allow[id]      — allowlist alone is dead-letter.
  *
  * Triggers the rebrand migration path.
  */
 export function hasLegacyPluginArtifacts(cfg: Record<string, any> | null): boolean {
-  const extDir = getConfigFilePathSafe().replace(/openclaw\.json$/, "extensions");
-  const hasDir = existsSync(resolve(extDir, LEGACY_PLUGIN_ID));
   const hasEntry = Boolean(cfg?.plugins?.entries?.[LEGACY_PLUGIN_ID]);
   const hasInstall = Boolean(cfg?.plugins?.installs?.[LEGACY_PLUGIN_ID]);
-  const inAllow = Array.isArray(cfg?.plugins?.allow) &&
-    cfg.plugins.allow.includes(LEGACY_PLUGIN_ID);
   const hasChannel = Boolean(cfg?.channels?.[LEGACY_CHANNEL_ID]);
   const hasBindings = Array.isArray(cfg?.bindings) &&
     (cfg.bindings as any[]).some((b: any) => b?.match?.channel === LEGACY_CHANNEL_ID);
-  return hasDir || hasEntry || hasInstall || inAllow || hasChannel || hasBindings;
+  return hasEntry || hasInstall || hasChannel || hasBindings;
 }


### PR DESCRIPTION
## Summary

Real-machine evidence from both Mac (dmwork@0.6.4 user) and Windows E2E test showed `detectInstallState` reporting `legacyDmworkResidue: true` after a successful rebrand migration, with `doctor` flagging "Unfinished dmwork → octo migration" — even though the cfg was clean (no entry, no channels.dmwork, no bindings on dmwork) and the bot was working normally.

This PR tightens the detection helpers to count only \"active\" residue — state OpenClaw actually reads at startup or that needs migration — while ignoring inert disk leftovers.

## Related Issue

N/A — surfaced by the Windows E2E test report (`/Users/caster/Downloads/windows-e2e-install-report.md`) and a Mac user's upgrade artefacts. Both pass the functional bar (bot data intact + IM verification OK) but get incorrectly flagged by the residue detector.

## Changes

### \`hasLegacyPluginArtifacts\` and \`hasVeryLegacyPluginArtifacts\` — drop two false-positive signals

- **Drop `extensions/<id>/` directory check.** Without a corresponding cfg entry, OpenClaw's startup disk-scan auto-adds a `disabled` registry entry — and disabled plugins don't have `setup()` called, so they cannot register a channel id. No duplicate channel registration risk. Cosmetic disk residue.
- **Drop `cfg.plugins.allow[<id>]` check.** An allowlist line with no matching entry is dead-letter — OpenClaw never loads it.

Remaining signals (entries / installs / channels / bindings) cover everything OpenClaw actually loads at startup or that needs migration to channel=octo.

### \`isPluginRegistered\` — disabled entries don't count as active

In the dual-active detection path, only count `plugins list --json` entries with `enabled === true`. Disabled entries from disk-scan auto-discovery don't have setup() called, so they can't register a duplicate channel id.

### Tests

- **13 new direct unit cases** for `hasLegacyPluginArtifacts` / `hasVeryLegacyPluginArtifacts` — cover each signal in isolation + the two now-dropped signals (disk residue alone / allow alone) + null cfg.
- **3 new `detectInstallState` cases** with disabled entries in plugins list (legacy npm, legacy dmwork, very-legacy dmwork) — each must return `octo-clawhub` with all residue flags `false`.
- `setupOctoClawHub` helper extended with `*InListDisabled` opts to simulate disk-scan auto-discovered disabled entries.

134/134 tests passing locally; type-check clean.

## Testing

- [x] Unit tests: \`npm test\` → **134/134 passing** (119 prior + 15 new)
- [x] Type-check: \`npx tsc --noEmit\` → clean
- [x] Build: \`npm run build\` → clean
- [x] No production code behavioural change for the happy path — clean systems still detect as `octo-clawhub`. Only fix is reducing false-positive residue flags after successful migration.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes (13 + 3 new cases)
- [x] Updated documentation — N/A (internal helper behaviour change; user-facing fix is doctor no longer false-flagging)
- [x] Followed commit message conventions (Conventional Commits)

## OpenClaw main repo bugs surfaced (not fixed here)

These three are from OpenClaw's `plugins uninstall` command itself; we cannot fix them in our CLI:

1. \`openclaw plugins uninstall\` claims \"Removed: directory\" when npm prune fails (Windows test evidence).
2. \`openclaw plugins uninstall\` only removes one install record when a plugin id has multi-layout installs (extensions + npm; Mac evidence).
3. \`openclaw plugins uninstall\` doesn't clean orphan bindings on the uninstalled channel.

These will be reported upstream to OpenClaw. Our CLI's user-visible alarm (the false-positive residue flag) is what this PR fixes.

## Why this is the right fix instead of \"clean up disk residue ourselves\"

Discussed with the user before writing this PR. Two design directions were considered:

- **Direction A (rejected)**: Have `install` aggressively clean disk files via `Remove-Item` / `rm -rf` to leave zero residue. Rejected because: (a) cross-platform path / permission complexity, (b) the user prefers we stick to commands rather than direct fs operations, (c) doesn't actually fix the underlying OpenClaw uninstall bugs.
- **Direction B (this PR)**: Recognize that disk residue without a cfg entry is functionally inert — OpenClaw won't load disabled plugins, so they can't register a duplicate channel. Tighten the detector to flag only states that have real behavioural impact. Cleanup of leftover bytes becomes a cosmetic follow-up if the user wants it; their bot keeps working either way.

Direction B aligns the detector with reality (cfg + channel + binding state is what matters, not file-system geography) and avoids us papering over OpenClaw bugs with platform-specific fs operations.