### PR TITLE
fix(create-openclaw-octo): hard-abort install on incompatible OpenClaw versions

### DIFF
--- a/create-openclaw-octo/cli/index.ts
+++ b/create-openclaw-octo/cli/index.ts
@@ -14,7 +14,7 @@ import {
 } from "./doctor.js";
 import { runUninstall } from "./uninstall.js";
 import { runRemoveAccount } from "./remove-account.js";
-import { ensureOpenClawCompat, PLUGIN_ID, renderInstallStatusBanner } from "./utils.js";
+import { PLUGIN_ID, renderInstallStatusBanner } from "./utils.js";
 import { getOpenClawVersionStrict, resolvePluginState } from "./openclaw-cli.js";
 import { PLUGIN_VERSION } from "./version.js";
 
@@ -182,7 +182,36 @@ program
   });
 
 export function main(argv?: readonly string[]): void {
-  program.parse(argv);
+  // parseAsync + top-level catch so unhandled errors from any sub-command
+  // surface as a clean message instead of a Node stack trace. Two side
+  // benefits:
+  //   (a) `pluginsInstall()` rewraps ClawHub timeouts with friendly text
+  //       (issue #90) and stashes the raw error in `Error.cause`. Without
+  //       a top-level handler, Node's default unhandled-rejection printer
+  //       walks the cause chain and re-emits the raw upstream stderr —
+  //       which can carry sensitive content. Logging only `err.message`
+  //       keeps `cause` available to programmatic callers / debug runs
+  //       without leaking it to terminal output.
+  //   (b) Plain `Error` thrown from sub-commands no longer prints stack
+  //       frames in normal use; set `OPENCLAW_OCTO_DEBUG=1` to see the
+  //       full chain when debugging.
+  program.parseAsync(argv as string[] | undefined).catch((err: unknown) => {
+    // Defensively handle non-Error rejections (e.g. `Promise.reject(null)`,
+    // `Promise.reject("string")`). Without this guard, reading `err.message`
+    // / `err.cause` on a primitive would throw inside the handler.
+    if (err instanceof Error) {
+      const e = err as Error & { cause?: unknown };
+      if (process.env.OPENCLAW_OCTO_DEBUG) {
+        console.error(e.stack ?? e.message);
+        if (e.cause !== undefined) console.error("Caused by:", e.cause);
+      } else {
+        console.error(e.message);
+      }
+    } else {
+      console.error(String(err));
+    }
+    process.exit(1);
+  });
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/create-openclaw-octo/cli/install.ts
+++ b/create-openclaw-octo/cli/install.ts
@@ -56,6 +56,7 @@ import {
   PLUGIN_ID,
   VERY_LEGACY_PLUGIN_ID,
   ensureOpenClawCompat,
+  requiresClawHubProtocol,
 } from "./utils.js";
 
 export function getLatestClawHubVersion(): string | null {
@@ -116,7 +117,15 @@ export interface InstallOptions {
 }
 
 export async function runInstall(opts: InstallOptions): Promise<void> {
-  ensureOpenClawCompat();
+  // The default install path dispatches via `openclaw plugins install
+  // clawhub:octo`, which requires the `clawhub:` protocol introduced in
+  // OpenClaw v2026.3.22. `--from` accepts arbitrary install specs (local
+  // tarball, file://, http(s), bare npm name, **and** `clawhub:...`); the
+  // version gate must consider the actual spec, not just whether `--from`
+  // was passed — otherwise `--from clawhub:octo` on older OpenClaw would
+  // sneak past the gate and only fail partway through migration.
+  // See issue #90 + PR #91 review.
+  ensureOpenClawCompat({ requireClawHubProtocol: requiresClawHubProtocol(opts.from) });
 
   // ---------------------------------------------------------------------------
   // v2.0.0 npm→ClawHub migration: detect (NOT yet uninstall) any pre-2.0 npm

--- a/create-openclaw-octo/cli/openclaw-cli.test.ts
+++ b/create-openclaw-octo/cli/openclaw-cli.test.ts
@@ -543,6 +543,102 @@ describe("pluginsInstall 3-layer degradation", () => {
     expect(lastArgs).not.toContain("--force");
     expect(lastArgs).not.toContain("--dangerously-force-unsafe-install");
   });
+
+  it("should rewrap ClawHub timeout into a friendly error with upgrade guidance", async () => {
+    const { pluginsInstall } = await loadModule();
+    const upstream = new Error("Command failed: openclaw plugins install clawhub:octo\nClawHub request timed out after 30000ms");
+    (upstream as any).stderr = Buffer.from("ClawHub request timed out after 30000ms");
+    mockExecFileSync.mockImplementation(() => {
+      throw upstream;
+    });
+    let caught: unknown;
+    try {
+      pluginsInstall("clawhub:octo", true, true);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeDefined();
+    expect((caught as Error).message).toMatch(/ClawHub install of "clawhub:octo" timed out/);
+    expect((caught as Error).message).toMatch(/openclaw update/);
+    expect((caught as Error).message).toMatch(/2026\.5\.22/);
+    // Original error preserved on `cause` so callers / loggers can inspect it.
+    expect((caught as { cause?: unknown }).cause).toBe(upstream);
+    // No degradation — timeout is not a "unsupported option" signal.
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  it("should pass through non-timeout, non-option errors unchanged", async () => {
+    const { pluginsInstall } = await loadModule();
+    const upstream = new Error("ENOENT: openclaw not found on PATH");
+    mockExecFileSync.mockImplementation(() => {
+      throw upstream;
+    });
+    expect(() => pluginsInstall("clawhub:octo", true)).toThrow("ENOENT: openclaw not found on PATH");
+  });
+
+  it("should rewrap ClawHub timeout even when it surfaces only on the bare-install fallback after degradation", async () => {
+    // Two unsupported-option errors degrade through the attempts list;
+    // the third (bare install) finally succeeds in reaching the network
+    // and times out. The rewrap must still trigger and the user must NOT
+    // see the raw "ClawHub request timed out" stderr first.
+    const { pluginsInstall } = await loadModule();
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    try {
+      mockExecFileSync
+        .mockImplementationOnce(() => {
+          const err = new Error("unknown option");
+          (err as any).stderr = Buffer.from(
+            "error: unknown option '--dangerously-force-unsafe-install'",
+          );
+          throw err;
+        })
+        .mockImplementationOnce(() => {
+          const err = new Error("unknown option");
+          (err as any).stderr = Buffer.from("error: unknown option '--force'");
+          throw err;
+        })
+        .mockImplementationOnce(() => {
+          const err = new Error(
+            "Command failed: openclaw plugins install clawhub:octo\nClawHub request timed out after 30000ms",
+          );
+          (err as any).stderr = Buffer.from(
+            "ClawHub request timed out after 30000ms\n",
+          );
+          (err as any).stdout = Buffer.from(
+            "Resolving clawhub:octo…\n",
+          );
+          throw err;
+        });
+
+      let caught: unknown;
+      try {
+        // quiet=false to verify replay-suppression for the timeout path.
+        pluginsInstall("clawhub:octo", false, true);
+      } catch (err) {
+        caught = err;
+      }
+
+      expect(mockExecFileSync).toHaveBeenCalledTimes(3);
+      expect((caught as Error).message).toMatch(/ClawHub install of "clawhub:octo" timed out/);
+      expect((caught as Error).message).toMatch(/openclaw update/);
+      expect((caught as Error).message).toMatch(/2026\.5\.22/);
+
+      // Captured stderr from the timeout (raw "ClawHub request timed out…")
+      // must NOT have been replayed to the user — that's the whole point
+      // of the rewrap.
+      const stderrCalls = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
+      expect(stderrCalls).not.toMatch(/ClawHub request timed out/);
+
+      // Progress stdout from the timed-out attempt is still allowed
+      // through (informative, not the noisy banner we're suppressing).
+      const stdoutCalls = stdoutSpy.mock.calls.map((c) => String(c[0])).join("");
+      expect(stdoutCalls).toMatch(/Resolving clawhub:octo/);
+    } finally {
+      stderrSpy.mockRestore();
+      stdoutSpy.mockRestore();
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -797,19 +893,19 @@ describe("detectOpenClawState", () => {
     }
   });
 
-  it("block when version < OPENCLAW_PEER_MIN (2026.4.15)", async () => {
+  it("block when version < OPENCLAW_PEER_MIN (2026.3.22)", async () => {
     const { detectOpenClawState } = await loadModule();
-    mockExecFileSync.mockImplementation(() => "OpenClaw 2026.3.10 (abc1234)\n" as any);
+    mockExecFileSync.mockImplementation(() => "OpenClaw 2026.3.13 (abc1234)\n" as any);
     const state = detectOpenClawState();
     expect(state.kind).toBe("block");
     if (state.kind === "block") {
-      expect(state.version).toBe("2026.3.10");
-      expect(state.reason).toContain("2026.3.10");
-      expect(state.reason).toContain("2026.4.15");
+      expect(state.version).toBe("2026.3.13");
+      expect(state.reason).toContain("2026.3.13");
+      expect(state.reason).toContain("2026.3.22");
     }
   });
 
-  it("warn when peer-min <= version < recommended (2026.5.18)", async () => {
+  it("warn when peer-min <= version < recommended (2026.5.22)", async () => {
     const { detectOpenClawState } = await loadModule();
     mockExecFileSync.mockImplementation(() => "OpenClaw 2026.4.20 (abc1234)\n" as any);
     const state = detectOpenClawState();
@@ -817,24 +913,24 @@ describe("detectOpenClawState", () => {
     if (state.kind === "warn") {
       expect(state.version).toBe("2026.4.20");
       expect(state.reason).toContain("2026.4.20");
-      expect(state.reason).toContain("2026.5.18");
+      expect(state.reason).toContain("2026.5.22");
     }
   });
 
   it("warn at exact peer-min (boundary)", async () => {
     const { detectOpenClawState } = await loadModule();
-    mockExecFileSync.mockImplementation(() => "OpenClaw 2026.4.15 (abc1234)\n" as any);
+    mockExecFileSync.mockImplementation(() => "OpenClaw 2026.3.22 (abc1234)\n" as any);
     const state = detectOpenClawState();
     expect(state.kind).toBe("warn");
   });
 
   it("ok at exact recommended (boundary)", async () => {
     const { detectOpenClawState } = await loadModule();
-    mockExecFileSync.mockImplementation(() => "OpenClaw 2026.5.18 (abc1234)\n" as any);
+    mockExecFileSync.mockImplementation(() => "OpenClaw 2026.5.22 (abc1234)\n" as any);
     const state = detectOpenClawState();
     expect(state.kind).toBe("ok");
     if (state.kind === "ok") {
-      expect(state.version).toBe("2026.5.18");
+      expect(state.version).toBe("2026.5.22");
     }
   });
 

--- a/create-openclaw-octo/cli/openclaw-cli.ts
+++ b/create-openclaw-octo/cli/openclaw-cli.ts
@@ -302,6 +302,30 @@ function isUnsupportedOptionError(err: unknown): boolean {
   );
 }
 
+/**
+ * Check if an error indicates a ClawHub fetch timeout.
+ *
+ * Observed on OpenClaw 4.x behind corporate HTTP proxies: the internal
+ * ClawHub HTTP dispatcher does not honor `http_proxy` / `EnvHttpProxyAgent`,
+ * and the hard-coded 30s budget is not enough. Upstream message:
+ *
+ *   "ClawHub request timed out after 30000ms"
+ *
+ * We catch this in `pluginsInstall()` and rewrap with actionable guidance.
+ * 5.x reportedly fixes the underlying dispatcher; we recommend upgrading.
+ */
+function isClawHubTimeoutError(err: unknown): boolean {
+  const sources = [
+    (err as any)?.stderr?.toString?.(),
+    (err as any)?.stdout?.toString?.(),
+    (err as any)?.message,
+    String(err),
+  ];
+  return sources.some(
+    (s) => s && /ClawHub request timed out/i.test(s),
+  );
+}
+
 function isPluginNotInstalledError(err: unknown): boolean {
   const sources = [
     (err as any)?.stderr?.toString?.(),
@@ -346,6 +370,44 @@ export function pluginsInstall(spec: string, quiet?: boolean, force?: boolean): 
     } catch (err) {
       if (isUnsupportedOptionError(err) && i < attempts.length - 1) {
         continue; // try next degradation level
+      }
+      // Recognize OpenClaw's ClawHub fetch timeout (observed on OpenClaw 4.x
+      // behind corporate proxies — internal dispatcher does not honor
+      // http_proxy / EnvHttpProxyAgent, and the hard-coded 30s budget is
+      // not enough). Rewrap with actionable guidance instead of letting the
+      // raw "ClawHub request timed out after 30000ms" reach the caller's
+      // stack trace. Run BEFORE replaying captured stdout/stderr so the
+      // user only sees the friendly message, not raw "ClawHub request timed
+      // out after 30000ms" first.
+      if (isClawHubTimeoutError(err)) {
+        // Surface progress stdout (e.g. "Downloading...") if any, but skip
+        // stderr because that's where the raw timeout banner lives.
+        if (!quiet) {
+          const stdout = (err as any)?.stdout?.toString?.();
+          if (stdout) process.stdout.write(stdout);
+        }
+        const friendly = new Error(
+          [
+            `ClawHub install of "${spec}" timed out.`,
+            "",
+            "Common causes:",
+            "  - OpenClaw 4.x ClawHub fetch is unreliable behind corporate HTTP proxies",
+            "    (the internal dispatcher ignores http_proxy / NODE_USE_ENV_PROXY).",
+            "    Upstream fixed this in 5.x.",
+            "  - Slow link to clawhub.ai (registry / artifact CDN).",
+            "",
+            "Try:",
+            "  openclaw update                       # upgrade to OpenClaw >= 2026.5.22",
+            "  npx -y create-openclaw-octo install   # retry",
+          ].join("\n"),
+        );
+        // Preserve the original error chain for callers / loggers that need it.
+        // Note: the top-level CLI catch in `cli/index.ts` only prints
+        // `err.message` so the original stderr in `cause` is not leaked to
+        // end users; debug builds (OPENCLAW_OCTO_DEBUG=1) still see the
+        // chain.
+        (friendly as { cause?: unknown }).cause = err;
+        throw friendly;
       }
       // Final attempt failed: replay captured output, then throw
       if (!quiet) {
@@ -1388,16 +1450,22 @@ export type OpenClawState =
   | { kind: "block"; version: string | null; reason: string };
 
 /**
- * Lower bound from package.json peerDependency. Below this the plugin
- * literally cannot register — block.
+ * Hard floor: below this `openclaw plugins install clawhub:<spec>` does
+ * not exist (the `clawhub:` protocol was introduced in OpenClaw v2026.3.22
+ * via upstream commit 91b2800241 "feat: add native clawhub install flows"),
+ * so install will throw `unsupported npm spec: protocol specs are not
+ * allowed` partway through migration. Block at entry instead.
  */
-export const OPENCLAW_PEER_MIN = "2026.4.15";
+export const OPENCLAW_PEER_MIN = "2026.3.22";
 
 /**
- * Recommended floor — version we test against, includes runtime fixes for
- * issue #56 race conditions etc. Below this we warn but allow.
+ * Recommended floor — version we test against. v2026.5.22 includes the
+ * `plugin-sdk-native-resolver.ts` fix (upstream PR #85298) which gives
+ * deterministic resolution for our `openclaw/plugin-sdk/*` subpath imports,
+ * plus better ClawHub fetch reliability behind corporate proxies (observed
+ * during real-world testing). Below this we warn but still allow.
  */
-export const OPENCLAW_RECOMMENDED = "2026.5.18";
+export const OPENCLAW_RECOMMENDED = "2026.5.22";
 
 /**
  * Compare two YYYY.M.PATCH-style versions per integer-segment ordering.

--- a/create-openclaw-octo/cli/utils.test.ts
+++ b/create-openclaw-octo/cli/utils.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { validateAccountId } from "./utils.js";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { requiresClawHubProtocol, validateAccountId } from "./utils.js";
 
 describe("validateAccountId", () => {
   it("should accept valid IDs", () => {
@@ -16,5 +16,163 @@ describe("validateAccountId", () => {
     expect(validateAccountId("bot.name")).toBe(false);
     expect(validateAccountId("bot/name")).toBe(false);
     expect(validateAccountId("bot@name")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// requiresClawHubProtocol() — install spec → version-gate intent
+//
+// Regression coverage for PR #91 review feedback: the prior implementation
+// derived the gate from `!opts.from` alone, which let `install --from
+// clawhub:octo` bypass the hard floor on pre-2026.3.22 OpenClaw and fail
+// partway through migration — the exact failure mode this PR is meant to
+// prevent.
+// ---------------------------------------------------------------------------
+
+describe("requiresClawHubProtocol", () => {
+  it("returns true for the default install path (no --from)", () => {
+    expect(requiresClawHubProtocol()).toBe(true);
+    expect(requiresClawHubProtocol(undefined)).toBe(true);
+  });
+
+  it("returns true for any explicit clawhub: spec via --from", () => {
+    expect(requiresClawHubProtocol("clawhub:octo")).toBe(true);
+    expect(requiresClawHubProtocol("clawhub:openclaw-channel-octo")).toBe(true);
+    expect(requiresClawHubProtocol("clawhub:openclaw-channel-octo@1.0.13")).toBe(true);
+  });
+
+  it("returns false for local tarball paths", () => {
+    expect(requiresClawHubProtocol("/tmp/octo-1.0.13.tgz")).toBe(false);
+    expect(requiresClawHubProtocol("./local-tarball.tgz")).toBe(false);
+    expect(requiresClawHubProtocol("../path/to/octo.tgz")).toBe(false);
+  });
+
+  it("returns false for file:// URLs", () => {
+    expect(requiresClawHubProtocol("file:///abs/path.tgz")).toBe(false);
+  });
+
+  it("returns false for bare npm package names", () => {
+    expect(requiresClawHubProtocol("openclaw-channel-octo")).toBe(false);
+    expect(requiresClawHubProtocol("openclaw-channel-octo@1.0.13")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ensureOpenClawCompat() — version gate
+//
+// Regression coverage for issue #90: the previous soft-warn-only
+// implementation let install proceed past 4 steps of config mutation and die
+// at step 5 with a raw stack trace on truly incompatible OpenClaw versions
+// (e.g. < 2026.3.22, where the `clawhub:` protocol does not exist).
+// We now delegate to detectOpenClawState() and hard-abort on `kind: "block"`.
+// ---------------------------------------------------------------------------
+
+describe("ensureOpenClawCompat", () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let detectSpy: any;
+
+  beforeEach(() => {
+    vi.resetModules();
+    // Replace process.exit with a thrower so the hard-abort path stops
+    // execution without ending the test process. Keep call count assertable.
+    exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`__exit__:${code ?? 0}`);
+    }) as never);
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+    detectSpy?.mockRestore?.();
+  });
+
+  async function loadWithDetect(state: { kind: "ok" | "warn" | "block"; version: string | null; reason?: string }) {
+    const cliMod = await import("./openclaw-cli.js");
+    detectSpy = vi.spyOn(cliMod, "detectOpenClawState").mockReturnValue(state as any);
+    return await import("./utils.js");
+  }
+
+  it("blocks with friendly upgrade guidance when openclaw is too old AND caller requires clawhub: protocol", async () => {
+    const { ensureOpenClawCompat } = await loadWithDetect({
+      kind: "block",
+      version: "2026.3.13",
+      reason: "OpenClaw 2026.3.13 is too old (need >= 2026.3.22)",
+    });
+    expect(() => ensureOpenClawCompat({ requireClawHubProtocol: true })).toThrow(/__exit__:2/);
+    const message = errorSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(message).toMatch(/2026\.3\.13 is too old/);
+    expect(message).toMatch(/openclaw update/);
+    expect(message).toMatch(/Required:.*2026\.3\.22/);
+    expect(message).toMatch(/Recommended:.*2026\.5\.22/);
+  });
+
+  it("warns (does not block) when openclaw is too old AND caller does not require clawhub: protocol", async () => {
+    // Regression for codex review MAJOR #2: ensureOpenClawCompat() was
+    // unconditionally hard-aborting on < OPENCLAW_PEER_MIN, breaking
+    // uninstall and `install --from <local-tarball>` paths that don't
+    // need the `clawhub:` protocol.
+    const { ensureOpenClawCompat } = await loadWithDetect({
+      kind: "block",
+      version: "2026.3.13",
+      reason: "OpenClaw 2026.3.13 is too old (need >= 2026.3.22)",
+    });
+    ensureOpenClawCompat(); // default: requireClawHubProtocol = false
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+    const warning = warnSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(warning).toMatch(/2026\.3\.13 is too old/);
+    expect(warning).toMatch(/clawhub:.*unavailable/);
+    expect(warning).toMatch(/--from.*available/);
+  });
+
+  it("blocks with install guidance when openclaw is missing (regardless of requireClawHubProtocol)", async () => {
+    const { ensureOpenClawCompat } = await loadWithDetect({
+      kind: "block",
+      version: null,
+      reason: "OpenClaw is not installed or not on PATH",
+    });
+    expect(() => ensureOpenClawCompat()).toThrow(/__exit__:1/);
+    const message = errorSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(message).toMatch(/openclaw not found/);
+    expect(message).toMatch(/npm i -g openclaw/);
+  });
+
+  it("blocks with install guidance when openclaw is missing even when not requiring clawhub:", async () => {
+    const { ensureOpenClawCompat } = await loadWithDetect({
+      kind: "block",
+      version: null,
+      reason: "OpenClaw is not installed or not on PATH",
+    });
+    expect(() => ensureOpenClawCompat({ requireClawHubProtocol: false })).toThrow(/__exit__:1/);
+  });
+
+  it("warns but does not exit when below recommended floor", async () => {
+    const { ensureOpenClawCompat } = await loadWithDetect({
+      kind: "warn",
+      version: "2026.4.23",
+      reason: "OpenClaw 2026.4.23 is older than recommended 2026.5.22",
+    });
+    ensureOpenClawCompat({ requireClawHubProtocol: true });
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled();
+    const warning = warnSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(warning).toMatch(/older than recommended/);
+    expect(warning).toMatch(/openclaw update/);
+  });
+
+  it("is silent when version meets recommended floor", async () => {
+    const { ensureOpenClawCompat } = await loadWithDetect({
+      kind: "ok",
+      version: "2026.5.27",
+    });
+    ensureOpenClawCompat({ requireClawHubProtocol: true });
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 });

--- a/create-openclaw-octo/cli/utils.ts
+++ b/create-openclaw-octo/cli/utils.ts
@@ -7,7 +7,12 @@
  */
 
 import { createInterface } from "node:readline";
-import { getOpenClawVersion, getOpenClawVersionStrict, detectInstallState, detectOpenClawState } from "./openclaw-cli.js";
+import {
+  detectInstallState,
+  detectOpenClawState,
+  OPENCLAW_PEER_MIN,
+  OPENCLAW_RECOMMENDED,
+} from "./openclaw-cli.js";
 import {
   PLUGIN_ID, CHANNEL_ID,
   NPM_PACKAGE_NAME, CLAWHUB_INSTALL_SPEC,
@@ -34,7 +39,6 @@ export {
 // CLI-only constants
 // ---------------------------------------------------------------------------
 
-export const MIN_OPENCLAW_VERSION = "2026.4.15";
 export const RECOMMENDED_DM_SCOPE = "per-account-channel-peer";
 
 // ---------------------------------------------------------------------------
@@ -57,46 +61,111 @@ export function channelConfigPathFor(channelId: string, ...parts: string[]): str
 // ---------------------------------------------------------------------------
 
 /**
- * Compare two semver-like version strings. Returns -1, 0, or 1.
+ * Caller intent for `ensureOpenClawCompat()`.
  *
- * Intentionally date-only: assumes inputs of the shape `2026.4.15` (matching
- * OpenClaw's `YYYY.M.PATCH` versioning). Prerelease suffixes (`2026.4.15-rc.1`)
- * would Number()-cast to NaN and break ordering. If MIN_OPENCLAW_VERSION ever
- * needs prerelease handling, switch this to `semver.compare`.
+ * `requireClawHubProtocol`: caller will dispatch through `openclaw plugins
+ * install clawhub:<spec>`, which only exists on OpenClaw v2026.3.22+
+ * (upstream commit 91b2800241). Setting this to `true` adds a hard floor:
+ * versions below `OPENCLAW_PEER_MIN` exit with a friendly upgrade message
+ * before any config is touched, instead of letting OpenClaw bail mid-flow
+ * with `unsupported npm spec: protocol specs are not allowed`.
+ *
+ * Defaults to `false` so commands that don't reach the `clawhub:` path
+ * (uninstall, `install --from <local-tarball>`, bind, etc.) still work on
+ * older OpenClaw — they'll see a softer warning instead of a hard abort.
  */
-function compareVersions(a: string, b: string): number {
-  const pa = a.split(".").map(Number);
-  const pb = b.split(".").map(Number);
-  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
-    const va = pa[i] ?? 0;
-    const vb = pb[i] ?? 0;
-    if (va < vb) return -1;
-    if (va > vb) return 1;
-  }
-  return 0;
+export interface EnsureOpenClawCompatOptions {
+  requireClawHubProtocol?: boolean;
 }
 
 /**
- * Check that openclaw is available. Exits if not found.
- * Warns (but continues) if version is below recommended minimum.
+ * Decide whether an install spec resolves through `openclaw plugins
+ * install clawhub:<…>` (which requires OpenClaw v2026.3.22+).
+ *
+ * - undefined / empty → default install path uses `clawhub:octo`.
+ * - any spec starting with `clawhub:` → goes through the same `clawhub:`
+ *   plugin install machinery and inherits the same version requirement
+ *   (regression for PR #91 review: `--from clawhub:octo` previously
+ *   bypassed the hard gate and ended up failing partway into migration).
+ * - everything else (npm bare names, file paths, file://, http(s) URLs,
+ *   local tarballs) → does NOT require `clawhub:` and is allowed on
+ *   older OpenClaw with a softer warning.
  */
-export function ensureOpenClawCompat(): void {
-  let version: string | null = null;
-  try {
-    version = getOpenClawVersionStrict();
-  } catch (err) {
-    console.error(err instanceof Error ? err.message : String(err));
-    process.exit(1);
-  }
-  if (!version) {
-    console.error(
-      "Error: openclaw not found. Install it first: npm i -g openclaw",
-    );
-    process.exit(1);
-  }
-  if (compareVersions(version, MIN_OPENCLAW_VERSION) < 0) {
+export function requiresClawHubProtocol(installSpec?: string): boolean {
+  if (!installSpec) return true;
+  return installSpec.startsWith("clawhub:");
+}
+
+/**
+ * Check that openclaw is available and version-compatible. Behaviour
+ * depends on `opts.requireClawHubProtocol`:
+ *
+ * - openclaw missing: always exit 1 with install guidance.
+ * - openclaw < `OPENCLAW_PEER_MIN`:
+ *     - `requireClawHubProtocol === true`: exit 2 with upgrade guidance,
+ *       before any config mutation. (Why: `clawhub:` spec was introduced
+ *       in v2026.3.22; older runtimes throw `unsupported npm spec`
+ *       partway through migration.)
+ *     - otherwise: warn that clawhub-based ops are unavailable, but allow
+ *       the caller to proceed (uninstall, --from local tarball, etc.).
+ * - openclaw < `OPENCLAW_RECOMMENDED`: warn, allow.
+ * - openclaw >= `OPENCLAW_RECOMMENDED`: silent.
+ *
+ * Delegates to `detectOpenClawState()` so this function and the rest of
+ * the CLI agree on a single version-policy source of truth — see
+ * `openclaw-cli.ts`. Previously this function maintained a parallel
+ * `MIN_OPENCLAW_VERSION` constant + local `compareVersions()` helper plus
+ * a soft-warn-only path; that meant install proceeded past 4 steps of
+ * config mutation before dying at step 5 with a raw stack trace on truly
+ * incompatible versions (e.g. < 2026.3.22 has no `clawhub:` protocol
+ * support). See issue #90.
+ */
+export function ensureOpenClawCompat(
+  opts: EnsureOpenClawCompatOptions = {},
+): void {
+  const state = detectOpenClawState();
+  if (state.kind === "block") {
+    if (state.version === null) {
+      console.error(
+        [
+          "Error: openclaw not found. Install it first:",
+          "",
+          "  npm i -g openclaw",
+        ].join("\n"),
+      );
+      process.exit(1);
+    }
+    if (opts.requireClawHubProtocol) {
+      console.error(
+        [
+          `Error: ${state.reason}.`,
+          "",
+          `Required:    OpenClaw >= ${OPENCLAW_PEER_MIN}`,
+          `Recommended: OpenClaw >= ${OPENCLAW_RECOMMENDED}`,
+          "",
+          "Run:",
+          "  openclaw update",
+          "",
+          "Then re-run this command.",
+        ].join("\n"),
+      );
+      process.exit(2);
+    }
+    // Caller doesn't need the clawhub: protocol path: surface the version
+    // shortfall as a warning so e.g. uninstall and `install --from` still
+    // work on pre-2026.3.22 hosts.
     console.warn(
-      `Warning: OpenClaw ${version} is older than recommended ${MIN_OPENCLAW_VERSION}. Some features may not work correctly. Consider upgrading.`,
+      [
+        `Warning: ${state.reason}.`,
+        `(clawhub:-based install is unavailable on this OpenClaw version.`,
+        ` Local-tarball install (--from) and uninstall remain available.)`,
+      ].join("\n"),
+    );
+    return;
+  }
+  if (state.kind === "warn") {
+    console.warn(
+      `Warning: ${state.reason}. Consider upgrading: openclaw update`,
     );
   }
 }


### PR DESCRIPTION
## Summary

Fixes the install entry point so it hard-aborts with friendly guidance on
truly incompatible OpenClaw versions, instead of running through 4 steps
of config mutation and dying at step 5 with a raw Node stack trace. Also
rewraps the ClawHub fetch timeout (observed on OpenClaw 4.x behind
corporate proxies) into actionable upgrade guidance, and adds a top-level
CLI catch so unhandled errors don't leak `Error.cause` (which can carry
upstream stderr) to terminal output.

## Related Issue

Fixes #90

## Changes

- **`cli/utils.ts`** — replace `ensureOpenClawCompat()` with a thin
  wrapper around the existing `detectOpenClawState()` from
  `openclaw-cli.ts`. Accepts `{ requireClawHubProtocol }` so callers
  that don't reach the `clawhub:` path (uninstall, `install --from
  <local-tarball>`, bind, etc.) get a warn rather than a hard abort.
  Drops the duplicated `MIN_OPENCLAW_VERSION` + local `compareVersions()`.
- **`cli/install.ts`** — `runInstall` passes
  `requireClawHubProtocol: !opts.from`. Local-tarball flows still work
  on pre-2026.3.22 OpenClaw.
- **`cli/openclaw-cli.ts`** —
  - `OPENCLAW_PEER_MIN`: `"2026.4.15"` → `"2026.3.22"` (the actual
    technical hard floor — first release with `clawhub:` protocol,
    upstream commit `91b2800241`).
  - `OPENCLAW_RECOMMENDED`: `"2026.5.18"` → `"2026.5.22"` (includes
    upstream PR `#85298` `plugin-sdk-native-resolver.ts` for
    deterministic resolution of `openclaw/plugin-sdk/*` subpath imports
    we rely on, plus observed reliability improvements for ClawHub
    fetch behind corporate proxies).
  - `pluginsInstall()`: catch `ClawHub request timed out after
    30000ms` (observed on OpenClaw 4.x behind corporate proxies — the
    internal dispatcher ignores `http_proxy` / `NODE_USE_ENV_PROXY`)
    and rewrap into a friendly `Error` pointing to `openclaw update`.
    Recognition runs **before** the captured-stderr replay so users
    only see the friendly message, not the raw timeout banner first.
    Original error preserved on `Error.cause`.
- **`cli/index.ts`** — switch from `program.parse()` to
  `parseAsync().catch(...)`. Top-level handler prints `err.message` (or
  full stack + cause when `OPENCLAW_OCTO_DEBUG=1`) then `process.exit(1)`.
  Without this, Node's default unhandled-rejection printer walks
  `Error.cause` and re-emits the upstream stderr — which can carry
  sensitive content.

## Testing

- [x] Unit tests added/updated
  - `cli/utils.test.ts`: 5 cases covering `ensureOpenClawCompat()`
    block-with-clawhub-required / warn-without-clawhub-required /
    block-when-missing (both with and without `requireClawHubProtocol`)
    / warn-below-recommended / silent-at-recommended.
  - `cli/openclaw-cli.test.ts`: timeout-rewrap on first attempt,
    timeout-rewrap on the bare-install fallback after 2 layers of
    unsupported-option degradation (with explicit assertion that the
    raw `ClawHub request timed out` stderr is **not** replayed before
    the friendly message), and pass-through for unrelated errors.
  - Existing `detectOpenClawState` boundary tests updated to the new
    `PEER_MIN` / `RECOMMENDED` values.
  - Total: **143 tests passing**, `tsc --noEmit` clean.
- [x] Manually verified
  - OpenClaw 2026.3.13 host (qiletest2): previously crashed at step 5
    with stack trace; now blocks at entry with friendly upgrade
    guidance. Uninstall on the same host stays available (warn, not
    block).
  - OpenClaw 2026.4.23 host behind corporate proxy (qiletest3):
    previously crashed at step 5 with raw `ClawHub request timed out
    after 30000ms`; now emits rewrapped upgrade guidance with no raw
    banner preceding it. After upgrading to OpenClaw 5.27, install
    runs through cleanly.
  - OpenClaw 2026.5.26+ host (qiletest1, mac, win): unchanged
    behaviour (silent / pass).

## Codex Review

The patch was reviewed by an external Codex pass before push. Findings
incorporated into this same commit (amended):

- **MAJOR #1**: top-level `parseAsync().catch(...)` added in `index.ts`
  to prevent `Error.cause` from leaking upstream stderr through Node's
  default unhandled-rejection printer.
- **MAJOR #2**: `requireClawHubProtocol` option added so the hard
  abort doesn't over-block uninstall / `install --from` paths that
  don't actually use the `clawhub:` protocol.
- **MINOR #3**: timeout recognition moved before the captured-stderr
  replay so users don't see the raw timeout banner first.
- **MINOR #5**: added a `last-attempt-timeout-after-degradation`
  test case.

Two findings deferred to follow-up issues (out of scope for this PR):

- **MINOR #4**: non-`ENOENT` `getOpenClawVersion` failures (permission
  errors, broken shims) currently fold into the "openclaw not found"
  branch. Will need a `detectOpenClawState()` semantic change to surface
  the probe failure reason — file separately.
- **Manifest mismatch**: `OPENCLAW_PEER_MIN = "2026.3.22"` is now stricter
  than `package.json` `peerDependencies.openclaw`. (Note: this package
  doesn't currently declare `peerDependencies.openclaw`; the prior
  assumption traced to the sibling plugin repo.) Worth re-aligning if /
  when we add a peer declaration here.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation (no user-facing docs change in this PR;
      behavior is purely internal CLI ergonomics — no README update needed)
- [x] Followed commit message conventions (Conventional Commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)