### PR TITLE
ci(codeql): switch to weekly schedule only

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,8 +1,11 @@
 name: CodeQL
 
 on:
-  # Weekly deep scan only — CodeQL is the slow, cross-function security tier.
-  # Per-PR breadth is covered by each repo's own CI (golangci-lint/gosec, eslint).
+  # Weekly deep scan only — CodeQL is the slow, cross-function SAST tier.
+  # NOTE: no per-PR SAST remains after this change. Per-PR CI runs the repo's
+  # own lint + osv-scanner (dependency CVEs); CodeQL moves to a weekly deep scan
+  # + manual dispatch. Findings still land in the Security tab. Detection latency
+  # for new code-level vulnerabilities widens to up to ~7 days.
   schedule:
     - cron: "0 6 * * 1"   # Mondays 06:00 UTC
   workflow_dispatch:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,11 +1,12 @@
 name: CodeQL
 
 on:
-  # Weekly deep scan only — CodeQL is the slow, cross-function SAST tier.
-  # NOTE: no per-PR SAST remains after this change. Per-PR CI runs the repo's
-  # own lint + osv-scanner (dependency CVEs); CodeQL moves to a weekly deep scan
-  # + manual dispatch. Findings still land in the Security tab. Detection latency
-  # for new code-level vulnerabilities widens to up to ~7 days.
+  # Weekly deep scan only. CodeQL (cross-function SAST) is intentionally NOT run
+  # per-PR or per-push: this removes pre-merge and per-merge SAST entirely. The
+  # only remaining code-level SAST is this weekly scan + manual dispatch. Per-PR
+  # CI still runs osv-scanner (dependency CVEs) — that is SCA, not SAST. Detection
+  # latency for newly introduced code-level vulnerabilities is up to ~7 days;
+  # findings land in the Security tab.
   schedule:
     - cron: "0 6 * * 1"   # Mondays 06:00 UTC
   workflow_dispatch:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,27 +1,20 @@
 name: CodeQL
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
-      - '.github/ISSUE_TEMPLATE/**'
+  # Weekly deep scan only — CodeQL is the slow, cross-function security tier.
+  # Per-PR breadth is covered by each repo's own CI (golangci-lint/gosec, eslint).
   schedule:
-    - cron: "0 6 * * *"
+    - cron: "0 6 * * 1"   # Mondays 06:00 UTC
   workflow_dispatch:
 
 permissions: {}
 
 concurrency:
-  group: codeql-${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: codeql-${{ github.workflow }}-${{ github.sha }}
+  cancel-in-progress: false
 
 jobs:
   analyze:
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     uses: Mininglamp-OSS/.github/.github/workflows/reusable-codeql.yml@v1
     with:
       language: javascript-typescript


### PR DESCRIPTION
CodeQL is the deep, cross-function security tier. Running it per-PR is slow and redundant with per-PR breadth checks (gosec/eslint) in this repo's own CI. Move to weekly scheduled scan + manual dispatch; findings still land in the Security tab.