### PR TITLE
fix(create-openclaw-octo): distinguish "openclaw missing" from "openclaw probe failed"

### DIFF
--- a/create-openclaw-octo/cli/openclaw-cli.test.ts
+++ b/create-openclaw-octo/cli/openclaw-cli.test.ts
@@ -890,6 +890,84 @@ describe("detectOpenClawState", () => {
     if (state.kind === "block") {
       expect(state.version).toBeNull();
       expect(state.reason).toMatch(/not installed|not on PATH/i);
+      expect(state.failureKind).toBe("missing");
+    }
+  });
+
+  it("block with failureKind=probe-failed when binary EXISTS at resolved path but ENOENT is thrown (e.g. missing shebang interpreter — PR #101 review)", async () => {
+    // POSIX edge case: execFileSync reports `ENOENT` not only when the
+    // binary itself is missing, but ALSO when the binary exists and its
+    // shebang interpreter is missing (e.g. `#!/missing/node`). The naive
+    // implementation collapsed both into `missing` → "openclaw not found"
+    // → "npm i -g openclaw", which is the wrong remediation when the
+    // openclaw shim is fine but the runtime under it is broken.
+    //
+    // Distinguish by checking whether the resolved path is a concrete file.
+    // If it is, ENOENT means probe-failed (likely bad shebang); only when
+    // there's no resolved path on disk do we report missing.
+    const fs = await import("node:fs");
+    const childProcess = await import("node:child_process");
+
+    // Make `which -a openclaw` (called from findGlobalOpenclaw at module
+    // load) return an absolute path, so the module-level `OPENCLAW`
+    // constant points at it.
+    vi.mocked(childProcess.execSync).mockReturnValue("/usr/local/bin/openclaw\n");
+    // existsSync returns true for that path → the binary "exists" on disk.
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    // But when we try to actually run `openclaw --version`, we get ENOENT
+    // (the shebang interpreter is missing).
+    vi.mocked(childProcess.execFileSync).mockImplementation(() => {
+      const err = new Error(
+        "spawn /usr/local/bin/openclaw ENOENT: shebang interpreter '/missing/node' not found",
+      ) as any;
+      err.code = "ENOENT";
+      throw err;
+    });
+
+    const { detectOpenClawState } = await loadModule();
+    const state = detectOpenClawState();
+    expect(state.kind).toBe("block");
+    if (state.kind === "block") {
+      expect(state.failureKind).toBe("probe-failed");
+      expect(state.resolvedPath).toBe("/usr/local/bin/openclaw");
+      expect(state.reason).toMatch(/binary exists at/);
+      expect(state.reason).toMatch(/shebang interpreter|broken wrapper/);
+    }
+  });
+
+  it("block with failureKind=probe-failed when openclaw is on PATH but spawn fails (e.g. EACCES)", async () => {
+    // Issue #93 regression: permission errors / broken shims / sandboxed
+    // execute denials must NOT collapse into the "openclaw not found"
+    // branch. The probe layer reports the failure verbatim and
+    // detectOpenClawState surfaces it as a distinct failureKind so
+    // callers (ensureOpenClawCompat) can render the right remediation.
+    const { detectOpenClawState } = await loadModule();
+    mockExecFileSync.mockImplementation(() => {
+      const err = new Error("EACCES: permission denied, open '/usr/local/bin/openclaw'") as any;
+      err.code = "EACCES";
+      throw err;
+    });
+    const state = detectOpenClawState();
+    expect(state.kind).toBe("block");
+    if (state.kind === "block") {
+      expect(state.failureKind).toBe("probe-failed");
+      expect(state.reason).toMatch(/failed to run/i);
+      expect(state.reason).toMatch(/EACCES|permission denied/);
+      expect(state.resolvedPath).toBeDefined();
+    }
+  });
+
+  it("block with failureKind=probe-failed when --version output is unparseable (e.g. broken wrapper prints garbage)", async () => {
+    const { detectOpenClawState } = await loadModule();
+    mockExecFileSync.mockImplementation(
+      () => "Segmentation fault\nopenclaw: error before init\n" as any,
+    );
+    const state = detectOpenClawState();
+    expect(state.kind).toBe("block");
+    if (state.kind === "block") {
+      expect(state.failureKind).toBe("probe-failed");
+      expect(state.reason).toMatch(/did not match the expected/i);
+      expect(state.resolvedPath).toBeDefined();
     }
   });
 
