### PR TITLE
fix(cli): accept app_ App Bot tokens in bind/doctor

### DIFF
--- a/create-openclaw-octo/README.md
+++ b/create-openclaw-octo/README.md
@@ -105,7 +105,7 @@ Bot accounts are stored in `~/.openclaw/openclaw.json` under `channels.octo.acco
 
 Configuration fields per account:
 
-- `botToken` (required): Bot token from BotFather (`bf_` prefix)
+- `botToken` (required): Bot token. Either a User Bot token from BotFather (`bf_` prefix, full group + thread access) or an App Bot token from the Octo admin console (`app_` prefix, direct-message only — server-enforced).
 - `apiUrl` (required): Octo server API URL
 - `wsUrl` (optional): WuKongIM WebSocket URL. Auto-detected if omitted.
 - `requireMention` (optional): Only respond when @mentioned in groups

--- a/create-openclaw-octo/cli/bind.ts
+++ b/create-openclaw-octo/cli/bind.ts
@@ -14,6 +14,7 @@ import {
   ensureChannelConfigObject,
   enforceHealthyClawHubInstall,
   validateAccountId,
+  isValidBotTokenPrefix,
 } from "./utils.js";
 
 export interface BindOptions {
@@ -28,8 +29,8 @@ export async function runBind(opts: BindOptions): Promise<void> {
   enforceHealthyClawHubInstall();
 
   // 2. Validate params
-  if (!opts.botToken.startsWith("bf_")) {
-    console.error("Error: Bot token must start with 'bf_'.");
+  if (!isValidBotTokenPrefix(opts.botToken)) {
+    console.error("Error: Bot token must start with 'bf_' (BotFather /newbot) or 'app_' (Admin App Bot).");
     process.exit(1);
   }
   if (!validateAccountId(opts.accountId)) {

--- a/create-openclaw-octo/cli/doctor.test.ts
+++ b/create-openclaw-octo/cli/doctor.test.ts
@@ -71,7 +71,7 @@ describe("doctor checks (in-process mode)", () => {
     expect(scopeCheck?.status).toBe("PASS");
   });
 
-  it("should WARN when botToken does not start with bf_ in-process", async () => {
+  it("should WARN when botToken has an unrecognized prefix in-process", async () => {
     const reader = stubReader({
       channels: {
         octo: {
@@ -91,6 +91,30 @@ describe("doctor checks (in-process mode)", () => {
 
     const tokenCheck = result.checks.find((c) => c.name === "bad_bot: botToken format");
     expect(tokenCheck?.status).toBe("WARN");
+  });
+
+  it("should NOT warn on an app_ App Bot token in-process", async () => {
+    const reader = stubReader({
+      channels: {
+        octo: {
+          accounts: {
+            app_bot: { botToken: "app_f33a87e108015aec1b6ad4410afebd82", apiUrl: "http://localhost" },
+          },
+        },
+      },
+      session: { dmScope: "per-account-channel-peer" },
+    });
+
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response("ok", { status: 200 }));
+
+    const result = await runDoctorChecks({ reader, inProcess: true });
+
+    globalThis.fetch = vi.fn() as any;
+
+    const formatWarn = result.checks.find((c) => c.name === "app_bot: botToken format");
+    expect(formatWarn).toBeUndefined();
+    const tokenPass = result.checks.find((c) => c.name === "app_bot: botToken");
+    expect(tokenPass?.status).toBe("PASS");
   });
 
   it("should fallback to legacy flat config when no accounts", async () => {

--- a/create-openclaw-octo/cli/doctor.ts
+++ b/create-openclaw-octo/cli/doctor.ts
@@ -27,7 +27,7 @@ import {
   resolvePluginState,
   runCmd,
 } from "./openclaw-cli.js";
-import { PLUGIN_ID, CHANNEL_ID, RECOMMENDED_DM_SCOPE, channelConfigPath, getChannelConfig } from "./utils.js";
+import { PLUGIN_ID, CHANNEL_ID, RECOMMENDED_DM_SCOPE, channelConfigPath, getChannelConfig, isValidBotTokenPrefix } from "./utils.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -321,11 +321,11 @@ export async function runDoctorChecks(params: {
     const tokenVal = reader.get(tokenPath);
 
     if (tokenVal) {
-      if (params.inProcess && !tokenVal.startsWith("bf_")) {
+      if (params.inProcess && !isValidBotTokenPrefix(tokenVal)) {
         checks.push({
           name: `${label}: botToken format`,
           status: "WARN",
-          detail: "Does not start with bf_",
+          detail: "Does not start with bf_ or app_",
         });
       } else {
         checks.push({

--- a/create-openclaw-octo/cli/index.ts
+++ b/create-openclaw-octo/cli/index.ts
@@ -106,7 +106,7 @@ program
 program
   .command("bind")
   .description("Configure a bot account and bind it to an agent")
-  .requiredOption("--bot-token <token>", "Bot token (starts with bf_)")
+  .requiredOption("--bot-token <token>", "Bot token (starts with bf_ or app_)")
   .requiredOption("--api-url <url>", "API server URL")
   .requiredOption("--account-id <id>", "Bot account ID")
   .requiredOption("--agent <agent>", "Agent identifier to bind to")

--- a/create-openclaw-octo/cli/utils.test.ts
+++ b/create-openclaw-octo/cli/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { requiresClawHubProtocol, validateAccountId } from "./utils.js";
+import { requiresClawHubProtocol, validateAccountId, isValidBotTokenPrefix } from "./utils.js";
 
 describe("validateAccountId", () => {
   it("should accept valid IDs", () => {
@@ -16,6 +16,24 @@ describe("validateAccountId", () => {
     expect(validateAccountId("bot.name")).toBe(false);
     expect(validateAccountId("bot/name")).toBe(false);
     expect(validateAccountId("bot@name")).toBe(false);
+  });
+});
+
+describe("isValidBotTokenPrefix", () => {
+  it("accepts bf_ User Bot tokens", () => {
+    expect(isValidBotTokenPrefix("bf_0123456789abcdef")).toBe(true);
+  });
+
+  it("accepts app_ App Bot tokens", () => {
+    // App Bot tokens (Admin 后台「应用 Bot」) are DM-only server-side, but the
+    // CLI must let them bind — that boundary is the server's to enforce.
+    expect(isValidBotTokenPrefix("app_f33a87e108015aec1b6ad4410afebd82")).toBe(true);
+  });
+
+  it("rejects unknown prefixes", () => {
+    expect(isValidBotTokenPrefix("uk_0123456789abcdef")).toBe(false);
+    expect(isValidBotTokenPrefix("")).toBe(false);
+    expect(isValidBotTokenPrefix("0123456789")).toBe(false);
   });
 });
 
@@ -112,10 +130,9 @@ describe("ensureOpenClawCompat", () => {
   });
 
   it("warns (does not block) when openclaw is too old AND caller does not require clawhub: protocol", async () => {
-    // Regression for codex review MAJOR #2: ensureOpenClawCompat() was
-    // unconditionally hard-aborting on < OPENCLAW_PEER_MIN, breaking
-    // uninstall and `install --from <local-tarball>` paths that don't
-    // need the `clawhub:` protocol.
+    // Regression: ensureOpenClawCompat() was unconditionally hard-aborting
+    // on < OPENCLAW_PEER_MIN, breaking uninstall and `install --from
+    // <local-tarball>` paths that don't need the `clawhub:` protocol.
     const { ensureOpenClawCompat } = await loadWithDetect({
       kind: "block",
       version: "2026.3.13",

--- a/create-openclaw-octo/cli/utils.ts
+++ b/create-openclaw-octo/cli/utils.ts
@@ -204,6 +204,20 @@ export function validateAccountId(id: string): boolean {
   return ACCOUNT_ID_RE.test(id);
 }
 
+// Two token prefixes can bind a bot to an agent:
+//   bf_*  — User Bot (BotFather /newbot): full group + thread + OBO access.
+//   app_* — App Bot (Admin 后台「应用 Bot」): direct-message only.
+// The capability difference is enforced by octo-server (it routes bot_api
+// auth by prefix and rejects App Bot group/thread/OBO calls), so the CLI must
+// let either prefix bind rather than pre-rejecting app_ for being limited.
+const BOT_TOKEN_PREFIXES = ["bf_", "app_"] as const;
+
+/** True when the token carries a recognized bot-token prefix. */
+export function isValidBotTokenPrefix(token: string): boolean {
+  return BOT_TOKEN_PREFIXES.some((p) => token.startsWith(p));
+}
+
+
 // ---------------------------------------------------------------------------
 // Interactive detection
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## 背景

用户在 Admin 后台创建 App Bot 后,照着右侧「连接指南」复制 `npx ... bind --bot-token app_xxx ...` 执行,直接报错 `Error: Bot token must start with 'bf_'`,**连绑都绑不上**。

`bind` 命令此前只接受 `bf_`(User Bot)token,对 Admin App Bot 的 `app_` token 一律 `process.exit(1)`。

关联反馈:#129

## 改动

- 新增共享 helper `isValidBotTokenPrefix`(`utils.ts`),前缀白名单 `{bf_, app_}`。
- `bind.ts`:pre-flight 校验改用 helper,报错文案更新为说明两种合法前缀及来源。
- `doctor.ts`:in-process 的 botToken 格式检查 + WARN detail 一并放宽。
- `index.ts`:`--bot-token` 帮助文案更新。

## 设计取舍

token 能力边界由 **octo-server 强制**(`bot_api` 按前缀分流鉴权,对 App Bot 的群/thread/OBO 调用显式拒绝)。因此 CLI **不应**替 server 预先拒绝 `app_` —— 绑上后能做什么(App Bot 仅私聊)由 server 决定。CLI 只负责放行,不复制 server 权限逻辑。

非目标:不改 server 解除 App Bot DM-only 限制;Admin 连接指南的包名更新归 admin 侧。

## 配套 PR

`openclaw-channel-octo#130` —— 修 `openclaw channels add` 路径同样的 `bf_` 硬校验(本 PR 修的是用户直接报错的 `bind` 命令路径)。

## 测试

- `utils.test.ts`:`isValidBotTokenPrefix` 覆盖 `bf_` / `app_` 放行、未知前缀 / 空串拒。
- `doctor.test.ts`:新增「`app_` token 不再 WARN、且 botToken 检查 PASS」回归用例;既有「未知前缀仍 WARN」用例保留。
- 全量 `vitest run`(175 passed)+ `tsc --noEmit` 通过。