### PR TITLE
fix(ci): grant actions:read permission to Octo CI Status workflow

### DIFF
--- a/.github/workflows/octo-ci-status.yml
+++ b/.github/workflows/octo-ci-status.yml
@@ -6,7 +6,8 @@ on:
     types: [completed]
     branches: [main]
 
-permissions: {}
+permissions:
+  actions: read
 
 jobs:
   notify:


### PR DESCRIPTION
## Problem

`Octo CI Status` workflow has been failing with `startup_failure` on **every run** since at least May 21st.

## Root Cause

The caller workflow sets `permissions: {}` (empty), but the reusable workflow (`Mininglamp-OSS/.github/.github/workflows/octo-ci-status.yml`) needs `actions: read` at the job level to query the GitHub API for workflow run history (state-change detection).

GitHub Actions enforces that reusable workflow job permissions cannot exceed caller permissions. Since the caller grants nothing, the job's `actions: read` request fails at startup.

## Fix

Change `permissions: {}` to `permissions: actions: read`, matching the working configuration in octo-server, octo-web, octo-matter, octo-lib, octo-smart-summary, octo-speech, and octo-daemon-cli.

## Verification

All 7 other repos with `permissions: actions: read` have 100% success rate on this workflow.