### PR TITLE
fix(create-openclaw-octo): prune stale npm package.json residue after npm-legacy uninstall

### DIFF
--- a/create-openclaw-octo/cli/install.test.ts
+++ b/create-openclaw-octo/cli/install.test.ts
@@ -483,6 +483,109 @@ describe("runInstall — update scenario", () => {
     expect(didCallGatewayRestart(calls)).toBe(true);
   });
 
+  it("legacy npm cleanup also prunes the package from ~/.openclaw/npm/package.json (issue #94)", async () => {
+    // End-to-end coverage that `runInstall()` actually invokes the
+    // manifest-residue cleanup after a successful legacy npm uninstall.
+    // Without this assertion, the helper unit tests would keep passing
+    // even if the call site in install.ts were dropped.
+    const fs = await import("node:fs");
+    const mockReadFileSync = vi.mocked(fs.readFileSync);
+    const mockExistsSync = vi.mocked(fs.existsSync);
+    const mockWriteFileSync = vi.mocked(fs.writeFileSync);
+    const mockRenameSync = vi.mocked(fs.renameSync);
+
+    mockReadFileSync.mockImplementation((path) => {
+      const p = String(path);
+      if (p.endsWith("openclaw.json")) {
+        return JSON.stringify({
+          plugins: {
+            entries: {
+              "openclaw-channel-octo": { enabled: true },
+              octo: { enabled: true },
+            },
+            installs: {
+              "openclaw-channel-octo": { source: "npm", version: "1.0.0" },
+              octo: { source: "clawhub", version: "1.0.7" },
+            },
+            allow: ["openclaw-channel-octo", "octo"],
+          },
+        });
+      }
+      if (p.endsWith("package.json")) {
+        // Mirror the manifest shape OpenClaw leaves behind after a Path B
+        // (npm-legacy) install — `node_modules/openclaw-channel-octo/` has
+        // been removed but the dependency entry persists.
+        return JSON.stringify({
+          name: "openclaw-managed",
+          private: true,
+          dependencies: {
+            "openclaw-channel-octo": "^1.0.0",
+          },
+        });
+      }
+      return "{}";
+    });
+    // Both the ClawHub plugin extension dir AND the npm/package.json need to
+    // appear to exist so isHealthyInstall("octo") returns true and the
+    // residue helper proceeds past its existsSync guard.
+    mockExistsSync.mockImplementation((path) => {
+      return (
+        pathEndsWith(path, "extensions/octo") ||
+        String(path).endsWith("package.json")
+      );
+    });
+
+    const { runInstall } = await loadInstall();
+
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const a = args as string[];
+      if (a[0] === "config" && a[1] === "file") return "/home/user/.openclaw/openclaw.json";
+      if (a[0] === "--version") return "OpenClaw 2026.5.7\n";
+      if (a[0] === "plugins" && a[1] === "inspect") {
+        const id = a[2];
+        if (id === "openclaw-channel-octo") {
+          return JSON.stringify({
+            plugin: { id: "openclaw-channel-octo", version: "1.0.0", enabled: true },
+          });
+        }
+        return inspectDispatch(a, {
+          id: "octo",
+          version: "1.0.7",
+          latestVersion: "1.0.7",
+          enabled: true,
+        });
+      }
+      if (a[0] === "plugins" && (a[1] === "uninstall" || a[1] === "disable")) return "";
+      if (a[0] === "gateway" && a[1] === "restart") return "";
+      return "";
+    });
+
+    await runInstall({ force: false, dev: false });
+
+    // The cleaned manifest must be staged to a `.tmp` sibling and then
+    // promoted via rename — this is the atomic-write contract of
+    // cleanNpmPackageJsonResidue.
+    const manifestTmpWrites = mockWriteFileSync.mock.calls.filter((c) =>
+      String(c[0]).endsWith("package.json.tmp"),
+    );
+    expect(manifestTmpWrites.length).toBeGreaterThan(0);
+
+    const writtenManifest = JSON.parse(String(manifestTmpWrites[0][1]));
+    // The stale dep entry must be gone. Other top-level fields (name,
+    // private) must survive; the now-empty dependencies section may either
+    // be dropped or present-but-empty depending on helper internals — we
+    // assert the contract that matters (the entry is gone).
+    expect(writtenManifest.dependencies?.["openclaw-channel-octo"]).toBeUndefined();
+    expect(writtenManifest.name).toBe("openclaw-managed");
+    expect(writtenManifest.private).toBe(true);
+
+    // And the tmp file must have been promoted into place.
+    const manifestRenames = mockRenameSync.mock.calls.filter((c) =>
+      String(c[0]).endsWith("package.json.tmp") && String(c[1]).endsWith("package.json"),
+    );
+    expect(manifestRenames.length).toBeGreaterThan(0);
+  });
+
   it("legacy npm cleanup preserves channels.octo + bindings(channel=octo) (P0-2 regression)", async () => {
     // PR #37 review P0-2: `openclaw plugins uninstall openclaw-channel-octo`
     // ALSO removes channels.octo as a side effect (both plugins own channel

--- a/create-openclaw-octo/cli/install.ts
+++ b/create-openclaw-octo/cli/install.ts
@@ -36,6 +36,7 @@ import {
   pluginsInspect,
   pluginsInstall,
   pluginsUninstall,
+  cleanNpmPackageJsonResidue,
   pluginsUpdate,
   readConfigFromFile,
   removeBindingsFromFile,
@@ -294,6 +295,14 @@ export async function runInstall(opts: InstallOptions): Promise<void> {
       }
       try {
         pluginsUninstall(NPM_PACKAGE_NAME, true);
+
+        // OpenClaw's uninstall removes the node_modules/<pkg>/ directory but
+        // leaves a stale `dependencies."openclaw-channel-octo": "^1.0.0"` entry
+        // in `~/.openclaw/npm/package.json`. Any later `npm install` against
+        // that manifest (doctor repair, manual command, host pull) would
+        // resurrect the v1.0.0 plugin weeks after this upgrade — see #94.
+        // Prune the manifest entry now, while we still own the migration.
+        cleanNpmPackageJsonResidue(NPM_PACKAGE_NAME);
 
         // RESTORE channels.octo + bindings (openclaw uninstall removed them as
         // a side effect; we kept a snapshot above)

--- a/create-openclaw-octo/cli/openclaw-cli.test.ts
+++ b/create-openclaw-octo/cli/openclaw-cli.test.ts
@@ -1587,3 +1587,165 @@ describe("getConfigFilePathSafe (Windows relative path)", () => {
     expect(result).toBe(RESOLVED_CFG_PATH);
   });
 });
+
+// ---------------------------------------------------------------------------
+// cleanNpmPackageJsonResidue — issue #94 regression coverage
+//
+// OpenClaw's `plugins uninstall` removes ~/.openclaw/npm/node_modules/<pkg>/
+// but leaves the entry under ~/.openclaw/npm/package.json `dependencies`,
+// which lets a later `npm install` resurrect the old plugin. This helper
+// prunes the manifest entry; here we lock down the cases that matter.
+// ---------------------------------------------------------------------------
+
+describe("cleanNpmPackageJsonResidue", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function setupManifest(initial: Record<string, any> | null): {
+    existsSync: any;
+    readFileSync: any;
+    writeFileSync: any;
+    renameSync: any;
+  } {
+    return {
+      existsSync: vi.fn((p: any) => {
+        const path = String(p);
+        // openclaw.json absent → getConfigFilePathSafe falls back to
+        // <homedir>/.openclaw/openclaw.json; the npm/package.json sibling is
+        // what we toggle on `initial !== null`.
+        if (path.endsWith("package.json")) return initial !== null;
+        return false;
+      }),
+      readFileSync: vi.fn(() => JSON.stringify(initial ?? {})),
+      writeFileSync: vi.fn(),
+      renameSync: vi.fn(),
+    };
+  }
+
+  async function loadWithMocks(initial: Record<string, any> | null) {
+    const mocks = setupManifest(initial);
+    vi.resetModules();
+    vi.doMock("node:fs", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:fs")>();
+      return {
+        ...actual,
+        existsSync: mocks.existsSync,
+        readFileSync: mocks.readFileSync,
+        writeFileSync: mocks.writeFileSync,
+        copyFileSync: vi.fn(),
+        renameSync: mocks.renameSync,
+      };
+    });
+    const mod = await import("./openclaw-cli.js");
+    return { mod, ...mocks };
+  }
+
+  it("removes the package from dependencies and writes the manifest atomically", async () => {
+    const { mod, writeFileSync, renameSync } = await loadWithMocks({
+      name: "openclaw-managed",
+      private: true,
+      dependencies: {
+        "openclaw-channel-octo": "^1.0.0",
+        "some-other-dep": "^2.0.0",
+      },
+    });
+    mod.cleanNpmPackageJsonResidue("openclaw-channel-octo");
+
+    expect(writeFileSync).toHaveBeenCalledTimes(1);
+    expect(renameSync).toHaveBeenCalledTimes(1);
+    const [tmpPath, content] = writeFileSync.mock.calls[0] as [string, string];
+    expect(tmpPath).toMatch(/package\.json\.tmp$/);
+    const written = JSON.parse(content);
+    expect(written.dependencies).not.toHaveProperty("openclaw-channel-octo");
+    expect(written.dependencies).toHaveProperty("some-other-dep");
+    // Other top-level fields preserved.
+    expect(written.name).toBe("openclaw-managed");
+    expect(written.private).toBe(true);
+  });
+
+  it("removes the package from devDependencies and peerDependencies too", async () => {
+    const { mod, writeFileSync } = await loadWithMocks({
+      devDependencies: { "openclaw-channel-octo": "^1.0.0" },
+      peerDependencies: { "openclaw-channel-octo": "^1.0.0" },
+    });
+    mod.cleanNpmPackageJsonResidue("openclaw-channel-octo");
+
+    expect(writeFileSync).toHaveBeenCalledTimes(1);
+    const written = JSON.parse(writeFileSync.mock.calls[0][1] as string);
+    expect(written).not.toHaveProperty("devDependencies");
+    expect(written).not.toHaveProperty("peerDependencies");
+  });
+
+  it("deletes a now-empty dependencies section instead of leaving an empty object", async () => {
+    const { mod, writeFileSync } = await loadWithMocks({
+      dependencies: { "openclaw-channel-octo": "^1.0.0" },
+    });
+    mod.cleanNpmPackageJsonResidue("openclaw-channel-octo");
+
+    const written = JSON.parse(writeFileSync.mock.calls[0][1] as string);
+    expect(written).not.toHaveProperty("dependencies");
+  });
+
+  it("is a no-op when the package is absent (no write, no rename)", async () => {
+    const { mod, writeFileSync, renameSync } = await loadWithMocks({
+      dependencies: { "some-other-dep": "^2.0.0" },
+    });
+    mod.cleanNpmPackageJsonResidue("openclaw-channel-octo");
+
+    expect(writeFileSync).not.toHaveBeenCalled();
+    expect(renameSync).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when the manifest file does not exist", async () => {
+    const { mod, writeFileSync, renameSync, readFileSync } =
+      await loadWithMocks(null);
+    mod.cleanNpmPackageJsonResidue("openclaw-channel-octo");
+
+    expect(readFileSync).not.toHaveBeenCalled();
+    expect(writeFileSync).not.toHaveBeenCalled();
+    expect(renameSync).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op (and does not throw) when the manifest is malformed JSON", async () => {
+    // Pre-prime with valid JSON to satisfy setupManifest's mock, then
+    // override readFileSync to return garbage.
+    const { mod, writeFileSync, renameSync, readFileSync } = await loadWithMocks({
+      dependencies: { "openclaw-channel-octo": "^1.0.0" },
+    });
+    readFileSync.mockReturnValue("{ this is not valid json");
+
+    expect(() =>
+      mod.cleanNpmPackageJsonResidue("openclaw-channel-octo"),
+    ).not.toThrow();
+    expect(writeFileSync).not.toHaveBeenCalled();
+    expect(renameSync).not.toHaveBeenCalled();
+  });
+
+  it("warns (but does not throw) when manifest write fails — keeps caller's main flow intact", async () => {
+    // Codex review (MINOR #2): silent IO failure would leave the residue in
+    // place while install reports success. Warn loudly so the user knows to
+    // clean up manually.
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const { mod, writeFileSync } = await loadWithMocks({
+        dependencies: { "openclaw-channel-octo": "^1.0.0" },
+      });
+      writeFileSync.mockImplementation(() => {
+        throw new Error("EACCES: permission denied");
+      });
+
+      expect(() =>
+        mod.cleanNpmPackageJsonResidue("openclaw-channel-octo"),
+      ).not.toThrow();
+
+      expect(warnSpy).toHaveBeenCalled();
+      const warning = warnSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+      expect(warning).toMatch(/openclaw-channel-octo/);
+      expect(warning).toMatch(/EACCES|permission denied/);
+      expect(warning).toMatch(/manually/);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});

--- a/create-openclaw-octo/cli/openclaw-cli.ts
+++ b/create-openclaw-octo/cli/openclaw-cli.ts
@@ -7,7 +7,7 @@
 import { execFileSync, execSync } from "node:child_process";
 import { readFileSync, writeFileSync, copyFileSync, existsSync, rmSync, readdirSync, statSync, renameSync } from "node:fs";
 import { homedir } from "node:os";
-import { resolve } from "node:path";
+import { resolve, dirname } from "node:path";
 import { CHANNEL_ID, PLUGIN_ID, NPM_PACKAGE_NAME, LEGACY_PLUGIN_ID, LEGACY_CHANNEL_ID, VERY_LEGACY_PLUGIN_ID } from "./constants.js";
 
 /**
@@ -941,6 +941,83 @@ export function removeChannelConfigFromFile(channelId: string = CHANNEL_ID): voi
     }
   } catch {
     // best effort
+  }
+}
+
+/**
+ * Best-effort cleanup of a stale plugin entry from `~/.openclaw/npm/package.json`.
+ *
+ * Background: when OpenClaw uninstalls a plugin that was originally installed
+ * via the npm-legacy path (`openclaw plugins install <bare-name>`, which
+ * materialises in `~/.openclaw/npm/node_modules/<pkg>/`), the underlying
+ * `node_modules/<pkg>/` directory is removed, but the entry under
+ * `~/.openclaw/npm/package.json` `dependencies` is NOT pruned. The manifest
+ * therefore still lists the package as a dependency.
+ *
+ * If any subsequent flow re-runs `npm install` against that manifest (doctor
+ * repair, manual user command, host-side plugin pull, etc.), the stale
+ * version resurrects in `node_modules`, gets discovered by OpenClaw at the
+ * next gateway restart, and re-registers — surfacing weeks after what the
+ * user thought was a successful upgrade.
+ *
+ * This helper removes the named package from `dependencies` (and
+ * `devDependencies` / `peerDependencies` if present) and writes the manifest
+ * back atomically. Best-effort — silently no-ops when the manifest is
+ * missing, malformed, or doesn't list the package.
+ *
+ * See issue #94.
+ */
+export function cleanNpmPackageJsonResidue(packageName: string): void {
+  const SECTIONS = ["dependencies", "devDependencies", "peerDependencies"] as const;
+  let pkgJsonPath: string | null = null;
+  let pkg: Record<string, any> | null = null;
+
+  // Phase 1 — read + parse + plan. All failures here collapse to a silent
+  // no-op: a missing manifest (the user never used the npm-legacy layout) or
+  // a malformed manifest (something else owns it) is not actionable for the
+  // caller and not the residue case we're trying to fix.
+  try {
+    const openclawHomeDir = dirname(getConfigFilePathSafe());
+    pkgJsonPath = resolve(openclawHomeDir, "npm", "package.json");
+    if (!existsSync(pkgJsonPath)) return;
+
+    const raw = readFileSync(pkgJsonPath, "utf-8");
+    pkg = JSON.parse(raw) as Record<string, any>;
+  } catch {
+    return;
+  }
+
+  let changed = false;
+  for (const section of SECTIONS) {
+    const deps = pkg[section];
+    if (deps && typeof deps === "object" && !Array.isArray(deps) && packageName in deps) {
+      delete deps[packageName];
+      changed = true;
+      // Drop the section entirely if it becomes empty, to keep the manifest tidy.
+      if (Object.keys(deps).length === 0) delete pkg[section];
+    }
+  }
+
+  if (!changed) return;
+
+  // Phase 2 — write. Failures here are different: the residue is real and
+  // we just failed to evict it. Warn the user so they can clean up manually
+  // (or at least know to watch for the v1.0.0 plugin resurrecting later),
+  // but don't throw — the broader install/uninstall flow has already
+  // completed everything else successfully and shouldn't fail over a
+  // best-effort cleanup. See PR #91 codex review MINOR #2.
+  try {
+    const tmpPath = pkgJsonPath + ".tmp";
+    writeFileSync(tmpPath, JSON.stringify(pkg, null, 2) + "\n", "utf-8");
+    renameSync(tmpPath, pkgJsonPath);
+  } catch (err) {
+    console.warn(
+      [
+        `Warning: could not prune "${packageName}" from ${pkgJsonPath} (${(err as Error).message ?? String(err)}).`,
+        `  The dependency entry remains in the npm manifest even though the package has been uninstalled.`,
+        `  If a later \`npm install\` resurrects the old version, remove the entry manually and re-run install.`,
+      ].join("\n"),
+    );
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes a latent corruption mode where a Path B (npm-legacy) upgrade succeeds visibly but leaves a stale dependency entry in `~/.openclaw/npm/package.json`. Any later `npm install` against that manifest resurrects the v1.0.0 plugin in `node_modules/`, OpenClaw discovers and re-registers it at the next gateway restart, and the user sees the "ghost" of an old version weeks after they thought the upgrade was complete.

## Related Issue

Fixes #94

## Changes

- **`cli/openclaw-cli.ts`** — add `cleanNpmPackageJsonResidue(packageName)`. Removes the named entry from `dependencies` / `devDependencies` / `peerDependencies`, drops a section that becomes empty, atomic-writes the manifest back (`<path>.tmp` + rename). Failure modes are split:
  - **read-side** (missing file / malformed JSON) → silent no-op. Not actionable for the caller; these aren't the residue case.
  - **write-side** (permission denied / rename failure) → `console.warn` so the user knows the residue is still in place. Main flow never throws — the broader install/uninstall has already succeeded.
- **`cli/install.ts`** — invoke the helper in the npm-legacy uninstall block, immediately after `pluginsUninstall(NPM_PACKAGE_NAME, true)` succeeds and before the saved channels/bindings restore.
- **`cli/openclaw-cli.test.ts`** — 7 unit cases: present in deps, present in dev + peer, now-empty section deletion, package absent (no write), manifest missing (no write), malformed JSON (no write/no throw), write failure (warn but no throw).
- **`cli/install.test.ts`** — end-to-end coverage that `runInstall()` actually invokes the cleanup. Locks the call site so it can't be silently dropped without a failing test (Codex review MINOR #3).

## Testing

- [x] Unit tests added/updated — `cli/openclaw-cli.test.ts` (7 cases for `cleanNpmPackageJsonResidue`), `cli/install.test.ts` (end-to-end assertion in the legacy npm cleanup scenario).
- [x] Manually verified — Path B (Windows) test host: pre-fix the residue persisted after `pluginsUninstall`; with this fix the entry is removed alongside the directory removal.
- Total: **156 tests passing**, `tsc --noEmit` clean.

## Codex Review

The patch was reviewed by an external Codex pass before push. Findings on `84898ce` (the initial commit):

- **MINOR #2** (silent IO failure on write): addressed in the amended commit `f985e61` — write-side failures now `console.warn` so the user knows the residue persists.
- **MINOR #3** (no end-to-end assertion): addressed in the amended commit — `install.test.ts` now asserts the cleanup runs from within `runInstall()`.
- **MINOR #1** (concurrent-write race on the same manifest): not addressed in this PR. Behavior matches the existing `writeConfigAtomic` pattern in the same file — race-hardening would touch all atomic-write call sites and belongs in its own focused PR.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation (no user-facing docs change — internal cleanup helper, no behavioural surface for end users beyond the absent ghost-version reappearance)
- [x] Followed commit message conventions (Conventional Commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)