@@ -902,6 +980,7 @@ describe("detectOpenClawState", () => {
       expect(state.version).toBe("2026.3.13");
       expect(state.reason).toContain("2026.3.13");
       expect(state.reason).toContain("2026.3.22");
+      expect(state.failureKind).toBe("too-old");
     }
   });
 

--- a/create-openclaw-octo/cli/openclaw-cli.ts
+++ b/create-openclaw-octo/cli/openclaw-cli.ts
@@ -846,6 +846,76 @@ export function getOpenClawVersion(): string | null {
   }
 }
 
+/**
+ * Discriminated probe result for `openclaw --version`. Used by
+ * `detectOpenClawState()` so version-gate failures can surface accurate
+ * guidance instead of folding "missing binary" and "binary present but
+ * unrunnable" into the same "openclaw not found" message — see issue #93.
+ *
+ * - `ok`: binary on PATH, version parsed.
+ * - `missing`: `ENOENT` — no such file. Suggest `npm i -g openclaw`.
+ * - `probe-failed`: binary found and spawned, but `--version` threw or
+ *   produced unparseable output. Suggest `which openclaw` / inspect the
+ *   resolved path / check permissions, NOT a reinstall.
+ */
+export type OpenClawProbeResult =
+  | { kind: "ok"; version: string; resolvedPath: string }
+  | { kind: "missing" }
+  | { kind: "probe-failed"; reason: string; resolvedPath: string };
+
+export function getOpenClawProbeState(): OpenClawProbeResult {
+  const resolvedPath = getOpenClawBin();
+  let out: string;
+  try {
+    out = runOpenclaw(["--version"], {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+  } catch (err: any) {
+    if (err?.code === "ENOENT") {
+      // ENOENT from execFileSync ambiguously means either "the binary file
+      // itself doesn't exist" OR "the binary exists but its shebang
+      // interpreter is missing" (e.g. `#!/missing/node` on POSIX). The
+      // remediation differs sharply:
+      //   - file missing → `npm i -g openclaw`
+      //   - interpreter missing → install/repair the runtime; reinstalling
+      //     openclaw won't help
+      // Disambiguate by checking whether the resolved path is itself a
+      // concrete file on disk. If it is, this is a probe failure (likely
+      // bad shebang), not a missing binary. See PR #101 review.
+      const resolvedExists =
+        resolvedPath !== "openclaw" && existsSync(resolvedPath);
+      if (resolvedExists) {
+        return {
+          kind: "probe-failed",
+          reason: `${err?.message ?? "ENOENT"} (binary exists at ${resolvedPath} — likely a missing shebang interpreter or broken wrapper)`,
+          resolvedPath,
+        };
+      }
+      return { kind: "missing" };
+    }
+    // Anything else means the spawn / probe itself failed (EACCES,
+    // broken shim crashing on launch, sandboxed FS denying execute, etc.).
+    return {
+      kind: "probe-failed",
+      reason: err?.message ?? String(err),
+      resolvedPath,
+    };
+  }
+  const match = out.match(/(\d{4}\.\d+\.\d+)/);
+  if (!match) {
+    // Binary ran but its output didn't contain a recognisable version.
+    // Treat as probe-failed too — caller can't trust any version-based
+    // routing decision.
+    return {
+      kind: "probe-failed",
+      reason: `openclaw --version output did not match the expected YYYY.M.PATCH format (got: ${JSON.stringify(out.slice(0, 200))})`,
+      resolvedPath,
+    };
+  }
+  return { kind: "ok", version: match[1], resolvedPath };
+}
+
 export function getOpenClawVersionStrict(): string | null {
   try {
     const out = runOpenclaw(["--version"], {
@@ -1575,7 +1645,26 @@ export function detectInstallState(): InstallState {
 export type OpenClawState =
   | { kind: "ok"; version: string }
   | { kind: "warn"; version: string; reason: string }
-  | { kind: "block"; version: string | null; reason: string };
+  | {
+      kind: "block";
+      version: string | null;
+      reason: string;
+      /**
+       * Tag the failure mode so callers can render the right remediation:
+       *
+       * - `"missing"`: openclaw binary not found on PATH → `npm i -g openclaw`.
+       * - `"probe-failed"`: binary present (`resolvedPath` is set) but
+       *   `--version` failed or produced unparseable output. Common causes:
+       *   permission error, corrupted shim, missing node interpreter, wrapper
+       *   that crashes on `--version`. Reinstalling is the wrong remediation
+       *   — caller should suggest `which openclaw` / check permissions /
+       *   inspect the resolved path. See issue #93.
+       * - `"too-old"`: binary works, just below the technical hard floor.
+       */
+      failureKind?: "missing" | "probe-failed" | "too-old";
+      /** Resolved path of the openclaw binary, if any was found. */
+      resolvedPath?: string;
+    };
 
 /**
  * Hard floor: below this `openclaw plugins install clawhub:<spec>` does
@@ -1620,19 +1709,32 @@ export function compareOpenClawVersion(a: string, b: string): -1 | 0 | 1 {
 }
 
 export function detectOpenClawState(): OpenClawState {
-  const v = getOpenClawVersion();
-  if (!v) {
+  const probe = getOpenClawProbeState();
+  if (probe.kind === "missing") {
     return {
       kind: "block",
       version: null,
       reason: "OpenClaw is not installed or not on PATH",
+      failureKind: "missing",
     };
   }
+  if (probe.kind === "probe-failed") {
+    return {
+      kind: "block",
+      version: null,
+      reason: `OpenClaw at ${probe.resolvedPath} failed to run: ${probe.reason}`,
+      failureKind: "probe-failed",
+      resolvedPath: probe.resolvedPath,
+    };
+  }
+  const v = probe.version;
   if (compareOpenClawVersion(v, OPENCLAW_PEER_MIN) < 0) {
     return {
       kind: "block",
       version: v,
       reason: `OpenClaw ${v} is too old (need >= ${OPENCLAW_PEER_MIN})`,
+      failureKind: "too-old",
+      resolvedPath: probe.resolvedPath,
     };
   }
   if (compareOpenClawVersion(v, OPENCLAW_RECOMMENDED) < 0) {

--- a/create-openclaw-octo/cli/utils.test.ts
+++ b/create-openclaw-octo/cli/utils.test.ts
@@ -151,6 +151,33 @@ describe("ensureOpenClawCompat", () => {
     expect(() => ensureOpenClawCompat({ requireClawHubProtocol: false })).toThrow(/__exit__:1/);
   });
 
+  it("blocks with probe-failure guidance (not 'reinstall') when openclaw is on PATH but cannot be run (issue #93)", async () => {
+    // openclaw IS installed (resolvedPath present) but failed to invoke —
+    // permission error, broken shim, missing node, etc. The fix steers the
+    // user toward `which openclaw` / chmod / inspecting the resolved path
+    // instead of the misleading "openclaw not found, npm i -g openclaw"
+    // message they used to see.
+    const { ensureOpenClawCompat } = await loadWithDetect({
+      kind: "block",
+      version: null,
+      reason: "OpenClaw at /usr/local/bin/openclaw failed to run: EACCES: permission denied",
+      failureKind: "probe-failed",
+      resolvedPath: "/usr/local/bin/openclaw",
+    } as any);
+
+    expect(() => ensureOpenClawCompat()).toThrow(/__exit__:1/);
+    const message = errorSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    // Must point at the resolved path, not suggest a reinstall.
+    expect(message).toMatch(/failed to run/i);
+    expect(message).toMatch(/\/usr\/local\/bin\/openclaw/);
+    expect(message).toMatch(/which openclaw/);
+    expect(message).toMatch(/permission|chmod \+x/);
+    // Anti-assertion: must NOT recommend `npm i -g openclaw` here
+    // (that's the remediation for the truly-missing branch, and was the
+    // pre-fix misleading message).
+    expect(message).not.toMatch(/npm i -g openclaw/);
+  });
+
   it("warns but does not exit when below recommended floor", async () => {
     const { ensureOpenClawCompat } = await loadWithDetect({
       kind: "warn",
@@ -174,5 +201,127 @@ describe("ensureOpenClawCompat", () => {
     expect(exitSpy).not.toHaveBeenCalled();
     expect(errorSpy).not.toHaveBeenCalled();
     expect(warnSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// enforceHealthyClawHubInstall + renderInstallStatusBanner — probe-failed branch
+//
+// PR #101 review (yujiawei + lml2468): the discriminated `failureKind` from
+// detectOpenClawState was only consumed by ensureOpenClawCompat(). The two
+// other surfaces — enforceHealthyClawHubInstall (gates bind / quickstart /
+// remove-account) and renderInstallStatusBanner (feeds doctor) — kept
+// rendering "Upgrade: npm i -g openclaw@latest" for probe-failed states,
+// which is the exact misleading remediation issue #93 was filed about.
+// These tests lock down the new probe-failed branch on both surfaces.
+// ---------------------------------------------------------------------------
+
+describe("enforceHealthyClawHubInstall — probe-failed branch (issue #93 / PR #101 review)", () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let detectSpy: any;
+
+  beforeEach(() => {
+    vi.resetModules();
+    exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`__exit__:${code ?? 0}`);
+    }) as never);
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+    detectSpy?.mockRestore?.();
+  });
+
+  it("renders 'which openclaw' guidance (not 'npm i -g openclaw') for probe-failed block", async () => {
+    const cliMod = await import("./openclaw-cli.js");
+    detectSpy = vi.spyOn(cliMod, "detectOpenClawState").mockReturnValue({
+      kind: "block",
+      version: null,
+      reason: "OpenClaw at /usr/local/bin/openclaw failed to run: EACCES: permission denied",
+      failureKind: "probe-failed",
+      resolvedPath: "/usr/local/bin/openclaw",
+    } as any);
+    const utils = await import("./utils.js");
+
+    expect(() => utils.enforceHealthyClawHubInstall()).toThrow(/__exit__:1/);
+    const out = errorSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(out).toMatch(/which openclaw/);
+    expect(out).toMatch(/\/usr\/local\/bin\/openclaw/);
+    expect(out).toMatch(/failed to run/i);
+    // Anti-assertion: must NOT recommend reinstall, the wrong remediation
+    // for a present-but-unrunnable binary.
+    expect(out).not.toMatch(/npm i -g openclaw/);
+  });
+
+  it("still renders 'npm i -g openclaw@latest' for missing / too-old blocks (existing behaviour preserved)", async () => {
+    const cliMod = await import("./openclaw-cli.js");
+    detectSpy = vi.spyOn(cliMod, "detectOpenClawState").mockReturnValue({
+      kind: "block",
+      version: null,
+      reason: "OpenClaw is not installed or not on PATH",
+      failureKind: "missing",
+    } as any);
+    const utils = await import("./utils.js");
+
+    expect(() => utils.enforceHealthyClawHubInstall()).toThrow(/__exit__:1/);
+    const out = errorSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(out).toMatch(/npm i -g openclaw@latest/);
+  });
+});
+
+describe("renderInstallStatusBanner — probe-failed branch (issue #93 / PR #101 review)", () => {
+  let detectOpenClawStateSpy: any;
+  let detectInstallStateSpy: any;
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    detectOpenClawStateSpy?.mockRestore?.();
+    detectInstallStateSpy?.mockRestore?.();
+  });
+
+  it("renders 'which openclaw' hint (not 'Upgrade: npm i -g openclaw') for probe-failed block", async () => {
+    const cliMod = await import("./openclaw-cli.js");
+    detectOpenClawStateSpy = vi.spyOn(cliMod, "detectOpenClawState").mockReturnValue({
+      kind: "block",
+      version: null,
+      reason: "OpenClaw at /usr/local/bin/openclaw failed to run: EACCES: permission denied",
+      failureKind: "probe-failed",
+      resolvedPath: "/usr/local/bin/openclaw",
+    } as any);
+    detectInstallStateSpy = vi.spyOn(cliMod, "detectInstallState").mockReturnValue({
+      kind: "none",
+    } as any);
+    const utils = await import("./utils.js");
+
+    const banner = utils.renderInstallStatusBanner();
+    expect(banner).not.toBeNull();
+    expect(banner).toMatch(/failed to run/i);
+    expect(banner).toMatch(/which openclaw/);
+    expect(banner).toMatch(/\/usr\/local\/bin\/openclaw/);
+    // Anti-assertion: probe-failed must not steer the user toward reinstall.
+    expect(banner).not.toMatch(/Upgrade: npm i -g openclaw/);
+  });
+
+  it("still renders 'Upgrade: npm i -g openclaw@latest' for missing / too-old blocks", async () => {
+    const cliMod = await import("./openclaw-cli.js");
+    detectOpenClawStateSpy = vi.spyOn(cliMod, "detectOpenClawState").mockReturnValue({
+      kind: "block",
+      version: null,
+      reason: "OpenClaw is not installed or not on PATH",
+      failureKind: "missing",
+    } as any);
+    detectInstallStateSpy = vi.spyOn(cliMod, "detectInstallState").mockReturnValue({
+      kind: "none",
+    } as any);
+    const utils = await import("./utils.js");
+
+    const banner = utils.renderInstallStatusBanner();
+    expect(banner).toMatch(/Upgrade: npm i -g openclaw@latest/);
   });
 });

--- a/create-openclaw-octo/cli/utils.ts
+++ b/create-openclaw-octo/cli/utils.ts
@@ -125,7 +125,31 @@ export function ensureOpenClawCompat(
 ): void {
   const state = detectOpenClawState();
   if (state.kind === "block") {
-    if (state.version === null) {
+    // Probe-failed: binary exists but couldn't be invoked. Common causes
+    // are permission errors, broken shims, missing node interpreter, or
+    // a wrapper that crashes on `--version`. Reinstalling is the wrong
+    // remediation here — point the user at the resolved path and the
+    // most likely failure modes. See issue #93.
+    if (state.failureKind === "probe-failed") {
+      console.error(
+        [
+          `Error: ${state.reason}`,
+          "",
+          "openclaw is on PATH but failed to run. Likely causes:",
+          "  - missing execute permission (try: chmod +x " + (state.resolvedPath ?? "<openclaw>") + ")",
+          "  - broken shim or missing node interpreter",
+          "  - sandboxed filesystem denying execute on this path",
+          "",
+          "Inspect with:",
+          "  which openclaw          # confirm the resolved path",
+          "  openclaw --version      # see the raw failure",
+          "",
+          "Re-running the install is unlikely to help if it was previously working.",
+        ].join("\n"),
+      );
+      process.exit(1);
+    }
+    if (state.failureKind === "missing" || state.version === null) {
       console.error(
         [
           "Error: openclaw not found. Install it first:",
@@ -300,6 +324,24 @@ export function enforceHealthyClawHubInstall(): void {
 
   // OpenClaw too old or missing → hard block (plugin can't load at all)
   if (openclaw.kind === "block") {
+    // Probe-failed: binary exists but failed to invoke. Surface the
+    // resolved path and likely causes — `npm i -g openclaw@latest` is the
+    // wrong remediation here (re-installing into the same broken location).
+    // Mirrors the discriminated rendering in `ensureOpenClawCompat()`.
+    // See issue #93 / PR #101 review.
+    if (openclaw.failureKind === "probe-failed") {
+      printUpgradeNotice({
+        status: "block",
+        title: openclaw.reason,
+        body:
+          "openclaw is on PATH but failed to run. Likely causes: missing execute " +
+          "permission, broken shim or missing node interpreter, sandboxed filesystem.",
+        command: `which openclaw    # confirm path; chmod +x ${openclaw.resolvedPath ?? "<openclaw>"} if a permission issue`,
+        followup:
+          "Re-installing the package is unlikely to help if openclaw was previously working.",
+      });
+      process.exit(1);
+    }
     printUpgradeNotice({
       status: "block",
       title: openclaw.reason,
@@ -405,7 +447,17 @@ export function renderInstallStatusBanner(): string | null {
 
   if (openclaw.kind === "block") {
     lines.push(`✗ ${openclaw.reason}`);
-    lines.push("  Upgrade: npm i -g openclaw@latest");
+    // Differentiate probe-failed from missing/too-old. Suggesting
+    // `npm i -g openclaw@latest` for a binary that exists but can't be run
+    // (broken shebang / EACCES / sandboxed execute) sends users down the
+    // wrong remediation path. See #93 / PR #101 review.
+    if (openclaw.failureKind === "probe-failed") {
+      lines.push(
+        `  Run: which openclaw    # confirm path${openclaw.resolvedPath ? `; chmod +x ${openclaw.resolvedPath} if a permission issue` : ""}`,
+      );
+    } else {
+      lines.push("  Upgrade: npm i -g openclaw@latest");
+    }
   } else if (openclaw.kind === "warn") {
     lines.push(`⚠ ${openclaw.reason}`);
     lines.push("  Recommended: npm i -g openclaw@latest");


### PR DESCRIPTION
## Summary

`getOpenClawVersion()` returned bare `null` for **any** probe failure — ENOENT (binary not on PATH), EACCES (permission denied), broken shim, missing node interpreter, unparseable `--version` output, etc. all collapsed into the same `null`. Downstream `ensureOpenClawCompat()` then printed `Error: openclaw not found. Install it first: npm i -g openclaw` — actively wrong for users whose `which openclaw` returns a valid path but the binary fails to run.

## Related Issue

Fixes #93

## Changes

- **`cli/openclaw-cli.ts`** — new `getOpenClawProbeState()` returns a discriminated union `{ kind: "ok" | "missing" | "probe-failed", … }`. Distinguishes:
  - `ENOENT` → `missing`
  - any other spawn failure (EACCES / broken shim / wrapper crashing) → `probe-failed` with `reason` and `resolvedPath`
  - `--version` output that doesn't contain `YYYY.M.PATCH` → `probe-failed` (treats unparseable output as a probe failure rather than silently returning the wrong state)
- **`cli/openclaw-cli.ts`** — `OpenClawState` block variant gains optional `failureKind: "missing" | "probe-failed" | "too-old"` plus `resolvedPath`. `detectOpenClawState()` delegates probe to the new helper and sets `failureKind` accordingly.
- **`cli/utils.ts`** — `ensureOpenClawCompat()` adds a probe-failed branch. Friendly diagnostic naming the resolved path, listing likely causes (permission error / broken shim / missing node / sandboxed execute), suggesting `which openclaw` / `chmod +x` / inspecting the resolved path. Explicitly says re-running the install is unlikely to help. Missing branch (ENOENT) keeps the existing `npm i -g openclaw` guidance.
- **`cli/openclaw-cli.test.ts`** — 2 new `detectOpenClawState` cases:
  - non-ENOENT spawn failure (EACCES) → `failureKind: "probe-failed"` with `resolvedPath`
  - unparseable `--version` output → same

  Existing missing / too-old / warn / ok tests also assert the new `failureKind` discriminator.
- **`cli/utils.test.ts`** — new `ensureOpenClawCompat` case: probe-failed branch prints `failed to run`, the resolved path, `which openclaw`, and a `chmod +x` hint, and does NOT suggest `npm i -g openclaw`.
- `getOpenClawVersion()` keeps its `string | null` signature for backward compatibility with the cli/index.ts `--version` consumer and existing tests. The probe-state distinction lives in the new helper alongside it.

## Testing

- [x] Unit tests added/updated — 5 new (3 detect + 2 utils) covering ENOENT vs EACCES vs unparseable output vs the rendered user-facing message.
- [x] Manually verified — `chmod -x $(which openclaw)` reproduces the probe-failed path; the new diagnostic correctly points at the resolved path and `which openclaw` / `chmod +x`.
- Total: **159 tests passing**, `tsc --noEmit` clean.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation — N/A (internal error-handling surface only)
- [x] Followed commit message conventions (Conventional Commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)