### PR TITLE
fix(create-openclaw-octo): thread --from <spec> log tag through migration / deadlock paths

### DIFF
--- a/create-openclaw-octo/cli/install-migration.test.ts
+++ b/create-openclaw-octo/cli/install-migration.test.ts
@@ -910,3 +910,141 @@ describe("runInstall — deadlock scenario (channels.octo without plugin)", () =
     expect(state.cfg.plugins.entries["octo"]?.enabled).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// --from <spec> log tagging across migration paths — issue #95 regression
+//
+// `--from` is propagated to `pluginsInstall(spec)` internally on every
+// path (rebrand / legacy-to-octo / deadlock), but the matching "Installing
+// octo..." log line previously dropped the spec suffix on migration paths
+// while keeping it on the simple update path. That made operators
+// debugging a `--from`-driven migration run unable to confirm from the
+// log which spec was actually used. The fix threads `tagLabel` through
+// `runMigration` and `runDeadlockRepair`.
+// ---------------------------------------------------------------------------
+
+describe("--from <spec> log tag propagates into migration paths (issue #95)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rebrand migration logs 'Installing octo (from <spec>)'", async () => {
+    const state = setupFs({
+      cfg: {
+        plugins: {
+          entries: { "openclaw-channel-dmwork": { enabled: true } },
+          installs: { "openclaw-channel-dmwork": { source: "npm", version: "0.6.4" } },
+          allow: ["openclaw-channel-dmwork"],
+        },
+        channels: {
+          dmwork: {
+            accounts: { mybot: { botToken: "bf_xxx", apiUrl: "https://im.example.com" } },
+          },
+        },
+      },
+      extDirs: ["openclaw-channel-dmwork"],
+    });
+    await applyFsMocks(state);
+
+    mockOpenclawCli({
+      inspect: {
+        "openclaw-channel-dmwork": { plugin: { id: "openclaw-channel-dmwork", version: "0.6.4", enabled: true } },
+      },
+    });
+
+    // Make pluginsInstall(spec) succeed for any spec the user passes — we
+    // only care about the log line here.
+    const origExecImpl = mockExecFileSync.getMockImplementation();
+    mockExecFileSync.mockImplementation((cmd: any, args: any) => {
+      const a = args as string[];
+      if (a[0] === "plugins" && a[1] === "install") {
+        state.cfg.plugins ??= {};
+        state.cfg.plugins.entries ??= {};
+        state.cfg.plugins.entries["octo"] = { enabled: true };
+        state.cfg.plugins.installs ??= {};
+        state.cfg.plugins.installs["octo"] = { source: "local", version: "1.0.1" };
+        state.extDirs.add("octo");
+        return "";
+      }
+      if (a[0] === "plugins" && a[1] === "inspect" && a[2] === "octo") {
+        if (state.cfg.plugins?.entries?.["octo"]) {
+          return JSON.stringify({ plugin: { id: "octo", version: "1.0.1", enabled: true } });
+        }
+        // Pre-install: fall through so the default `mockOpenclawCli` says
+        // not-installed and runMigration takes the install branch.
+      }
+      return origExecImpl!(cmd, args, undefined as any) as any;
+    });
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      const { runInstall } = await loadInstall();
+      await runInstall({ force: false, dev: false, from: "/tmp/my-local-octo.tgz" });
+
+      const lines = logSpy.mock.calls.map((c) => c.join(" "));
+      const installingLine = lines.find((l) => /Installing\s+octo/.test(l));
+      expect(installingLine).toBeDefined();
+      expect(installingLine).toMatch(/\(from \/tmp\/my-local-octo\.tgz\)/);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it("rebrand migration log without --from omits the (from …) suffix", async () => {
+    const state = setupFs({
+      cfg: {
+        plugins: {
+          entries: { "openclaw-channel-dmwork": { enabled: true } },
+          installs: { "openclaw-channel-dmwork": { source: "npm", version: "0.6.4" } },
+          allow: ["openclaw-channel-dmwork"],
+        },
+        channels: {
+          dmwork: {
+            accounts: { mybot: { botToken: "bf_xxx", apiUrl: "https://im.example.com" } },
+          },
+        },
+      },
+      extDirs: ["openclaw-channel-dmwork"],
+    });
+    await applyFsMocks(state);
+
+    mockOpenclawCli({
+      inspect: {
+        "openclaw-channel-dmwork": { plugin: { id: "openclaw-channel-dmwork", version: "0.6.4", enabled: true } },
+      },
+    });
+
+    const origExecImpl = mockExecFileSync.getMockImplementation();
+    mockExecFileSync.mockImplementation((cmd: any, args: any) => {
+      const a = args as string[];
+      if (a[0] === "plugins" && a[1] === "install" && a[2] === "clawhub:octo") {
+        state.cfg.plugins ??= {};
+        state.cfg.plugins.entries ??= {};
+        state.cfg.plugins.entries["octo"] = { enabled: true };
+        state.cfg.plugins.installs ??= {};
+        state.cfg.plugins.installs["octo"] = { source: "clawhub", version: "1.0.1" };
+        state.extDirs.add("octo");
+        return "";
+      }
+      if (a[0] === "plugins" && a[1] === "inspect" && a[2] === "octo") {
+        if (state.cfg.plugins?.entries?.["octo"]) {
+          return JSON.stringify({ plugin: { id: "octo", version: "1.0.1", enabled: true } });
+        }
+      }
+      return origExecImpl!(cmd, args, undefined as any) as any;
+    });
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      const { runInstall } = await loadInstall();
+      await runInstall({ force: false, dev: false });
+
+      const lines = logSpy.mock.calls.map((c) => c.join(" "));
+      const installingLine = lines.find((l) => /Installing\s+octo/.test(l));
+      expect(installingLine).toBeDefined();
+      expect(installingLine).not.toMatch(/\(from /);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+});

--- a/create-openclaw-octo/cli/install.ts
+++ b/create-openclaw-octo/cli/install.ts
@@ -176,14 +176,14 @@ export async function runInstall(opts: InstallOptions): Promise<void> {
     case "legacy-to-octo":
     case "legacy":
       // Phase B: full migration from very-legacy "dmwork" plugin id to octo.
-      runLegacyToOctoMigration(spec, quiet, opts.force);
+      runLegacyToOctoMigration(spec, quiet, opts.force, tagLabel);
       didChange = true;
       break;
     case "rebrand":
     case "legacy-warn":
       // Phase B: full migration from openclaw-channel-dmwork to the ClawHub
       // octo plugin (plugin id = "octo", installed to ~/.openclaw/extensions/octo/).
-      runRebrandMigration(spec, quiet, opts.force);
+      runRebrandMigration(spec, quiet, opts.force, tagLabel);
       didChange = true;
       break;
     case "update": {
@@ -245,7 +245,7 @@ export async function runInstall(opts: InstallOptions): Promise<void> {
       break;
     }
     case "deadlock":
-      runDeadlockRepair(spec, quiet);
+      runDeadlockRepair(spec, quiet, tagLabel);
       didChange = true;
       break;
     case "fresh":
@@ -359,10 +359,17 @@ interface MigrationContext {
   spec: string;
   quiet: boolean;
   force?: boolean;
+  /**
+   * Display suffix for the install log line, e.g. ` (from /tmp/octo.tgz)`.
+   * Passed by `runInstall()` when the user gave `--from <spec>`, so operators
+   * debugging a migration run can confirm from the log which spec was actually
+   * used. Optional to keep callers that don't have a label simple. See #95.
+   */
+  tagLabel?: string;
 }
 
 function runMigration(ctx: MigrationContext): void {
-  const { legacyPluginId, scenarioLabel, spec, quiet, force } = ctx;
+  const { legacyPluginId, scenarioLabel, spec, quiet, force, tagLabel = "" } = ctx;
   console.log(`Detected ${scenarioLabel}. Starting migration...`);
 
   // -------------------------------------------------------------------------
@@ -454,7 +461,7 @@ function runMigration(ctx: MigrationContext): void {
   const octoAlreadyHealthy = octoSnapshot.installed && isHealthyInstall(PLUGIN_ID);
   if (!octoAlreadyHealthy) {
     try {
-      console.log(`  Installing ${PLUGIN_ID}...`);
+      console.log(`  Installing ${PLUGIN_ID}${tagLabel}...`);
       pluginsInstall(spec, quiet, force);
     } catch (err) {
       rollback(`pluginsInstall(${PLUGIN_ID}) threw: ${(err as Error).message}`);
@@ -627,23 +634,25 @@ function normalizeChannelConfig(raw: Record<string, unknown>): Record<string, un
   return cloned;
 }
 
-export function runRebrandMigration(spec: string, quiet: boolean, force?: boolean): void {
+export function runRebrandMigration(spec: string, quiet: boolean, force?: boolean, tagLabel?: string): void {
   runMigration({
     legacyPluginId: LEGACY_PLUGIN_ID,
     scenarioLabel: "rebrand",
     spec,
     quiet,
     force,
+    tagLabel,
   });
 }
 
-export function runLegacyToOctoMigration(spec: string, quiet: boolean, force?: boolean): void {
+export function runLegacyToOctoMigration(spec: string, quiet: boolean, force?: boolean, tagLabel?: string): void {
   runMigration({
     legacyPluginId: VERY_LEGACY_PLUGIN_ID,
     scenarioLabel: "legacy-to-octo",
     spec,
     quiet,
     force,
+    tagLabel,
   });
 }
 
@@ -651,7 +660,7 @@ export function runLegacyToOctoMigration(spec: string, quiet: boolean, force?: b
 // Deadlock repair: channels.octo exists but plugin missing.
 // (Distinct from rebrand — there's no legacy plugin/channel to migrate.)
 // ---------------------------------------------------------------------------
-function runDeadlockRepair(spec: string, quiet: boolean): void {
+function runDeadlockRepair(spec: string, quiet: boolean, tagLabel: string = ""): void {
   console.log(`Detected config deadlock (channels.${CHANNEL_ID} exists but no plugin).`);
 
   const configPath = getConfigFilePathSafe();
@@ -678,7 +687,7 @@ function runDeadlockRepair(spec: string, quiet: boolean): void {
   }
 
   try {
-    console.log(`  Installing ${PLUGIN_ID}...`);
+    console.log(`  Installing ${PLUGIN_ID}${tagLabel}...`);
     // P2 (PR #37): pass force=true to be consistent with other recovery paths
     // (broken / cleanup) — deadlock repair may leave a partial extension dir
     // from a previous crashed attempt that bare install would refuse to overwrite.


### PR DESCRIPTION
## Summary

`runInstall()` already builds a `tagLabel = opts.from ? " (from <path>)" : ""` and appends it to direct install / update log lines (`Installing Octo plugin (from /tmp/local.tgz)...`), so operators debugging a `--from` override can confirm from the log which spec was actually used. But the `runMigration()` (rebrand / legacy-to-octo) and `runDeadlockRepair()` paths previously logged a generic `Installing octo...` with no suffix — meaning a `--from`-driven migration run was invisible in the log.

## Related Issue

Fixes #95

## Changes

- **`cli/install.ts`** — `MigrationContext` gains an optional `tagLabel?: string`; `runMigration()` uses it in the `Installing ${PLUGIN_ID}${tagLabel}...` log line. `runRebrandMigration()` and `runLegacyToOctoMigration()` accept a `tagLabel` parameter and forward it. Signature remains backward-compatible (new arg is optional, last position).
- **`cli/install.ts`** — `runDeadlockRepair()` accepts an optional `tagLabel = ""`, uses it in the same log line.
- **`cli/install.ts`** — `runInstall()` passes `tagLabel` to all three migration / deadlock call sites.
- **`cli/install-migration.test.ts`** — 2 regression tests:
  - rebrand migration logs `Installing octo (from /tmp/my-local-octo.tgz)` when `--from` is set.
  - rebrand migration log without `--from` omits the `(from …)` suffix.

## Testing

- [x] Unit tests added/updated — 2 new cases in `install-migration.test.ts` asserting both the tagged and untagged forms.
- [x] Manually verified — runs through `runRebrandMigration` print the spec when `--from` is set.
- Total: **158 tests passing**, `tsc --noEmit` clean.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation — N/A (internal log line surface only)
- [x] Followed commit message conventions (Conventional Commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)